### PR TITLE
fix: allow empty playlist description

### DIFF
--- a/app/Http/Requests/API/Playlist/PlaylistStoreRequest.php
+++ b/app/Http/Requests/API/Playlist/PlaylistStoreRequest.php
@@ -28,7 +28,7 @@ class PlaylistStoreRequest extends Request
         return [
             'name' => 'required',
             'songs' => ['array', new AllPlayablesAreAccessibleBy($this->user())],
-            'description' => 'string|sometimes', // backward compatibility for mobile apps
+            'description' => 'string|sometimes|nullable', // backward compatibility for mobile apps
             'rules' => ['array', 'nullable', new ValidSmartPlaylistRulePayload()],
             'folder_id' => ['nullable', 'sometimes', Rule::exists(PlaylistFolder::class, 'id')],
             'cover' => ['sometimes', 'nullable', new ValidImageData()],

--- a/app/Http/Requests/API/Playlist/PlaylistUpdateRequest.php
+++ b/app/Http/Requests/API/Playlist/PlaylistUpdateRequest.php
@@ -25,7 +25,7 @@ class PlaylistUpdateRequest extends Request
     {
         return [
             'name' => 'required',
-            'description' => 'string|sometimes',
+            'description' => 'string|sometimes|nullable',
             'rules' => ['array', 'nullable', new ValidSmartPlaylistRulePayload()],
             'folder_id' => ['nullable', 'sometimes', Rule::exists(PlaylistFolder::class, 'id')],
             'cover' => ['string', 'sometimes', 'nullable', new ValidImageData()],

--- a/tests/Feature/PlaylistTest.php
+++ b/tests/Feature/PlaylistTest.php
@@ -76,6 +76,25 @@ class PlaylistTest extends TestCase
     }
 
     #[Test]
+    public function createPlaylistWithoutDescription(): void
+    {
+        $user = create_user();
+
+        $this->postAs('api/playlists', [
+            'name' => 'Foo Bar',
+            'description' => '',
+            'songs' => [],
+            'rules' => [],
+        ], $user)
+            ->assertJsonStructure(PlaylistResource::JSON_STRUCTURE);
+
+        $playlist = Playlist::query()->latest()->first();
+
+        self::assertSame('Foo Bar', $playlist->name);
+        self::assertSame('', $playlist->description);
+    }
+
+    #[Test]
     public function creatingSmartPlaylist(): void
     {
         $user = create_user();
@@ -157,6 +176,21 @@ class PlaylistTest extends TestCase
 
         self::assertSame('Bar', $playlist->refresh()->name);
         self::assertSame('Bar Description', $playlist->description);
+    }
+
+    #[Test]
+    public function updateWithoutDescription(): void
+    {
+        $playlist = create_playlist(['name' => 'Foo', 'description' => 'Bar Description']);
+
+        $this->putAs("api/playlists/{$playlist->id}", [
+            'name' => 'Bar',
+            'description' => '',
+        ], $playlist->owner)
+            ->assertJsonStructure(PlaylistResource::JSON_STRUCTURE);
+
+        self::assertSame('Bar', $playlist->refresh()->name);
+        self::assertSame('', $playlist->description);
     }
 
     #[Test]


### PR DESCRIPTION
When creating or updating a playlist, without a description, i always got the error message "The description must be a string."