### PR TITLE
Quick fix for webpack compile issue

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -149,7 +149,7 @@ if (Mix.preprocessors) {
         let sourceMap = Mix.sourcemaps ? '?sourceMap' : '';
 
         module.exports.module.rules.push({
-            test: new RegExp(toCompile.src.path.replace(/\\/g, '\\\\') + '$'),
+            test: new RegExp(toCompile.src.file.replace(/\\/g, '\\\\') + '$'),
             use: extractPlugin.extract({
                 fallback: 'style-loader',
                 use: [


### PR DESCRIPTION
a quick fix for the webpack issue on compiling

```
Module parse failed: /koel/resources/assets/sass/app.scss Unexpected character '@' (1:0)
You may need an appropriate loader to handle this file type.
```
OSX 10.12.4 - LAMP