### PR TITLE
fix(frontend): Fix the base URL supplied to the frontend

### DIFF
--- a/app/Helpers.php
+++ b/app/Helpers.php
@@ -70,3 +70,9 @@ function attempt_unless($condition, callable $callback, bool $log = true): mixed
 {
     return !value($condition) ? attempt($callback, $log) : null;
 }
+
+/** Get the correct base URL for the app. */
+function base_url(): string
+{
+    return rtrim(config('app.url'), '/') . '/';
+}

--- a/resources/views/base.blade.php
+++ b/resources/views/base.blade.php
@@ -11,7 +11,7 @@
     <meta name="theme-color" content="#282828">
     <meta name="msapplication-navbutton-color" content="#282828">
 
-    <base href="{{ config('app.url') }}">
+    <base href="{{ base_url() }}">
     <link rel="manifest" href="{{ static_url('manifest.json') }}"/>
     <meta name="msapplication-config" content="{{ static_url('browserconfig.xml') }}"/>
     <link rel="icon" type="image/x-icon" href="{{ static_url('img/favicon.ico') }}"/>
@@ -29,7 +29,7 @@
 <noscript>It may sound funny, but Koel requires JavaScript to sing. Please enable it.</noscript>
 
 <script>
-    window.BASE_URL = @json(config('app.url'));
+    window.BASE_URL = @json(base_url());
     window.PUSHER_APP_KEY = @json(config('broadcasting.connections.pusher.key'));
     window.PUSHER_APP_CLUSTER = @json(config('broadcasting.connections.pusher.options.cluster'));
 </script>

--- a/resources/views/base.blade.php
+++ b/resources/views/base.blade.php
@@ -11,7 +11,7 @@
     <meta name="theme-color" content="#282828">
     <meta name="msapplication-navbutton-color" content="#282828">
 
-    <base href="{{ asset('') }}">
+    <base href="{{ config('app.url') }}">
     <link rel="manifest" href="{{ static_url('manifest.json') }}"/>
     <meta name="msapplication-config" content="{{ static_url('browserconfig.xml') }}"/>
     <link rel="icon" type="image/x-icon" href="{{ static_url('img/favicon.ico') }}"/>
@@ -29,7 +29,7 @@
 <noscript>It may sound funny, but Koel requires JavaScript to sing. Please enable it.</noscript>
 
 <script>
-    window.BASE_URL = @json(asset(''));
+    window.BASE_URL = @json(config('app.url'));
     window.PUSHER_APP_KEY = @json(config('broadcasting.connections.pusher.key'));
     window.PUSHER_APP_CLUSTER = @json(config('broadcasting.connections.pusher.options.cluster'));
 </script>


### PR DESCRIPTION
I've encountered an issue when running behind a reverse proxy. Proxy terminates SSL correctly and provides correct `X-Forwarded` headers, but URLs generated for the frontend aren't `https`, so it tries to call the API via `http` which browsers explicitly forbid and throw an error along the lines of `...was not allowed to display insecure content from http://...`

This PR fixes the `BASE_URL` explicitly used in Vue and the URL in `<base>` tag which may be used implicitly.

Now the "non-working" `APP_URL` ENV value actually does something.