### PR TITLE
fix: ensure default storage is local

### DIFF
--- a/config/koel.php
+++ b/config/koel.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-    'storage_driver' => env('STORAGE_DRIVER', 'local'),
+    'storage_driver' => env('STORAGE_DRIVER', 'local') ?: 'local',
 
     'media_path' => env('MEDIA_PATH'),
 


### PR DESCRIPTION
Currently if `STORAGE_DRIVER` is set to an empty string in `.env`, `config('koel.storage_driver')` will return an empty string instead of `'local'` and break some functionalities.