### PR TITLE
Add .opus to list of recognized file extensions.

### DIFF
--- a/app/Services/MediaSyncService.php
+++ b/app/Services/MediaSyncService.php
@@ -157,7 +157,7 @@ class MediaSyncService
                 ->ignoreDotFiles((bool) config('koel.ignore_dot_files')) // https://github.com/phanan/koel/issues/450
                 ->files()
                 ->followLinks()
-                ->name('/\.(mp3|ogg|m4a|flac)$/i')
+                ->name('/\.(mp3|ogg|m4a|flac|opus)$/i')
                 ->in($path)
         );
     }


### PR DESCRIPTION
.opus is standarized extension for opus encoded files: https://wiki.xiph.org/MIME_Types_and_File_Extensions

Fixes #1249.