### PR TITLE
fix: do not lazy-load GlobalEventListeners

### DIFF
--- a/resources/assets/js/App.vue
+++ b/resources/assets/js/App.vue
@@ -2,10 +2,10 @@
   <Overlay/>
   <DialogBox ref="dialog"/>
   <MessageToaster ref="toaster"/>
+  <GlobalEventListeners/>
 
   <div id="main" v-if="authenticated" @dragover="onDragOver" @drop="onDrop" @dragend="onDragEnd">
     <Hotkeys/>
-    <GlobalEventListeners/>
     <AppHeader/>
     <MainWrapper/>
     <AppFooter/>
@@ -39,8 +39,10 @@ import Overlay from '@/components/ui/Overlay.vue'
 // that is necessary to properly initialize the playService and equalizer.
 import AppFooter from '@/components/layout/app-footer/index.vue'
 
+// GlobalEventListener must NOT be lazy-loaded, so that it can handle LOG_OUT event properly.
+import GlobalEventListeners from '@/components/utils/GlobalEventListeners.vue'
+
 const AppHeader = defineAsyncComponent(() => import('@/components/layout/AppHeader.vue'))
-const GlobalEventListeners = defineAsyncComponent(() => import('@/components/utils/GlobalEventListeners.vue'))
 const Hotkeys = defineAsyncComponent(() => import('@/components/utils/HotkeyListener.vue'))
 const LoginForm = defineAsyncComponent(() => import('@/components/auth/LoginForm.vue'))
 const MainWrapper = defineAsyncComponent(() => import('@/components/layout/main-wrapper/index.vue'))

--- a/resources/assets/js/components/album/AlbumTrackListItem.vue
+++ b/resources/assets/js/components/album/AlbumTrackListItem.vue
@@ -43,6 +43,7 @@ const play = () => {
   if (matchedSong.value) {
     queueStore.queueIfNotQueued(matchedSong.value)
     playbackService.play(matchedSong.value)
+
   }
 }
 </script>

--- a/resources/assets/js/components/album/AlbumTrackListItem.vue
+++ b/resources/assets/js/components/album/AlbumTrackListItem.vue
@@ -43,7 +43,6 @@ const play = () => {
   if (matchedSong.value) {
     queueStore.queueIfNotQueued(matchedSong.value)
     playbackService.play(matchedSong.value)
-
   }
 }
 </script>


### PR DESCRIPTION
Lazyloading GlobalEventListeners may cause `LOG_OUT` event to not be listened to and handled properly.