### PR TITLE
preload artist image as well

### DIFF
--- a/app/Services/SongService.php
+++ b/app/Services/SongService.php
@@ -33,6 +33,7 @@ class SongService
         private readonly TranscodeRepository $transcodeRepository,
         private readonly ArtworkService $artworkService,
         private readonly CacheStrategy $cache,
+        private readonly EncyclopediaService $encyclopediaService,
     ) {
     }
 
@@ -215,6 +216,10 @@ class SongService
             } else {
                 $this->artworkService->trySetAlbumCoverFromDirectory($album, dirname($data['path']));
             }
+        }
+
+        if (!$artist->has_image && SpotifyService::enabled()) {
+            $this->encyclopediaService->getArtistInformation($artist);
         }
 
         Arr::forget($data, ['album', 'artist', 'albumartist', 'cover']);


### PR DESCRIPTION
On sync it preload album images, but not artist images, leading to a blank ui. to see the artist image you first need to open the artist details so it loads in the background, then reload the page. Better to just preload it like the other images.

Seemed like an easy fix so figured i'd just do a PR quickly