### PR TITLE
Add two tests for smartPlaylistService

### DIFF
--- a/tests/Integration/Services/SmartPlaylistServiceTest.php
+++ b/tests/Integration/Services/SmartPlaylistServiceTest.php
@@ -2,9 +2,83 @@
 
 namespace Tests\Integration\Services;
 
+use App\Exceptions\NonSmartPlaylistException;
+use App\Models\Playlist;
+use App\Models\Song;
+use App\Models\User;
+use App\Services\SmartPlaylistService;
+use App\Values\SmartPlaylistRuleGroupCollection;
 use Tests\TestCase;
 
 class SmartPlaylistServiceTest extends TestCase
 {
-    // @todo write tests
+    private SmartPlaylistService $smartPlaylistService;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->smartPlaylistService = app(SmartPlaylistService::class);
+    }
+
+    public function testGetSongsBasedOnMySmartPlaylistViaSmartPlaylistService()
+    {
+        $rules = SmartPlaylistRuleGroupCollection::create([
+            [
+                'id' => 1634756491129,
+                'rules' => [
+                    [
+                        'id' => 1634756491129,
+                        'model' => 'title',
+                        'operator' => 'is',
+                        'value' => ['smart'],
+                    ],
+                    [
+                        "id" => 1669824399012,
+                        "model" => "year",
+                        "operator" => "isGreaterThan",
+                        "value" => [2000]
+                    ]
+                ],
+            ],
+        ]);
+
+        /** @var User $user */
+        $user = User::factory()->create();
+
+        /** @var Playlist $playlist */
+        $playlist = Playlist::factory([
+            'user_id' => $user->id,
+            'rules' => $rules
+        ])->create()->first();
+
+        /** @var Song $songs */
+        $newSongs = Song::factory(3, [
+            'year' => random_int(2001, 2010),
+            'title' => 'smart'
+        ])->create();
+
+        $playlist->songs()->sync($newSongs->pluck('id'));
+
+        $songs = $this->smartPlaylistService->getSongs($playlist);
+        self::assertInstanceOf(Song::class, $songs->first());
+        self::assertEquals($songs->count(), $newSongs->count());
+        self::assertEquals($songs->pluck('lyrics'), $newSongs->pluck('lyrics'));
+    }
+
+    public function testIfPlaylistIsNotSmartThenThrowsNonSmartPlaylistException()
+    {
+        self::expectException(NonSmartPlaylistException::class);
+        /** @var Playlist $playlist */
+        $playlist = Playlist::factory()->create()->first();
+
+        /** @var Song $songs */
+        $newSongs = Song::factory(3, [
+            'title' => 'foo'
+        ])->create();
+
+        $playlist->songs()->sync($newSongs->pluck('id'));
+
+        $this->smartPlaylistService->getSongs($playlist);
+    }
 }


### PR DESCRIPTION
Add two new tests for SmartPlaylistService
(Generally, I like to use underline in test function name for example test_if_a_user_is_logged_in is better testIfAUserIsLoggedIn but because you use this approach I used also this approach in naming. but if you agree we can use underline in test function names also. )

1- create a smart Playlist and then add new songs to it. then try to retrieve the songs by SmartPlaylistService.
this function has 3 different assertions.  
   a - checking instance of returning object.
   b - check returning object counts with created songs 
   c - check return object lyric property and compare with created songs.

2- what happens if the created playlist is not smart? => so it should return NonSmartPlaylistException 
I checked if the playlist is not smart so it should return this exception.

Dear Phan, what do you think about my new tests?
if this approach is acceptable I will continue to work by this way :)
