### PR TITLE
fix: display defaultCover when processing empty cover image

### DIFF
--- a/resources/assets/js/components/layout/app-footer/FooterSongInfo.vue
+++ b/resources/assets/js/components/layout/app-footer/FooterSongInfo.vue
@@ -43,7 +43,7 @@ const artistOrPodcastName = computed(() => {
   return getPlayableProp(song.value, 'artist_name', 'podcast_title')
 })
 
-const coverBackgroundImage = computed(() => `url(${cover.value})`)
+const coverBackgroundImage = computed(() => `url(${cover.value ?? defaultCover})`)
 const draggable = computed(() => Boolean(song.value))
 
 const onDragStart = (event: DragEvent) => {

--- a/resources/assets/js/components/ui/__snapshots__/ProfileAvatar.spec.ts.snap
+++ b/resources/assets/js/components/ui/__snapshots__/ProfileAvatar.spec.ts.snap
@@ -1,3 +1,3 @@
 // Vitest Snapshot v1
 
-exports[`renders 1`] = `<a class="view-profile rounded-full" data-testid="view-profile-link" href="/#/profile" title="Profile and preferences"><img alt="Avatar of John Doe" src="https://example.com/avatar.jpg" title="John Doe" onerror="undefined/resources/assets/img/covers/default.svg" class="object-cover rounded-full aspect-square bg-k-bg-primary p-0.5 border border-solid border-white/10 transition duration-200 ease-in-out hover:border-white/30 active:scale-95" width="40"></a>`;
+exports[`renders 1`] = `<a class="view-profile rounded-full" data-testid="view-profile-link" href="/#/profile" title="Profile and preferences"><img alt="Avatar of John Doe" src="https://example.com/avatar.jpg" title="John Doe" class="object-cover rounded-full aspect-square bg-k-bg-primary p-0.5 border border-solid border-white/10 transition duration-200 ease-in-out hover:border-white/30 active:scale-95" width="40"></a>`;

--- a/resources/assets/js/components/ui/__snapshots__/ProfileAvatar.spec.ts.snap
+++ b/resources/assets/js/components/ui/__snapshots__/ProfileAvatar.spec.ts.snap
@@ -1,3 +1,3 @@
 // Vitest Snapshot v1
 
-exports[`renders 1`] = `<a class="view-profile rounded-full" data-testid="view-profile-link" href="/#/profile" title="Profile and preferences"><img alt="Avatar of John Doe" src="https://example.com/avatar.jpg" title="John Doe" class="rounded-full aspect-square bg-k-bg-primary object-cover p-0.5 border border-solid border-white/10 transition duration-200 ease-in-out hover:border-white/30 active:scale-95" width="40"></a>`;
+exports[`renders 1`] = `<a class="view-profile rounded-full" data-testid="view-profile-link" href="/#/profile" title="Profile and preferences"><img alt="Avatar of John Doe" src="https://example.com/avatar.jpg" title="John Doe" onerror="undefined/resources/assets/img/covers/default.svg" class="object-cover rounded-full aspect-square bg-k-bg-primary p-0.5 border border-solid border-white/10 transition duration-200 ease-in-out hover:border-white/30 active:scale-95" width="40"></a>`;

--- a/resources/assets/js/components/user/UserAvatar.vue
+++ b/resources/assets/js/components/user/UserAvatar.vue
@@ -3,7 +3,7 @@
     :alt="`Avatar of ${user.name}`"
     :src="avatar"
     :title="user.name"
-    :onerror="avatar = defaultCover"
+    @error="avatar = defaultCover"
     class="object-cover rounded-full aspect-square bg-k-bg-primary"
   >
 </template>

--- a/resources/assets/js/components/user/UserAvatar.vue
+++ b/resources/assets/js/components/user/UserAvatar.vue
@@ -1,17 +1,18 @@
 <template>
   <img
     :alt="`Avatar of ${user.name}`"
-    :src="user.avatar"
+    :src="avatar"
     :title="user.name"
-    :onerror="user.avatar = defaultCover"
-    class="rounded-full aspect-square bg-k-bg-primary object-cover"
+    :onerror="avatar = defaultCover"
+    class="object-cover rounded-full aspect-square bg-k-bg-primary"
   >
 </template>
 
 <script lang="ts" setup>
-import { toRefs } from 'vue'
+import { toRefs, ref } from 'vue'
 import { defaultCover } from '@/utils'
 
 const props = defineProps<{ user: Pick<User, 'name' | 'avatar'> }>()
 const { user } = toRefs(props)
+const avatar = ref(user.value.avatar)
 </script>

--- a/resources/assets/js/components/user/UserAvatar.vue
+++ b/resources/assets/js/components/user/UserAvatar.vue
@@ -3,12 +3,14 @@
     :alt="`Avatar of ${user.name}`"
     :src="user.avatar"
     :title="user.name"
+    :onerror="user.avatar = defaultCover"
     class="rounded-full aspect-square bg-k-bg-primary object-cover"
   >
 </template>
 
 <script lang="ts" setup>
 import { toRefs } from 'vue'
+import { defaultCover } from '@/utils'
 
 const props = defineProps<{ user: Pick<User, 'name' | 'avatar'> }>()
 const { user } = toRefs(props)


### PR DESCRIPTION
- display defaultCover when processing empty cover image
- load default avatar when avatar loading fails, because the network in some places can't access www.gravatar.com, I added the default avatar to use logo.

@phanan TBR; thank you for your excellent work to bring us joy, If there is anything I can do for you, please let me know.

**[Surprise Origin] [lzc-app](https://lazycat.cloud/appstore/%2Fshop%2Fdetail%2Fcloud.lazycat.app.koel) porting upstream code giveback plan**