### PR TITLE
Add years to album table. Fix issue #730

### DIFF
--- a/app/Models/Album.php
+++ b/app/Models/Album.php
@@ -72,10 +72,10 @@ class Album extends Model
     /**
      * Get an album using some provided information.
      *
-     * @param Artist  $artist
-     * @param string  $name
-     * @param integer $year
-     * @param bool    $isCompilation
+     * @param Artist $artist
+     * @param string $name
+     * @param int    $year
+     * @param bool   $isCompilation
      *
      * @return self
      */

--- a/app/Models/Album.php
+++ b/app/Models/Album.php
@@ -19,6 +19,7 @@ use Log;
  * @property bool   is_compilation  If the album is a compilation from multiple artists
  * @property Artist artist          The album's artist
  * @property int    artist_id
+ * @property int    year
  * @property Collection  songs
  * @property bool   is_unknown
  */
@@ -32,7 +33,10 @@ class Album extends Model
 
     protected $guarded = ['id'];
     protected $hidden = ['updated_at'];
-    protected $casts = ['artist_id' => 'integer'];
+    protected $casts = [
+        'artist_id' => 'integer',
+        'year' => 'integer',
+    ];
     protected $appends = ['is_compilation'];
 
     /**
@@ -68,13 +72,14 @@ class Album extends Model
     /**
      * Get an album using some provided information.
      *
-     * @param Artist $artist
-     * @param string $name
-     * @param bool   $isCompilation
+     * @param Artist  $artist
+     * @param string  $name
+     * @param integer $year
+     * @param bool    $isCompilation
      *
      * @return self
      */
-    public static function get(Artist $artist, $name, $isCompilation = false)
+    public static function get(Artist $artist, $name, $year, $isCompilation = false)
     {
         // If this is a compilation album, its artist must be "Various Artists"
         if ($isCompilation) {
@@ -84,6 +89,7 @@ class Album extends Model
         return self::firstOrCreate([
             'artist_id' => $artist->id,
             'name' => $name ?: self::UNKNOWN_NAME,
+            'year' => $year,
         ]);
     }
 

--- a/app/Models/Song.php
+++ b/app/Models/Song.php
@@ -170,6 +170,7 @@ class Song extends Model
                 trim($data['artistName']) ?: $song->artist->name,
                 $single ? trim($data['lyrics']) : $song->lyrics,
                 $single ? (int) $data['track'] : $song->track,
+                $song->album->year,
                 (int) $data['compilationState']
             ));
         }
@@ -194,11 +195,12 @@ class Song extends Model
      * @param string $artistName
      * @param string $lyrics
      * @param int    $track
+     * @param int    $year
      * @param int    $compilationState
      *
      * @return self
      */
-    public function updateSingle($title, $albumName, $artistName, $lyrics, $track, $compilationState)
+    public function updateSingle($title, $albumName, $artistName, $lyrics, $track, $year, $compilationState)
     {
         if ($artistName === Artist::VARIOUS_NAME) {
             // If the artist name is "Various Artists", it's a compilation song no matter what.
@@ -221,7 +223,7 @@ class Song extends Model
                 break;
         }
 
-        $album = Album::get($artist, $albumName, $isCompilation);
+        $album = Album::get($artist, $albumName, $year, $isCompilation);
 
         $this->artist_id = $artist->id;
         $this->album_id = $album->id;

--- a/app/Services/Media.php
+++ b/app/Services/Media.php
@@ -26,6 +26,7 @@ class Media
     protected $allTags = [
         'artist',
         'album',
+        'year',
         'title',
         'length',
         'track',

--- a/database/migrations/2018_05_09_184010_add_year_into_albums.php
+++ b/database/migrations/2018_05_09_184010_add_year_into_albums.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddYearIntoAlbums extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('albums', function (Blueprint $table) {
+            $table->integer('year')->after('name')->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('albums', function (Blueprint $table) {
+            $table->dropColumn('year');
+        });
+    }
+}

--- a/tests/Integration/Models/AlbumTest.php
+++ b/tests/Integration/Models/AlbumTest.php
@@ -38,10 +38,11 @@ class AlbumTest extends TestCase
         /** @var Album $album */
         $album = factory(Album::class)->create([
             'artist_id' => $artist->id,
+            'year' => 2015,
         ]);
 
         // When I try to get the album by artist and name
-        $gottenAlbum = Album::get($artist, $album->name);
+        $gottenAlbum = Album::get($artist, $album->name, 2015);
 
         // Then I get the album
         $this->assertSame($album->id, $gottenAlbum->id);
@@ -58,7 +59,7 @@ class AlbumTest extends TestCase
         $this->assertNull(Album::whereArtistIdAndName($artist->id, $name)->first());
 
         // When I try to get the album by such artist and name
-        $album = Album::get($artist, $name);
+        $album = Album::get($artist, $name, 2015);
 
         // Then I get the new album
         $this->assertNotNull($album);
@@ -71,7 +72,7 @@ class AlbumTest extends TestCase
         $name = '';
 
         // When we create such an album
-        $album = Album::get(factory(Artist::class)->create(), $name);
+        $album = Album::get(factory(Artist::class)->create(), $name, 2015);
 
         // Then the album's name is "Unknown Album"
         $this->assertEquals('Unknown Album', $album->name);
@@ -84,7 +85,7 @@ class AlbumTest extends TestCase
         $isCompilation = true;
 
         // When the album is created
-        $album = Album::get(factory(Artist::class)->create(), 'Foo', $isCompilation);
+        $album = Album::get(factory(Artist::class)->create(), 'Foo', 2015, $isCompilation);
 
         // Then its artist is Various Artist
         $this->assertTrue($album->artist->is_various);

--- a/tests/Integration/Models/FileTest.php
+++ b/tests/Integration/Models/FileTest.php
@@ -20,6 +20,7 @@ class FileTest extends TestCase
             'title' => 'Amet',
             'track' => 5,
             'disc' => 3,
+            'year' => 2015,
             'lyrics' => "Foo\rbar",
             'cover' => [
                 'data' => file_get_contents(__DIR__.'/../../blobs/cover.png'),


### PR DESCRIPTION
### Description:
See on Issue #730 (Use at least the year of release to identify homonymous albums.)

### TODO:
 - [x] Show years on album view.
 - [x] Show years on song view.
 - [x] Allow sort by years.

### Result:
![imagen](https://user-images.githubusercontent.com/733715/39866574-928ddcfc-5427-11e8-94ff-6272fcf3bff0.png)
