### PR TITLE
fix: empty URL would sometimes be displayed

### DIFF
--- a/resources/assets/js/components/album/AlbumInfo.vue
+++ b/resources/assets/js/components/album/AlbumInfo.vue
@@ -19,6 +19,7 @@
         data-testid="album-info-tracks"
       />
     </template>
+
     <template v-if="!loading && info?.url" #footer>
       <a :href="info.url" rel="noopener" target="_blank">Source</a>
     </template>

--- a/resources/assets/js/components/album/AlbumInfo.vue
+++ b/resources/assets/js/components/album/AlbumInfo.vue
@@ -19,8 +19,7 @@
         data-testid="album-info-tracks"
       />
     </template>
-
-    <template v-if="!loading && info" #footer>
+    <template v-if="!loading && info?.url" #footer>
       <a :href="info.url" rel="noopener" target="_blank">Source</a>
     </template>
   </AlbumArtistInfo>


### PR DESCRIPTION
There were circumstances where an album/track wouldn't have a link available but the 'Source' text would still be present.

