### PR TITLE
fix: update multiple songs duplicate values

### DIFF
--- a/app/Values/SongUpdateData.php
+++ b/app/Values/SongUpdateData.php
@@ -31,7 +31,7 @@ final class SongUpdateData implements Arrayable
             track: (int) $request->input('data.track'),
             disc: (int) $request->input('data.disc'),
             genre: $request->input('data.genre'),
-            year: (int) $request->input('data.year') ?: null,
+            year: (int) $request->input('data.year'),
             lyrics: $request->input('data.lyrics'),
         );
     }


### PR DESCRIPTION
Fixing a bug where updating multiple songs will leak data from the first song to the next.
Also fixing a bug where user can't clear some values when editing only one song.