### PR TITLE
chore: add port 8000 into .env's APP_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,7 +28,7 @@ IGNORE_DOT_FILES=true
 
 APP_ENV=production
 APP_DEBUG=true
-APP_URL=http://localhost
+APP_URL=http://localhost:8000
 
 
 # The maximum scan time, in seconds. Increase this if you have a huge library.


### PR DESCRIPTION
This port number actually determines how `yarn dev` displays and behaves:

```bash
$ yarn dev
4:35:34 PM [vite] server restarted.

  ➜  Local:   http://127.0.0.1:5173/
  ➜  Network: use --host to expose

  LARAVEL v9.22.1  plugin v0.6.1

  ➜  APP_URL: http://localhost:8000 <--- THIS
```