### PR TITLE
feat: add option to skip installation of scheduler

### DIFF
--- a/app/Console/Commands/InitCommand.php
+++ b/app/Console/Commands/InitCommand.php
@@ -27,7 +27,7 @@ class InitCommand extends Command
     private const DEFAULT_ADMIN_PASSWORD = 'KoelIsCool';
     private const NON_INTERACTION_MAX_DATABASE_ATTEMPT_COUNT = 10;
 
-    protected $signature = 'koel:init {--no-assets : Do not compile front-end assets}';
+    protected $signature = 'koel:init {--no-assets : Do not compile front-end assets} {--no-scheduler : Do not install scheduler}';
     protected $description = 'Install or upgrade Koel';
 
     private bool $adminSeeded = false;
@@ -352,6 +352,10 @@ class InitCommand extends Command
     private function tryInstallingScheduler(): void
     {
         if (PHP_OS_FAMILY === 'Windows' || PHP_OS_FAMILY === 'Unknown') {
+            return;
+        }
+
+        if ((bool) $this->option('no-scheduler')) {
             return;
         }
 

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -63,9 +63,10 @@ php artisan koel:init [options]
 ```
 
 #### Options
-| Name          | Description                     |
-|---------------|---------------------------------|
-| `--no-assets` | Do not compile front-end assets |
+| Name             | Description                     |
+|------------------|---------------------------------|
+| `--no-assets`    | Do not compile front-end assets |
+| `--no-scheduler` | Do not install scheduler        |
 
 ### `koel:license:activate`
 


### PR DESCRIPTION
In the Cloudron package, we have a readonly filesystem and the cron is run outside the container . This option allows skipping installation of the scheduler crontab.