### PR TITLE
fix: uuid generator

### DIFF
--- a/resources/assets/js/utils/crypto.ts
+++ b/resources/assets/js/utils/crypto.ts
@@ -8,5 +8,5 @@ export const uuid = () => {
 
   return typeof window.crypto?.randomUUID === 'function'
     ? window.crypto.randomUUID()
-    : window.URL.createObjectURL(new Blob([])).substring(31)
+    : window.URL.createObjectURL(new Blob([])).split('/').pop()
 }


### PR DESCRIPTION
fixes #1669

The length of `window.URL.createObjectURL(new Blob([]))` can vary, leading to a truncated uuid when extracting with a hardcorded substring length.

Replacing with a split pop, guarantees that the full uuid is extracted.