### PR TITLE
feature/force-by-path

### DIFF
--- a/app/Console/Commands/SyncMedia.php
+++ b/app/Console/Commands/SyncMedia.php
@@ -17,7 +17,8 @@ class SyncMedia extends Command
     protected $signature = 'koel:sync
         {record? : A single watch record. Consult Wiki for more info.}
         {--tags= : The comma-separated tags to sync into the database}
-        {--force : Force re-syncing even unchanged files}';
+        {--force : Force re-syncing even unchanged files}
+        {--path= : Force re-syncing of files that match a given path}';
 
     protected $ignored = 0;
     protected $invalid = 0;
@@ -71,7 +72,7 @@ class SyncMedia extends Command
         // New records will have every applicable field sync'ed in.
         $tags = $this->option('tags') ? explode(',', $this->option('tags')) : [];
 
-        Media::sync(null, $tags, $this->option('force'), $this);
+        Media::sync(null, $tags, $this->option('force'), $this->option('path'), $this);
 
         $this->output->writeln(
             PHP_EOL.PHP_EOL

--- a/app/Services/Media.php
+++ b/app/Services/Media.php
@@ -53,9 +53,10 @@ class Media
      *                                 Only taken into account for existing records.
      *                                 New records will have all tags synced in regardless.
      * @param bool        $force       Whether to force syncing even unchanged files
+     * @param string      $forcePath   Whether to force syncing, even unchanged files, of a specific path
      * @param SyncMedia   $syncCommand The SyncMedia command object, to log to console if executed by artisan.
      */
-    public function sync($path = null, $tags = [], $force = false, SyncMedia $syncCommand = null)
+    public function sync($path = null, $tags = [], $force = false, $forcePath = '', SyncMedia $syncCommand = null)
     {
         if (!app()->runningInConsole()) {
             set_time_limit(config('koel.sync.timeout'));
@@ -81,7 +82,7 @@ class Media
         foreach ($files as $file) {
             $file = new File($file, $getID3);
 
-            $song = $file->sync($this->tags, $force);
+            $song = $file->sync($this->tags, $force, $forcePath);
 
             if ($song === true) {
                 $results['ugly'][] = $file;

--- a/tests/Feature/MediaTest.php
+++ b/tests/Feature/MediaTest.php
@@ -114,6 +114,27 @@ class MediaTest extends BrowserKitTestCase
         $this->assertEquals($originalLyrics, $song->lyrics);
     }
 
+    public function testForcePathSync()
+    {
+        $this->expectsEvents(LibraryChanged::class);
+
+        $media = new Media();
+        $media->sync($this->mediaPath);
+
+        // Resync with force path
+        $media->sync($this->mediaPath, [], false, 'blank');
+
+        // Validate that only songs that pregmatch 'blank' were updated
+        $songs = Song::orderBy('id', 'desc');
+        foreach ($songs as $song) {
+            if (preg_match('#blank#', $song->path)) {
+                $this->assertNotEquals($song->created_at, $song->updated_at);
+            } else {
+                $this->assertEquals($song->created_at, $song->updated_at);
+            }
+        }
+    }
+
     public function testSyncSelectiveTags()
     {
         $this->expectsEvents(LibraryChanged::class);


### PR DESCRIPTION
This PR adds the command line option `--path` which performs a force sync only on files whose path matches the path provided. This is extremely useful for libraries with a large number of files as forcing the entire library update causes PHP to use, and potentially run out of memory, as the library gets larger. (ex: my library contains over 40,000 files and the PHP memory limit has been increased to 2GB and it still runs out).

This update also adds the ability that both `--force` and `--path` options force an update to the album artwork as well.

EDIT: showing examples

Since the path matching uses a regular expression, force syncing by path can be used to force sync single files, albums, or artists depending on the depth of the path.

Assume my music is in `/home/me/Music`

```
# This command will update a single file
php artisan koel:sync -v --path "/home/me/Music/Nine Inch Nails/With Teeth/10 Sunspots.flac"

# This command will update a the entire album
php artisan koel:sync -v --path "/home/me/Music/Nine Inch Nails/With Teeth"

# This command will update the entire artist
php artisan koel:sync -v --path "/home/me/Music/Nine Inch Nails/"
```

Although the code still iterates through every file, it won't perform any update actions except for those that match sucessfully.
