### PR TITLE
feat(smart-playlist): add path as a smart playlist rule

### DIFF
--- a/app/Values/SmartPlaylistRule.php
+++ b/app/Values/SmartPlaylistRule.php
@@ -42,6 +42,7 @@ final class SmartPlaylistRule implements Arrayable
     private const MODEL_LENGTH = 'length';
     private const MODEL_DATE_ADDED = 'created_at';
     private const MODEL_DATE_MODIFIED = 'updated_at';
+    private const MODEL_PATH = 'path';
 
     private const VALID_MODELS = [
         self::MODEL_TITLE,
@@ -52,6 +53,7 @@ final class SmartPlaylistRule implements Arrayable
         self::MODEL_LENGTH,
         self::MODEL_DATE_ADDED,
         self::MODEL_DATE_MODIFIED,
+        self::MODEL_PATH,
     ];
 
     private const MODEL_COLUMN_MAP = [

--- a/resources/assets/js/config/smart-playlist/models.ts
+++ b/resources/assets/js/config/smart-playlist/models.ts
@@ -41,6 +41,10 @@ const models: SmartPlaylistModel[] = [
     name: 'updated_at',
     type: 'date',
     label: 'Date Modified'
+  }, {
+    name: 'path',
+    type: 'text',
+    label: 'Path'
   }
 ]
 

--- a/resources/assets/js/types.d.ts
+++ b/resources/assets/js/types.d.ts
@@ -199,7 +199,7 @@ interface SmartPlaylistRuleGroup {
 }
 
 interface SmartPlaylistModel {
-  name: 'title' | 'length' | 'created_at' | 'updated_at' | 'album.name' | 'artist.name' | 'interactions.play_count' | 'interactions.updated_at'
+  name: 'title' | 'length' | 'created_at' | 'updated_at' | 'album.name' | 'artist.name' | 'interactions.play_count' | 'interactions.updated_at' | 'path'
   type: 'text' | 'number' | 'date'
   label: string
   unit?: 'seconds' | 'days'


### PR DESCRIPTION
Adds path as a smart playlist rule.

I needed this because I have multiple music folders (e.g. "Violin", "Untagged", "Partially-Tagged"), and I want to create playlists based on those folders.