### PR TITLE
feat: unify all generated/uploaded images

### DIFF
--- a/app/Helpers.php
+++ b/app/Helpers.php
@@ -23,54 +23,14 @@ function base_url(): string
     return app()->runningUnitTests() ? config('app.url') : asset('');
 }
 
-function album_cover_path(?string $fileName): ?string
+function image_storage_path(?string $fileName): ?string
 {
-    return $fileName ? public_path(config('koel.album_cover_dir') . $fileName) : null;
+    return $fileName ? public_path(config('koel.image_storage_dir') . $fileName) : null;
 }
 
-function album_cover_url(?string $fileName): ?string
+function image_storage_url(?string $fileName): ?string
 {
-    return $fileName ? static_url(config('koel.album_cover_dir') . $fileName) : null;
-}
-
-function artist_image_path(?string $fileName): ?string
-{
-    return $fileName ? public_path(config('koel.artist_image_dir') . $fileName) : null;
-}
-
-function artist_image_url(?string $fileName): ?string
-{
-    return $fileName ? static_url(config('koel.artist_image_dir') . $fileName) : null;
-}
-
-function playlist_cover_path(?string $fileName): ?string
-{
-    return $fileName ? public_path(config('koel.playlist_cover_dir') . $fileName) : null;
-}
-
-function playlist_cover_url(?string $fileName): ?string
-{
-    return $fileName ? static_url(config('koel.playlist_cover_dir') . $fileName) : null;
-}
-
-function radio_station_logo_path(?string $fileName): ?string
-{
-    return $fileName ? public_path(config('koel.radio_station_logo_dir') . $fileName) : null;
-}
-
-function radio_station_logo_url(?string $fileName): ?string
-{
-    return $fileName ? static_url(config('koel.radio_station_logo_dir') . $fileName) : null;
-}
-
-function user_avatar_path(?string $fileName): ?string
-{
-    return $fileName ? public_path(config('koel.user_avatar_dir') . $fileName) : null;
-}
-
-function user_avatar_url(?string $fileName): ?string
-{
-    return $fileName ? static_url(config('koel.user_avatar_dir') . $fileName) : null;
+    return $fileName ? static_url(config('koel.image_storage_dir') . $fileName) : null;
 }
 
 function artifact_path(?string $subPath = null, $ensureDirectoryExists = true): string
@@ -121,7 +81,7 @@ function avatar_or_gravatar(?string $avatar, string $email): string
         return $avatar;
     }
 
-    return user_avatar_url($avatar);
+    return image_storage_url($avatar);
 }
 
 /**

--- a/app/Models/Album.php
+++ b/app/Models/Album.php
@@ -114,7 +114,7 @@ class Album extends Model implements AuditableContract, Favoriteable, Permission
 
     protected function cover(): Attribute
     {
-        return Attribute::get(static fn (?string $value): ?string => album_cover_url($value));
+        return Attribute::get(static fn (?string $value): ?string => image_storage_url($value));
     }
 
     protected function hasCover(): Attribute
@@ -129,7 +129,7 @@ class Album extends Model implements AuditableContract, Favoriteable, Permission
         return Attribute::get(function () {
             $cover = Arr::get($this->attributes, 'cover');
 
-            return $cover ? album_cover_path($cover) : null;
+            return $cover ? image_storage_path($cover) : null;
         });
     }
 
@@ -157,12 +157,12 @@ class Album extends Model implements AuditableContract, Favoriteable, Permission
 
     protected function thumbnailPath(): Attribute
     {
-        return Attribute::get(fn () => $this->thumbnail_name ? album_cover_path($this->thumbnail_name) : null);
+        return Attribute::get(fn () => $this->thumbnail_name ? image_storage_path($this->thumbnail_name) : null);
     }
 
     protected function thumbnail(): Attribute
     {
-        return Attribute::get(fn () => $this->thumbnail_name ? album_cover_url($this->thumbnail_name) : null);
+        return Attribute::get(fn () => $this->thumbnail_name ? image_storage_url($this->thumbnail_name) : null);
     }
 
     /** @deprecated Only here for backward compat with mobile apps */

--- a/app/Models/Artist.php
+++ b/app/Models/Artist.php
@@ -138,12 +138,12 @@ class Artist extends Model implements AuditableContract, Favoriteable, Permissio
      */
     protected function image(): Attribute
     {
-        return Attribute::get(static fn (?string $value): ?string => artist_image_url($value));
+        return Attribute::get(static fn (?string $value): ?string => image_storage_url($value));
     }
 
     protected function imagePath(): Attribute
     {
-        return Attribute::get(fn (): ?string => artist_image_path(Arr::get($this->attributes, 'image')));
+        return Attribute::get(fn (): ?string => image_storage_path(Arr::get($this->attributes, 'image')));
     }
 
     protected function hasImage(): Attribute
@@ -151,7 +151,7 @@ class Artist extends Model implements AuditableContract, Favoriteable, Permissio
         return Attribute::get(function (): bool {
             $image = Arr::get($this->attributes, 'image');
 
-            return $image && (app()->runningUnitTests() || File::exists(artist_image_path($image)));
+            return $image && (app()->runningUnitTests() || File::exists(image_storage_path($image)));
         });
     }
 

--- a/app/Models/Playlist.php
+++ b/app/Models/Playlist.php
@@ -103,7 +103,7 @@ class Playlist extends Model implements AuditableContract
 
     protected function cover(): Attribute
     {
-        return Attribute::get(static fn (?string $value): ?string => playlist_cover_url($value))->shouldCache();
+        return Attribute::get(static fn (?string $value): ?string => image_storage_url($value))->shouldCache();
     }
 
     protected function coverPath(): Attribute
@@ -111,7 +111,7 @@ class Playlist extends Model implements AuditableContract
         return Attribute::get(function () {
             $cover = Arr::get($this->attributes, 'cover');
 
-            return $cover ? playlist_cover_path($cover) : null;
+            return $cover ? image_storage_path($cover) : null;
         })->shouldCache();
     }
 

--- a/app/Models/RadioStation.php
+++ b/app/Models/RadioStation.php
@@ -68,7 +68,7 @@ class RadioStation extends Model implements AuditableContract, Favoriteable, Per
 
     protected function logo(): Attribute
     {
-        return Attribute::get(static fn (?string $value): ?string => radio_station_logo_url($value))->shouldCache();
+        return Attribute::get(static fn (?string $value): ?string => image_storage_url($value))->shouldCache();
     }
 
     protected function logoPath(): Attribute
@@ -76,7 +76,7 @@ class RadioStation extends Model implements AuditableContract, Favoriteable, Per
         return Attribute::get(function () {
             $logo = Arr::get($this->attributes, 'logo');
 
-            return $logo ? radio_station_logo_path($logo) : null;
+            return $logo ? image_storage_path($logo) : null;
         })->shouldCache();
     }
 

--- a/app/Observers/AlbumObserver.php
+++ b/app/Observers/AlbumObserver.php
@@ -19,11 +19,11 @@ class AlbumObserver
         rescue_if(
             $oldCover,
             static function () use ($oldCover): void {
-                $oldCoverPath = album_cover_path($oldCover);
+                $oldCoverPath = image_storage_path($oldCover);
                 $parts = pathinfo($oldCoverPath);
 
                 $oldThumbnail = sprintf('%s_thumb.%s', $parts['filename'], $parts['extension']);
-                File::delete([$oldCoverPath, album_cover_path($oldThumbnail)]);
+                File::delete([$oldCoverPath, image_storage_path($oldThumbnail)]);
             },
         );
     }

--- a/app/Observers/ArtistObserver.php
+++ b/app/Observers/ArtistObserver.php
@@ -15,7 +15,7 @@ class ArtistObserver
 
         $oldImage = $artist->getRawOriginal('image');
 
-        rescue_if($oldImage, static fn () => File::delete(artist_image_path($oldImage)));
+        rescue_if($oldImage, static fn () => File::delete(image_storage_path($oldImage)));
     }
 
     public function updated(Artist $artist): void

--- a/app/Observers/PlaylistObserver.php
+++ b/app/Observers/PlaylistObserver.php
@@ -16,7 +16,7 @@ class PlaylistObserver
         $oldCover = $playlist->getRawOriginal('cover');
 
         // If the cover is being updated, delete the old cover
-        rescue_if($oldCover, static fn () => File::delete(playlist_cover_path($oldCover)));
+        rescue_if($oldCover, static fn () => File::delete(image_storage_path($oldCover)));
     }
 
     public function deleted(Playlist $playlist): void

--- a/app/Observers/RadioStationObserver.php
+++ b/app/Observers/RadioStationObserver.php
@@ -20,7 +20,7 @@ class RadioStationObserver
         rescue_if(
             $radioStation->getRawOriginal('logo'),
             static function (string $oldLogo): void {
-                File::delete(radio_station_logo_path($oldLogo));
+                File::delete(image_storage_path($oldLogo));
             }
         );
     }

--- a/app/Services/ArtworkService.php
+++ b/app/Services/ArtworkService.php
@@ -14,7 +14,7 @@ class ArtworkService
 {
     public function __construct(
         private readonly ImageWriter $imageWriter,
-        private readonly Finder $finder
+        private readonly Finder $finder,
     ) {
     }
 
@@ -27,7 +27,7 @@ class ArtworkService
     public function storeAlbumCover(Album $album, string $source, ?string $destination = ''): ?string
     {
         return rescue(function () use ($album, $source, $destination): string {
-            $destination = $destination ?: $this->generateAlbumCoverPath();
+            $destination = $destination ?: self::generateImageStoragePath();
             $this->imageWriter->write($destination, $source);
 
             $album->update(['cover' => basename($destination)]);
@@ -46,7 +46,7 @@ class ArtworkService
     public function storeArtistImage(Artist $artist, string $source, ?string $destination = ''): ?string
     {
         return rescue(function () use ($artist, $source, $destination): string {
-            $destination = $destination ?: $this->generateArtistImagePath();
+            $destination = $destination ?: self::generateImageStoragePath();
             $this->imageWriter->write($destination, $source);
 
             $artist->update(['image' => basename($destination)]);
@@ -58,7 +58,7 @@ class ArtworkService
     public function storePlaylistCover(Playlist $playlist, string $source): ?string
     {
         return rescue(function () use ($playlist, $source): string {
-            $destination = $this->generatePlaylistCoverPath();
+            $destination = self::generateImageStoragePath();
             $this->imageWriter->write($destination, $source);
 
             if ($playlist->cover_path) {
@@ -69,26 +69,6 @@ class ArtworkService
 
             return $playlist->cover;
         });
-    }
-
-    private function generateAlbumCoverPath(): string
-    {
-        return album_cover_path(sprintf('%s.webp', Ulid::generate()));
-    }
-
-    private function generateArtistImagePath(): string
-    {
-        return artist_image_path(sprintf('%s.webp', Ulid::generate()));
-    }
-
-    private function generatePlaylistCoverPath(): string
-    {
-        return playlist_cover_path(sprintf('%s.webp', Ulid::generate()));
-    }
-
-    private function generateRadioStationLogoPath(): string
-    {
-        return radio_station_logo_path(sprintf('%s.webp', Ulid::generate()));
     }
 
     /**
@@ -141,9 +121,14 @@ class ArtworkService
 
     public function storeRadioStationLogo(string $logo): ?string
     {
-        $destination = $this->generateRadioStationLogoPath();
+        $destination = self::generateImageStoragePath();
         $this->imageWriter->write($destination, $logo);
 
         return basename($destination);
+    }
+
+    private static function generateImageStoragePath(): string
+    {
+        return image_storage_path(sprintf('%s.webp', Ulid::generate()));
     }
 }

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -135,6 +135,6 @@ class UserService
 
     private static function generateUserAvatarPath(): string
     {
-        return user_avatar_path(sprintf('%s.webp', Ulid::generate()));
+        return image_storage_path(sprintf('%s.webp', Ulid::generate()));
     }
 }

--- a/config/koel.php
+++ b/config/koel.php
@@ -9,20 +9,10 @@ return [
     // or downloaded podcast episodes. By default, it is set to the system's temporary directory.
     'artifacts_path' => env('ARTIFACTS_PATH') ?: sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'koel',
 
-    // The *relative* path to the directory to store album covers and thumbnails, *with* a trailing slash.
-    'album_cover_dir' => 'img/covers/',
+    // The *relative* path to the directory to store artist images, playlist covers, user avatars, etc.
+    // This is relative to the public path.
+    'image_storage_dir' => 'img/storage/',
 
-    // The *relative* path to the directory to store artist images, *with* a trailing slash.
-    'artist_image_dir' => 'img/artists/',
-
-    // The *relative* path to the directory to store playlist covers, *with* a trailing slash.
-    'playlist_cover_dir' => 'img/playlists/',
-
-    // The *relative* path to the directory to store user avatars, *with* a trailing slash.
-    'user_avatar_dir' => 'img/avatars/',
-
-    // The *relative* path to the directory to store radio station logos, *with* a trailing slash.
-    'radio_station_logo_dir' => 'img/radio-stations/',
 
     /*
     |--------------------------------------------------------------------------

--- a/public/.gitignore
+++ b/public/.gitignore
@@ -6,25 +6,9 @@ img/*
 !img/icon.png
 !img/favicon.ico
 
-!img/covers
-img/covers/*
-!img/covers/.gitkeep
-
-!img/artists
-img/artists/*
-!img/artists/.gitkeep
-
-!img/playlists
-img/playlists/*
-!img/playlists/.gitkeep
-
-!img/avatars
-img/avatars/*
-!img/avatars/.gitkeep
-
-!img/radio-stations
-img/radio-stations/*
-!img/radio-stations/.gitkeep
+!img/storage
+img/storage/*
+!img/storage/.gitkeep
 
 vendor/*
 

--- a/tests/Feature/AlbumCoverTest.php
+++ b/tests/Feature/AlbumCoverTest.php
@@ -56,7 +56,7 @@ class AlbumCoverTest extends TestCase
     public function destroy(): void
     {
         $file = Ulid::generate() . '.jpg';
-        File::put(album_cover_path($file), 'foo');
+        File::put(image_storage_path($file), 'foo');
 
         /** @var Album $album */
         $album = Album::factory()->create([
@@ -67,7 +67,7 @@ class AlbumCoverTest extends TestCase
             ->assertNoContent();
 
         self::assertNull($album->refresh()->cover);
-        self::assertFileDoesNotExist(album_cover_path($file));
+        self::assertFileDoesNotExist(image_storage_path($file));
     }
 
     #[Test]

--- a/tests/Feature/AlbumTest.php
+++ b/tests/Feature/AlbumTest.php
@@ -84,7 +84,7 @@ class AlbumTest extends TestCase
 
         self::assertEquals('Updated Album Name', $album->name);
         self::assertEquals(2023, $album->year);
-        self::assertEquals(album_cover_url("$ulid.webp"), $album->cover);
+        self::assertEquals(image_storage_url("$ulid.webp"), $album->cover);
     }
 
     #[Test]

--- a/tests/Feature/ArtistImageTest.php
+++ b/tests/Feature/ArtistImageTest.php
@@ -58,7 +58,7 @@ class ArtistImageTest extends TestCase
     public function destroy(): void
     {
         $file = Ulid::generate() . '.jpg';
-        File::put(artist_image_path($file), 'foo');
+        File::put(image_storage_path($file), 'foo');
 
         /** @var Artist $artist */
         $artist = Artist::factory()->create([
@@ -69,7 +69,7 @@ class ArtistImageTest extends TestCase
             ->assertNoContent();
 
         self::assertNull($artist->refresh()->image);
-        self::assertFileDoesNotExist(artist_image_path($file));
+        self::assertFileDoesNotExist(image_storage_path($file));
     }
 
     #[Test]

--- a/tests/Feature/ArtistTest.php
+++ b/tests/Feature/ArtistTest.php
@@ -77,7 +77,7 @@ class ArtistTest extends TestCase
         $artist->refresh();
 
         self::assertEquals('Updated Artist Name', $artist->name);
-        self::assertEquals(artist_image_url("$ulid.webp"), $artist->image);
+        self::assertEquals(image_storage_url("$ulid.webp"), $artist->image);
     }
 
     #[Test]

--- a/tests/Feature/ProfileTest.php
+++ b/tests/Feature/ProfileTest.php
@@ -78,7 +78,7 @@ class ProfileTest extends TestCase
 
         $user->refresh();
 
-        self::assertFileExists(user_avatar_path($user->getRawOriginal('avatar')));
+        self::assertFileExists(image_storage_path($user->getRawOriginal('avatar')));
     }
 
     #[Test]

--- a/tests/Integration/Services/AlbumServiceTest.php
+++ b/tests/Integration/Services/AlbumServiceTest.php
@@ -70,7 +70,7 @@ class AlbumServiceTest extends TestCase
 
         self::assertEquals('New Album Name', $updatedAlbum->name);
         self::assertEquals(2023, $updatedAlbum->year);
-        self::assertEquals(album_cover_url("$ulid.webp"), $updatedAlbum->cover);
+        self::assertEquals(image_storage_url("$ulid.webp"), $updatedAlbum->cover);
 
         $songs->each(static function (Song $song) use ($updatedAlbum): void {
             self::assertEquals($updatedAlbum->name, $song->fresh()->album_name);
@@ -96,8 +96,8 @@ class AlbumServiceTest extends TestCase
     public function removeCover(): void
     {
         $ulid = Ulid::generate();
-        File::put(album_cover_path("$ulid.webp"), 'content');
-        File::put(album_cover_path("{$ulid}_thumb.webp"), 'thumb-content');
+        File::put(image_storage_path("$ulid.webp"), 'content');
+        File::put(image_storage_path("{$ulid}_thumb.webp"), 'thumb-content');
 
         /** @var Album $album */
         $album = Album::factory()->create(['cover' => "$ulid.webp"]);
@@ -105,7 +105,7 @@ class AlbumServiceTest extends TestCase
         $this->service->removeAlbumCover($album);
 
         self::assertNull($album->refresh()->cover);
-        self::assertFileDoesNotExist(album_cover_path("$ulid.webp"));
-        self::assertFileDoesNotExist(album_cover_path("{$ulid}_thumb.webp"));
+        self::assertFileDoesNotExist(image_storage_path("$ulid.webp"));
+        self::assertFileDoesNotExist(image_storage_path("{$ulid}_thumb.webp"));
     }
 }

--- a/tests/Integration/Services/ArtistServiceTest.php
+++ b/tests/Integration/Services/ArtistServiceTest.php
@@ -67,7 +67,7 @@ class ArtistServiceTest extends TestCase
         $updatedArtist = $this->service->updateArtist($artist, $data);
 
         self::assertEquals('New Artist Name', $updatedArtist->name);
-        self::assertEquals(artist_image_url("$ulid.webp"), $updatedArtist->image);
+        self::assertEquals(image_storage_url("$ulid.webp"), $updatedArtist->image);
 
         $songs->each(static function (Song $song) use ($updatedArtist): void {
             self::assertEquals($updatedArtist->name, $song->fresh()->artist_name);

--- a/tests/Integration/Services/EncyclopediaServiceTest.php
+++ b/tests/Integration/Services/EncyclopediaServiceTest.php
@@ -22,17 +22,17 @@ class EncyclopediaServiceTest extends TestCase
     #[Test]
     public function getAlbumThumbnailUrl(): void
     {
-        File::copy(test_path('fixtures/cover.png'), album_cover_path('album-cover-for-thumbnail-test.jpg'));
+        File::copy(test_path('fixtures/cover.png'), image_storage_path('album-cover-for-thumbnail-test.jpg'));
 
         /** @var Album $album */
         $album = Album::factory()->create(['cover' => 'album-cover-for-thumbnail-test.jpg']);
 
         self::assertSame(
-            album_cover_url('album-cover-for-thumbnail-test_thumb.jpg'),
+            image_storage_url('album-cover-for-thumbnail-test_thumb.jpg'),
             app(ArtworkService::class)->getAlbumThumbnailUrl($album)
         );
 
-        self::assertFileExists(album_cover_path('album-cover-for-thumbnail-test_thumb.jpg'));
+        self::assertFileExists(image_storage_path('album-cover-for-thumbnail-test_thumb.jpg'));
     }
 
     #[Test]
@@ -45,11 +45,11 @@ class EncyclopediaServiceTest extends TestCase
 
     private function cleanUp(): void
     {
-        File::delete(album_cover_path('album-cover-for-thumbnail-test.jpg'));
-        File::delete(album_cover_path('album-cover-for-thumbnail-test_thumb.jpg'));
+        File::delete(image_storage_path('album-cover-for-thumbnail-test.jpg'));
+        File::delete(image_storage_path('album-cover-for-thumbnail-test_thumb.jpg'));
 
-        self::assertFileDoesNotExist(album_cover_path('album-cover-for-thumbnail-test.jpg'));
-        self::assertFileDoesNotExist(album_cover_path('album-cover-for-thumbnail-test_thumb.jpg'));
+        self::assertFileDoesNotExist(image_storage_path('album-cover-for-thumbnail-test.jpg'));
+        self::assertFileDoesNotExist(image_storage_path('album-cover-for-thumbnail-test_thumb.jpg'));
     }
 
     protected function tearDown(): void

--- a/tests/Integration/Services/UserServiceTest.php
+++ b/tests/Integration/Services/UserServiceTest.php
@@ -39,7 +39,7 @@ class UserServiceTest extends TestCase
         $this->assertModelExists($user);
         self::assertTrue(Hash::check('FearOfTheDark', $user->password));
         self::assertTrue($user->is_admin);
-        self::assertFileExists(user_avatar_path($user->getRawOriginal('avatar')));
+        self::assertFileExists(image_storage_path($user->getRawOriginal('avatar')));
     }
 
     #[Test]
@@ -92,7 +92,7 @@ class UserServiceTest extends TestCase
         self::assertSame('steve@iron.com', $user->email);
         self::assertTrue(Hash::check('TheTrooper', $user->password));
         self::assertTrue($user->is_admin);
-        self::assertFileExists(user_avatar_path($user->getRawOriginal('avatar')));
+        self::assertFileExists(image_storage_path($user->getRawOriginal('avatar')));
     }
 
     #[Test]

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -54,17 +54,11 @@ abstract class TestCase extends BaseTestCase
     private static function createSandbox(): void
     {
         config([
-            'koel.album_cover_dir' => 'sandbox/img/covers/',
-            'koel.artist_image_dir' => 'sandbox/img/artists/',
-            'koel.playlist_cover_dir' => 'sandbox/img/playlists/',
-            'koel.user_avatar_dir' => 'sandbox/img/avatars/',
+            'koel.image_storage_dir' => 'sandbox/img/storage/',
             'koel.artifacts_path' => public_path('sandbox/artifacts/'),
         ]);
 
-        File::ensureDirectoryExists(public_path(config('koel.album_cover_dir')));
-        File::ensureDirectoryExists(public_path(config('koel.artist_image_dir')));
-        File::ensureDirectoryExists(public_path(config('koel.playlist_cover_dir')));
-        File::ensureDirectoryExists(public_path(config('koel.user_avatar_dir')));
+        File::ensureDirectoryExists(public_path(config('koel.image_storage_dir')));
         File::ensureDirectoryExists(public_path('sandbox/media/'));
     }
 

--- a/tests/Unit/Services/ArtworkServiceTest.php
+++ b/tests/Unit/Services/ArtworkServiceTest.php
@@ -44,7 +44,7 @@ class ArtworkServiceTest extends TestCase
 
         $cover = $this->service->storeAlbumCover($album, 'dummy-src', $coverPath);
 
-        self::assertSame(album_cover_url('foo.jpg'), $album->refresh()->cover);
+        self::assertSame(image_storage_url('foo.jpg'), $album->refresh()->cover);
         self::assertSame($cover, $album->cover);
     }
 
@@ -61,7 +61,7 @@ class ArtworkServiceTest extends TestCase
 
         $this->service->storeArtistImage($artist, 'dummy-src', $imagePath);
 
-        self::assertSame(artist_image_url('foo.jpg'), $artist->refresh()->image);
+        self::assertSame(image_storage_url('foo.jpg'), $artist->refresh()->image);
     }
 
     #[Test]
@@ -72,7 +72,7 @@ class ArtworkServiceTest extends TestCase
 
         $this->imageWriter
             ->expects('write')
-            ->with(radio_station_logo_path($logo), 'dummy-logo-src');
+            ->with(image_storage_path($logo), 'dummy-logo-src');
 
         self::assertSame($logo, $this->service->storeRadioStationLogo('dummy-logo-src'));
     }


### PR DESCRIPTION
Moving all generated/uploaded images (album arts, artist images, etc.) to under one `public/img/storage` folder.