### PR TITLE
fix: reapply the selection state for playable lists

### DIFF
--- a/resources/assets/js/components/playable/playable-list/PlayableList.vue
+++ b/resources/assets/js/components/playable/playable-list/PlayableList.vue
@@ -106,6 +106,7 @@ const {
   inSelectedRange,
   lastSelected,
   selected,
+  reapplySelection,
 } = useListSelection(rows, 'playable.id')
 
 const shouldTriggerContinuousPlayback = computed(() => {
@@ -131,6 +132,7 @@ const sort = (field: MaybeArray<PlayableListSortField>, order: SortOrder) => {
 
 const render = () => {
   config.sortable || (sortFields.value = [])
+  reapplySelection()
 }
 
 watch(playables, () => render(), { deep: true })

--- a/resources/assets/js/composables/useListSelection.ts
+++ b/resources/assets/js/composables/useListSelection.ts
@@ -12,14 +12,14 @@ export const useListSelection = <T> (
 
   // Keep track of selected items by their ID, so that when the list is updated (e.g., items are removed or added,
   // the list is sorted, or infinite loading triggered), we can reapply the selection.
-  const selectedIds = new Map()
+  const selectedIds = new Set()
 
   const resolveIdPath = (selectable: Selectable<T>) => typeof idPath === 'function' ? idPath(selectable) : idPath
 
   const select = (selectable: Selectable<T>) => {
     selectable.selected = true
     lastSelected.value = selectable
-    selectedIds.set(get(selectable, resolveIdPath(selectable)), true)
+    selectedIds.add(get(selectable, resolveIdPath(selectable)))
   }
 
   const deselect = (selectable: Selectable<T>) => {
@@ -30,7 +30,7 @@ export const useListSelection = <T> (
 
   const selectAll = () => selectables.value.forEach(select)
   const deselectAll = () => selectables.value.forEach(deselect)
-  const isSelected = (item: Selectable<T>) => item.selected
+  const isSelected = (item: Selectable<T>) => selectedIds.has(get(item, resolveIdPath(item)))
   const selected = computed(() => selectables.value.filter(isSelected))
 
   const toggleSelected = (selectable: Selectable<T>) => {


### PR DESCRIPTION
Reapply the selection state for playable lists after changes made to the list (sorting, filtering, adding/removing items etc.)