### PR TITLE
feat: Add env TRANSCODE_FLAC (default true) to toggle transcoding on/off for FLAC files

### DIFF
--- a/app/Services/TranscodingService.php
+++ b/app/Services/TranscodingService.php
@@ -8,6 +8,6 @@ class TranscodingService
 {
     public function songShouldBeTranscoded(Song $song): bool
     {
-        return ends_with(mime_content_type($song->path), 'flac');
+        return ends_with(mime_content_type($song->path), 'flac') && config('koel.streaming.transcode_flac');
     }
 }

--- a/config/koel.php
+++ b/config/koel.php
@@ -37,6 +37,7 @@ return [
         'bitrate' => env('OUTPUT_BIT_RATE', 128),
         'method' => env('STREAMING_METHOD'),
         'ffmpeg_path' => env('FFMPEG_PATH'),
+        'transcode_flac' => env('TRANSCODE_FLAC', true),
     ],
 
     /*


### PR DESCRIPTION
It seems there were some attempts at making this work before but apparently they weren't done the right way or something.

The following request was closed as stale: https://github.com/koel/koel/pull/527

The following request was denied due to confusing label and wrong approach (?) https://github.com/koel/koel/pull/699

---

The only changes are: new config variable `koel.streaming.transcode_flac` that pulls data from `TRANSCODE_FLAC` env var and defaults to `true` in `config/koel.php` file and extended bool check in `app/Services/TranscodingService.php` file. [Full diff here.](https://github.com/koel/koel/compare/master...MaciejGorczyca:master#diff-c394adf35324659049bb91f7b82378371d236078ffeb27da855a076867d13f5e) 

The default behavior is the same as before but now you can turn off transcoding simply by setting env variable.

I built the Docker image with my changes here: https://hub.docker.com/r/coust/koel