### PR TITLE
 Recognize the standard MIME type for uploaded FLAC audio

### DIFF
--- a/app/Http/Requests/API/UploadRequest.php
+++ b/app/Http/Requests/API/UploadRequest.php
@@ -20,7 +20,7 @@ class UploadRequest extends AbstractRequest
             'file' => [
                 'required',
                 'file',
-                'mimetypes:audio/mpeg,audio/ogg,audio/x-flac,audio/x-aac',
+                'mimetypes:audio/flac,audio/mpeg,audio/ogg,audio/x-flac,audio/x-aac',
             ],
         ];
     }


### PR DESCRIPTION
Before this change, Koel only recognized the non-standard MIME type audio/x-flac.

Server-side portion of https://github.com/koel/core/pull/53.