### PR TITLE
Use fullText() index for artist and album name columns

### DIFF
--- a/database/migrations/2025_07_04_090408_denormalize_artist_albums.php
+++ b/database/migrations/2025_07_04_090408_denormalize_artist_albums.php
@@ -10,12 +10,12 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('songs', static function (Blueprint $table): void {
-            $table->string('artist_name', (2 ** 16) - 32)->nullable()->index();
-            $table->string('album_name', (2 ** 16) - 32)->nullable()->index();
+            $table->string('artist_name')->nullable()->index();
+            $table->string('album_name')->nullable()->index();
         });
 
         Schema::table('albums', static function (Blueprint $table): void {
-            $table->string('artist_name', (2 ** 16) - 32)->nullable()->index();
+            $table->string('artist_name')->nullable()->index();
         });
 
         $pdo = DB::connection()->getPdo();


### PR DESCRIPTION
Apparently for large text columns, the text index supporting all databases is fullText() https://laravel.com/docs/12.x/migrations#available-index-types

Fixes #2010 