### PR TITLE
feat: increase send_timeout in nginx config

### DIFF
--- a/nginx.conf.example
+++ b/nginx.conf.example
@@ -8,6 +8,8 @@ server {
   gzip_types      text/plain text/css application/x-javascript text/xml application/xml application/xml+rss text/javascript application/json;
   gzip_comp_level  9;
 
+  send_timeout    3600;
+
   location / {
     try_files   $uri $uri/ /index.php?$args;
   }


### PR DESCRIPTION
This PR specifies a `send_timeout` in the example `nginx` configuration.

If the `koel` client has not finished buffering a song within the default client timeout (60s), `nginx` closes the connection. This causes the song to either stop playing in a desktop browser, or skip to the beginning and endlessly repeat in the mobile app. By increasing the client timeout, `nginx` keeps the connection open until buffering is done.

c.f. https://www.davidschlachter.com/misc/koel-songs-skipping-stopping