### PR TITLE
fix: pressing Space causes lists to scroll

### DIFF
--- a/resources/assets/js/components/utils/HotkeyListener.vue
+++ b/resources/assets/js/components/utils/HotkeyListener.vue
@@ -23,6 +23,7 @@ const togglePlayback = (e: KeyboardEvent) => {
     return true
   }
 
+  e.preventDefault()
   playbackService.toggle()
 
   return false


### PR DESCRIPTION
Since we're using the Space key to toggle playback, the default browser behavior (scroll to the next page) should be prevented.