### PR TITLE
fix: layout of koel plus modal

### DIFF
--- a/resources/assets/js/components/koel-plus/KoelPlusModal.vue
+++ b/resources/assets/js/components/koel-plus/KoelPlusModal.vue
@@ -1,13 +1,13 @@
 <template>
-  <div class="plus text-k-text-secondary max-w-[480px] flex flex-col items-center" data-testid="koel-plus" tabindex="0">
+  <div id="koel-plus-modal" class="plus text-k-text-secondary max-w-[480px] flex flex-col items-center" data-testid="koel-plus" tabindex="0">
     <img
       alt="Koel Plus"
-      class="-mt-[48px] rounded-full border-[6px] border-white"
+      class="absolute top-0 left-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full border-[6px] border-white z-50 shadow-lg"
       src="@/../img/koel-plus.svg"
       width="96"
     >
 
-    <main class="!px-8 !py-5 text-center flex flex-col gap-5">
+    <main class="!px-8 !pt-24 !pb-5 text-center flex flex-col gap-5 rounded-lg shadow-lg">
       <div>
         Koel Plus adds premium features on top of the default installation.<br>
         Pay <em>once</em> and enjoy all additional features forever — including those to be built into the app

--- a/resources/assets/js/components/layout/ModalWrapper.vue
+++ b/resources/assets/js/components/layout/ModalWrapper.vue
@@ -1,7 +1,7 @@
 <template>
   <dialog
     ref="dialog"
-    class="text-k-text-primary min-w-full md:min-w-[480px] border-0 p-0 rounded-md overflow-hidden bg-k-bg-primary backdrop:bg-black/70"
+    class="text-k-text-primary min-w-full md:min-w-[480px] border-0 p-0 rounded-md bg-k-bg-primary backdrop:bg-black/70"
     @close.prevent
   >
     <Component
@@ -62,7 +62,6 @@ eventBus.on('MODAL_SHOW_ABOUT_KOEL', () => (activeModalName.value = 'about-koel'
       folder,
       playables: playables ? arrayify(playables) : [],
     }
-
     activeModalName.value = 'create-playlist-form'
   })
   .on('MODAL_SHOW_CREATE_SMART_PLAYLIST_FORM', folder => {
@@ -87,7 +86,6 @@ eventBus.on('MODAL_SHOW_ABOUT_KOEL', () => (activeModalName.value = 'about-koel'
       initialTab,
       songs: arrayify(songs),
     }
-
     activeModalName.value = 'edit-song-form'
   })
   .on('MODAL_SHOW_EDIT_PLAYLIST_FOLDER_FORM', folder => {
@@ -106,26 +104,31 @@ eventBus.on('MODAL_SHOW_ABOUT_KOEL', () => (activeModalName.value = 'about-koel'
 
 <style lang="postcss" scoped>
 dialog {
-  :deep(form),
-  :deep(> div) {
-    @apply relative;
+  overflow: visible;
+}
 
-    > header,
-    > main,
-    > footer {
-      @apply px-6 py-5;
-    }
+:deep([id='koel-plus-modal']) {
+  overflow: visible;
+}
 
-    > footer {
-      @apply mt-0 bg-black/10 border-t border-white/5 space-x-2;
-    }
+:deep(> div) {
+  @apply relative;
 
-    > header {
-      @apply flex bg-k-bg-secondary;
+  > header,
+  > main,
+  > footer {
+    @apply px-6 py-5;
+  }
 
-      h1 {
-        @apply text-3xl leading-normal overflow-hidden text-ellipsis whitespace-nowrap;
-      }
+  > footer {
+    @apply mt-0 bg-black/10 border-t border-white/5 space-x-2;
+  }
+
+  > header {
+    @apply flex bg-k-bg-secondary;
+
+    h1 {
+      @apply text-3xl leading-normal overflow-hidden text-ellipsis whitespace-nowrap;
     }
   }
 }


### PR DESCRIPTION
The modal looked like it was cut off so I made some tweaks to resolve it!

**Before:**

<img width="525" height="349" alt="CleanShot 2025-08-18 at 03 10 59" src="https://github.com/user-attachments/assets/2c7358d2-9c14-4929-b2c5-9124def15cd2" />

**After:**

<img width="661" height="502" alt="CleanShot 2025-08-18 at 03 09 31" src="https://github.com/user-attachments/assets/4d99ce96-bc47-43a4-ae0b-47334443ce23" />

There might be some slight linting issues, I couldn't get eslint to run reliably for some reason. 