### PR TITLE
Build via github actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,61 @@
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+name: Upload Release Asset
+
+jobs:
+  build:
+    name: Upload Release Asset
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Build project # This would actually build your project, using zip for an example artifact
+        run: |
+          sudo apt install php7.4 composer php7.4-sqlite3 php7.4-intl php7.4-gd pngquant zip unzip
+          git submodule update --init --recursive
+          composer install --no-dev -o
+          sed -i 's/DB_CONNECTION=mysql/DB_CONNECTION=sqlite/' .env
+          php artisan koel:init --no-interaction
+          sed -i 's/DB_CONNECTION=sqlite/DB_CONNECTION=sqlite-persistent/' .env
+          sed -i 's/DB_DATABASE=koel/DB_DATABASE=koel.db/' .env
+          rm -rf .git ./node_modules ./resources/assets/.git ./resources/assets/node_modules ./koel.db ./.env
+          cd ../
+          zip -r /tmp/koel-${{ steps.get_version.outputs.VERSION }}.zip koel/
+          tar -zcvf /tmp/koel-${{ steps.get_version.outputs.VERSION }}.tar.gz koel/
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.get_version.outputs.VERSION }}
+          release_name: Release ${{ steps.get_version.outputs.VERSION }}
+          draft: true
+          prerelease: false
+      - name: Upload Release Asset Zip
+        id: upload-release-asset-zip
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          asset_path: /tmp/koel-${{ steps.get_version.outputs.VERSION }}.zip
+          asset_name: koel-${{ steps.get_version.outputs.VERSION }}.zip
+          asset_content_type: application/zip
+      - name: Upload Release Asset Gzip
+        id: upload-release-asset-gzip
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          asset_path: /tmp/koel-${{ steps.get_version.outputs.VERSION }}.tar.gz
+          asset_name: koel-${{ steps.get_version.outputs.VERSION }}.tar.gz
+          asset_content_type: application/gzip

--- a/app/Console/Commands/InitCommand.php
+++ b/app/Console/Commands/InitCommand.php
@@ -19,7 +19,7 @@ class InitCommand extends Command
 {
     use AskForPassword;
 
-    protected $signature = 'koel:init';
+    protected $signature = 'koel:init {--no-assets}';
     protected $description = 'Install or upgrade Koel';
 
     private $mediaCacheService;
@@ -64,7 +64,7 @@ class InitCommand extends Command
             $this->migrateDatabase();
             $this->maybeSeedDatabase();
             $this->maybeSetMediaPath();
-            $this->compileFrontEndAssets();
+            $this->maybeCompileFrontEndAssets();
         } catch (Exception $e) {
             $this->error("Oops! Koel installation or upgrade didn't finish successfully.");
             $this->error('Please try again, or visit '.config('koel.misc.docs_url').' for manual installation.');
@@ -143,6 +143,11 @@ class InitCommand extends Command
     private function inNoInteractionMode(): bool
     {
         return (bool) $this->option('no-interaction');
+    }
+
+    private function inNoAssetsMode(): bool
+    {
+        return (bool) $this->option('no-assets');
     }
 
     private function setUpAdminAccount(): void
@@ -247,8 +252,12 @@ class InitCommand extends Command
         $this->mediaCacheService->clear();
     }
 
-    private function compileFrontEndAssets(): void
+    private function maybeCompileFrontEndAssets(): void
     {
+        if ($this->inNoAssetsMode()) {
+            return;
+        }
+
         $this->info('Now to front-end stuff');
 
         // We need to run several yarn commands:


### PR DESCRIPTION
This adds a build step on pushed tags that will install all dependencies and run the assets build step, zip/tar up the result and create a release draft. That draft can then have the release notes added and published which will then contain zip/tar versions that are ready to use.

It also adds a option to the init command to not build the assets, which removes the install dependency on yarn/node.

The zip/tar files come with sqlite configured as the default db, mostly because that is the only one without runtime dependencies.

The point of this is to enable people to get going with koel without git/composer/node/yarn, so that a basic install can be run with only php as

    curl -LO https://github.com/SahAssar/koel/releases/download/v0.0.7-beta3/koel-v0.0.7-beta2.zip
    unzip koel-v0.0.7-beta2.zip
    cd koel
    touch koel.db
    php artisan koel:init --no-assets
    php artisan serve