### PR TITLE
feat: implement and use new confg key for trusted hosts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,11 @@ APP_ENV=production
 APP_DEBUG=true
 APP_URL=http://localhost:8000
 
+# A comma-separated list of (Koel server) hostnames accepted to access Koel.
+# Leave this empty to allow access to Koel with any hostname.
+# Example: localhost,192.168.0.1,yourdomain.com
+TRUSTED_HOSTS=
+
 # A random 32-char string. You can leave this empty if use php artisan koel:init.
 APP_KEY=
 

--- a/app/Http/Middleware/TrustHosts.php
+++ b/app/Http/Middleware/TrustHosts.php
@@ -11,8 +11,6 @@ class TrustHosts extends IlluminateTrustHost
      */
     public function hosts(): array
     {
-        return [
-            $this->allSubdomainsOfApplicationUrl(),
-        ];
+        return config('app.trusted_hosts');
     }
 }

--- a/config/app.php
+++ b/config/app.php
@@ -34,6 +34,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Trusted hosts
+    |--------------------------------------------------------------------------
+    |
+    | An array of (Koel server) hostnames accepted to access Koel.
+    | An empty array allows access to Koel with any hostname.
+    | Example: ['localhost', '192.168.0.1', 'yourdomain.com']
+    |
+    */
+
+    'trusted_hosts' => explode(',', env('TRUSTED_HOSTS', '')),
+
+    /*
+    |--------------------------------------------------------------------------
     | Application Timezone
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
After commit https://github.com/koel/koel/commit/e969549, Koel accepts only the hostname from `APP_URL` (and all its sub domains) as trusted hosts, as long as HTTPS is not enforced. This breaks access with `.env.example`, until `APP_URL` is set, and then allows to define a single trusted host only, which can be a problem instances which one wants to access from localhost, from within LAN via local hostname or IP, and remotely with a public hostname at the same time, or for testing instances.

This commit introduces a new config key `TRUSTED_HOSTS`. It is empty by default, which permits access via all hostnames, restoring the pre-v7.0.0 behaviour. When definitng it as comma-separated list of hostnames (and/or IPs), access is restricted to those.

Fixes: #1796