### PR TITLE
Add support for selecting Redis DB

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -127,7 +127,7 @@ return [
                     'host' => env('REDIS_HOST', '127.0.0.1'),
                     'password' => env('REDIS_PASSWORD', null),
                     'port' => env('REDIS_PORT', 6379),
-                    'database' => 0,
+                    'database' => env('REDIS_DATABASE', 0),
                 ],
             ],
         ],


### PR DESCRIPTION
I happen to use a central instance of Redis for various projects and could use having this change integrated, allowing to specify from .env the database to use.