### PR TITLE
Fix S3 storage song compilation setting

### DIFF
--- a/app/Http/Controllers/API/ObjectStorage/S3/SongController.php
+++ b/app/Http/Controllers/API/ObjectStorage/S3/SongController.php
@@ -26,7 +26,7 @@ class SongController extends Controller
             $request->key,
             $artist,
             array_get($request->tags, 'album'),
-            (bool) $albumartist && $albumartist != $artist,
+            (bool) $albumartist && $albumartist !== $artist,
             array_get($request->tags, 'cover'),
             trim(array_get($request->tags, 'title', '')),
             (int) array_get($request->tags, 'duration', 0),

--- a/app/Http/Controllers/API/ObjectStorage/S3/SongController.php
+++ b/app/Http/Controllers/API/ObjectStorage/S3/SongController.php
@@ -19,12 +19,14 @@ class SongController extends Controller
 
     public function put(PutSongRequest $request)
     {
+        $artist = array_get($request->tags, 'artist', '');
+        $albumartist = trim(array_get($request->tags, 'albumartist', ''));
         $song = $this->s3Service->createSongEntry(
             $request->bucket,
             $request->key,
-            array_get($request->tags, 'artist'),
+            $artist,
             array_get($request->tags, 'album'),
-            (bool) trim(array_get($request->tags, 'albumartist')),
+            (bool) $albumartist && $albumartist != $artist,
             array_get($request->tags, 'cover'),
             trim(array_get($request->tags, 'title', '')),
             (int) array_get($request->tags, 'duration', 0),


### PR DESCRIPTION
The S3 song controller was setting `compilation` to true as long as an album artist was specified, even if it matched the artist tag. This PR adjusts the behavior to match the `isCompilation` method defined here: https://github.com/koel/koel/blob/aedff9cf6e055fa7f58eb08e52206ea750f33be2/app/Services/FileSynchronizer.php#L338-L345