### PR TITLE
chore: improve assertEquals

### DIFF
--- a/tests/Feature/LastfmTest.php
+++ b/tests/Feature/LastfmTest.php
@@ -19,7 +19,7 @@ class LastfmTest extends TestCase
         $this->postAs('api/lastfm/session-key', ['key' => 'foo'], $user)
             ->assertNoContent();
 
-        self::assertEquals('foo', $user->refresh()->lastfm_session_key);
+        self::assertSame('foo', $user->refresh()->lastfm_session_key);
     }
 
     public function testConnectToLastfm(): void
@@ -97,7 +97,7 @@ class LastfmTest extends TestCase
 
         $this->get('lastfm/callback?token=foo&api_token=my-token');
 
-        self::assertEquals('my-session-key', $user->refresh()->lastfm_session_key);
+        self::assertSame('my-session-key', $user->refresh()->lastfm_session_key);
     }
 
     public function testDisconnectUser(): void

--- a/tests/Feature/ObjectStorage/S3Test.php
+++ b/tests/Feature/ObjectStorage/S3Test.php
@@ -40,7 +40,7 @@ class S3Test extends TestCase
         self::assertSame('Koel Testing Vol. 1', $song->album->name);
         self::assertSame('Koel', $song->artist->name);
         self::assertSame('When you wake up, turn your radio on, and you\'ll hear this simple song', $song->lyrics);
-        self::assertEquals(10, $song->length);
+        self::assertSame(10, (int) $song->length);
         self::assertSame(5, $song->track);
     }
 

--- a/tests/Feature/SettingTest.php
+++ b/tests/Feature/SettingTest.php
@@ -30,7 +30,7 @@ class SettingTest extends TestCase
         $this->putAs('/api/settings', ['media_path' => __DIR__], $admin)
             ->assertSuccessful();
 
-        self::assertEquals(__DIR__, Setting::get('media_path'));
+        self::assertSame(__DIR__, Setting::get('media_path'));
     }
 
     public function testNonAdminCannotSaveSettings(): void

--- a/tests/Feature/SongTest.php
+++ b/tests/Feature/SongTest.php
@@ -78,10 +78,10 @@ class SongTest extends TestCase
             ->assertOk();
 
         // We don't expect the song's artist to change
-        self::assertEquals($originalArtistId, $song->refresh()->artist->id);
+        self::assertSame($originalArtistId, $song->refresh()->artist->id);
 
         // But we expect a new album to be created for this artist and contain this song
-        self::assertEquals('One by One', $song->album->name);
+        self::assertSame('One by One', $song->album->name);
     }
 
     public function testMultipleUpdateNoCompilation(): void
@@ -105,11 +105,11 @@ class SongTest extends TestCase
         $songs = Song::query()->whereIn('id', $songIds)->get();
 
         // All of these songs must now belong to a new album and artist set
-        self::assertEquals('One by One', $songs[0]->album->name);
+        self::assertSame('One by One', $songs[0]->album->name);
         self::assertSame($songs[0]->album_id, $songs[1]->album_id);
         self::assertSame($songs[0]->album_id, $songs[2]->album_id);
 
-        self::assertEquals('John Cena', $songs[0]->artist->name);
+        self::assertSame('John Cena', $songs[0]->artist->name);
         self::assertSame($songs[0]->artist_id, $songs[1]->artist_id);
         self::assertSame($songs[0]->artist_id, $songs[2]->artist_id);
     }
@@ -140,17 +140,17 @@ class SongTest extends TestCase
 
         // Even though the album name doesn't change, a new artist should have been created
         // and thus, a new album with the same name was created as well.
-        self::assertEquals($songs[0]->album->name, $originalSongs[0]->album->name);
-        self::assertNotEquals($songs[0]->album->id, $originalSongs[0]->album->id);
-        self::assertEquals($songs[1]->album->name, $originalSongs[1]->album->name);
-        self::assertNotEquals($songs[1]->album->id, $originalSongs[1]->album->id);
-        self::assertEquals($songs[2]->album->name, $originalSongs[2]->album->name);
-        self::assertNotEquals($songs[2]->album->id, $originalSongs[2]->album->id);
+        self::assertSame($songs[0]->album->name, $originalSongs[0]->album->name);
+        self::assertNotSame($songs[0]->album->id, $originalSongs[0]->album->id);
+        self::assertSame($songs[1]->album->name, $originalSongs[1]->album->name);
+        self::assertNotSame($songs[1]->album->id, $originalSongs[1]->album->id);
+        self::assertSame($songs[2]->album->name, $originalSongs[2]->album->name);
+        self::assertNotSame($songs[2]->album->id, $originalSongs[2]->album->id);
 
         // And of course, the new artist is...
-        self::assertEquals('John Cena', $songs[0]->artist->name); // JOHN CENA!!!
-        self::assertEquals('John Cena', $songs[1]->artist->name); // JOHN CENA!!!
-        self::assertEquals('John Cena', $songs[2]->artist->name); // And... JOHN CENAAAAAAAAAAA!!!
+        self::assertSame('John Cena', $songs[0]->artist->name); // JOHN CENA!!!
+        self::assertSame('John Cena', $songs[1]->artist->name); // JOHN CENA!!!
+        self::assertSame('John Cena', $songs[2]->artist->name); // And... JOHN CENAAAAAAAAAAA!!!
     }
 
     public function testSingleUpdateAllInfoWithCompilation(): void
@@ -199,11 +199,11 @@ class SongTest extends TestCase
 
     public function testDeletingByChunk(): void
     {
-        self::assertNotEquals(0, Song::query()->count());
+        self::assertNotSame(0, Song::query()->count());
         $ids = Song::query()->select('id')->get()->pluck('id')->all();
 
         Song::deleteByChunk($ids, 'id', 1);
 
-        self::assertEquals(0, Song::query()->count());
+        self::assertSame(0, Song::query()->count());
     }
 }

--- a/tests/Feature/V6/PlayCountTest.php
+++ b/tests/Feature/V6/PlayCountTest.php
@@ -24,7 +24,7 @@ class PlayCountTest extends TestCase
                 'play_count',
             ]);
 
-        self::assertEquals(11, $interaction->refresh()->play_count);
+        self::assertSame(11, $interaction->refresh()->play_count);
     }
 
     public function testStoreNewEntry(): void
@@ -50,6 +50,6 @@ class PlayCountTest extends TestCase
             ->where('user_id', $user->id)
             ->first();
 
-        self::assertEquals(1, $interaction->play_count);
+        self::assertSame(1, $interaction->play_count);
     }
 }

--- a/tests/Integration/Models/SongZipArchiveTest.php
+++ b/tests/Integration/Models/SongZipArchiveTest.php
@@ -16,8 +16,8 @@ class SongZipArchiveTest extends TestCase
         $songZipArchive = new SongZipArchive();
         $songZipArchive->addSong($song);
 
-        self::assertEquals(1, $songZipArchive->getArchive()->numFiles);
-        self::assertEquals('full.mp3', $songZipArchive->getArchive()->getNameIndex(0));
+        self::assertSame(1, $songZipArchive->getArchive()->numFiles);
+        self::assertSame('full.mp3', $songZipArchive->getArchive()->getNameIndex(0));
     }
 
     public function testAddMultipleSongsIntoArchive(): void
@@ -30,8 +30,8 @@ class SongZipArchiveTest extends TestCase
         $songZipArchive = new SongZipArchive();
         $songZipArchive->addSongs($songs);
 
-        self::assertEquals(2, $songZipArchive->getArchive()->numFiles);
-        self::assertEquals('full.mp3', $songZipArchive->getArchive()->getNameIndex(0));
-        self::assertEquals('lorem.mp3', $songZipArchive->getArchive()->getNameIndex(1));
+        self::assertSame(2, $songZipArchive->getArchive()->numFiles);
+        self::assertSame('full.mp3', $songZipArchive->getArchive()->getNameIndex(0));
+        self::assertSame('lorem.mp3', $songZipArchive->getArchive()->getNameIndex(1));
     }
 }

--- a/tests/Integration/Services/ApplicationInformationServiceTest.php
+++ b/tests/Integration/Services/ApplicationInformationServiceTest.php
@@ -23,7 +23,7 @@ class ApplicationInformationServiceTest extends TestCase
         $client = new Client(['handler' => HandlerStack::create($mock)]);
         $service = new ApplicationInformationService($client, app(Cache::class));
 
-        self::assertEquals($latestVersion, $service->getLatestVersionNumber());
+        self::assertSame($latestVersion, $service->getLatestVersionNumber());
         self::assertSame($latestVersion, cache()->get('latestKoelVersion'));
     }
 }

--- a/tests/Integration/Services/InteractionServiceTest.php
+++ b/tests/Integration/Services/InteractionServiceTest.php
@@ -30,7 +30,7 @@ class InteractionServiceTest extends TestCase
         $currentCount = $interaction->play_count;
         $this->interactionService->increasePlayCount($interaction->song, $interaction->user);
 
-        self::assertEquals($currentCount + 1, $interaction->refresh()->play_count);
+        self::assertSame($currentCount + 1, $interaction->refresh()->play_count);
     }
 
     public function testToggleLike(): void

--- a/tests/Integration/Services/MediaSyncServiceTest.php
+++ b/tests/Integration/Services/MediaSyncServiceTest.php
@@ -73,7 +73,7 @@ class MediaSyncServiceTest extends TestCase
         // Albums and artists should be correctly linked
         /** @var Album $album */
         $album = Album::query()->where('name', 'Koel Testing Vol. 1')->first();
-        self::assertEquals('Koel', $album->artist->name);
+        self::assertSame('Koel', $album->artist->name);
 
         // Compilation albums, artists and songs must be recognized
         /** @var Song $song */

--- a/tests/Unit/ApplicationTest.php
+++ b/tests/Unit/ApplicationTest.php
@@ -10,15 +10,15 @@ class ApplicationTest extends TestCase
     {
         config(['koel.cdn.url' => '']);
 
-        self::assertEquals('http://localhost/', static_url());
-        self::assertEquals('http://localhost/foo.css', static_url('/foo.css '));
+        self::assertSame('http://localhost/', static_url());
+        self::assertSame('http://localhost/foo.css', static_url('/foo.css '));
     }
 
     public function testStaticUrlsWithCdnAreConstructedCorrectly(): void
     {
         config(['koel.cdn.url' => 'http://cdn.tld']);
 
-        self::assertEquals('http://cdn.tld/', static_url());
-        self::assertEquals('http://cdn.tld/foo.css', static_url('/foo.css '));
+        self::assertSame('http://cdn.tld/', static_url());
+        self::assertSame('http://cdn.tld/foo.css', static_url('/foo.css '));
     }
 }

--- a/tests/Unit/Models/AlbumTest.php
+++ b/tests/Unit/Models/AlbumTest.php
@@ -48,6 +48,6 @@ class AlbumTest extends TestCase
 
         $album = Album::getOrCreate($artist, $name);
 
-        self::assertEquals('Unknown Album', $album->name);
+        self::assertSame('Unknown Album', $album->name);
     }
 }

--- a/tests/Unit/Models/SettingTest.php
+++ b/tests/Unit/Models/SettingTest.php
@@ -40,7 +40,7 @@ class SettingTest extends TestCase
         Setting::set('foo', 'bar');
         Setting::set('foo', 'baz');
 
-        self::assertEquals('baz', Setting::get('foo'));
+        self::assertSame('baz', Setting::get('foo'));
     }
 
     public function testGetSettings(): void

--- a/tests/Unit/Models/SongTest.php
+++ b/tests/Unit/Models/SongTest.php
@@ -20,6 +20,6 @@ class SongTest extends TestCase
         /** @var Song $song */
         $song = Song::factory()->create(['lyrics' => "[00:00.00]Line 1\n[00:01.00]Line 2\n[00:02.00]Line 3"]);
 
-        self::assertEquals("Line 1\nLine 2\nLine 3", $song->lyrics);
+        self::assertSame("Line 1\nLine 2\nLine 3", $song->lyrics);
     }
 }

--- a/tests/Unit/Services/ApiClients/ApiClientTest.php
+++ b/tests/Unit/Services/ApiClients/ApiClientTest.php
@@ -28,9 +28,9 @@ class ApiClientTest extends TestCase
     {
         $api = new ConcreteApiClient($this->wrapped);
 
-        self::assertEquals('https://foo.com/get/param?key=bar', $api->buildUrl('get/param'));
-        self::assertEquals('https://foo.com/get/param?baz=moo&key=bar', $api->buildUrl('/get/param?baz=moo'));
-        self::assertEquals('https://baz.com/?key=bar', $api->buildUrl('https://baz.com/'));
+        self::assertSame('https://foo.com/get/param?key=bar', $api->buildUrl('get/param'));
+        self::assertSame('https://foo.com/get/param?baz=moo&key=bar', $api->buildUrl('/get/param?baz=moo'));
+        self::assertSame('https://baz.com/?key=bar', $api->buildUrl('https://baz.com/'));
     }
 
     /** @return array<mixed> */

--- a/tests/Unit/Services/ApiClients/LastfmClientTest.php
+++ b/tests/Unit/Services/ApiClients/LastfmClientTest.php
@@ -19,6 +19,6 @@ class LastfmClientTest extends TestCase
 
         $client = new LastfmClient(new GuzzleHttpClient(['handler' => HandlerStack::create($mock)]));
 
-        self::assertEquals('foo', $client->getSessionKey('bar'));
+        self::assertSame('foo', $client->getSessionKey('bar'));
     }
 }

--- a/tests/Unit/Services/MediaMetadataServiceTest.php
+++ b/tests/Unit/Services/MediaMetadataServiceTest.php
@@ -53,7 +53,7 @@ class MediaMetadataServiceTest extends TestCase
             ->with('/koel/public/img/album/foo.jpg', 'dummy-src');
 
         $this->mediaMetadataService->writeAlbumCover($album, 'dummy-src', 'jpg', $coverPath);
-        self::assertEquals(album_cover_url('foo.jpg'), $album->refresh()->cover);
+        self::assertSame(album_cover_url('foo.jpg'), $album->refresh()->cover);
     }
 
     public function testTryDownloadArtistImage(): void
@@ -82,6 +82,6 @@ class MediaMetadataServiceTest extends TestCase
 
         $this->mediaMetadataService->writeArtistImage($artist, 'dummy-src', 'jpg', $imagePath);
 
-        self::assertEquals(artist_image_url('foo.jpg'), $artist->refresh()->image);
+        self::assertSame(artist_image_url('foo.jpg'), $artist->refresh()->image);
     }
 }

--- a/tests/Unit/Services/YouTubeServiceTest.php
+++ b/tests/Unit/Services/YouTubeServiceTest.php
@@ -25,7 +25,7 @@ class YouTubeServiceTest extends TestCase
         $service = new YouTubeService($client, app(Repository::class));
         $response = $service->searchVideosRelatedToSong($song, 'my-token');
 
-        self::assertEquals('Slipknot - Snuff [OFFICIAL VIDEO]', $response->items[0]->snippet->title);
+        self::assertSame('Slipknot - Snuff [OFFICIAL VIDEO]', $response->items[0]->snippet->title);
         self::assertNotNull(cache()->get('5becf539115b18b2df11c39adbc2bdfa'));
     }
 }


### PR DESCRIPTION
# Changed log

- It should use the `assertSame` to make assert equals strict.