### PR TITLE
feat: add composer script for koel:init

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ APP_URL=http://localhost:8000
 # Example: localhost,192.168.0.1,yourdomain.com
 TRUSTED_HOSTS=
 
-# A random 32-char string. You can leave this empty if use php artisan koel:init.
+# A random 32-char string. You can leave this empty if use composer koel:init.
 APP_KEY=
 
 # Database connection name, which corresponds to the database driver.
@@ -18,7 +18,7 @@ APP_KEY=
 #   pgsql (PostgreSQL)
 #   sqlsrv (Microsoft SQL Server)
 #   sqlite-persistent (Local sqlite file)
-# IMPORTANT: This value must present for `artisan koel:init` command to work.
+# IMPORTANT: This value must present for the `composer koel:init` script to work.
 DB_CONNECTION=mysql
 
 DB_HOST=127.0.0.1

--- a/composer.json
+++ b/composer.json
@@ -119,6 +119,7 @@
     "post-create-project-cmd": [
       "@php artisan key:generate"
     ],
+    "koel:init": "@php scripts/koel-init.php",
     "test": "@php artisan test",
     "coverage": "@php artisan test --coverage-clover=coverage.xml",
     "cs": "phpcs --standard=ruleset.xml",

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -115,11 +115,18 @@ Usage
 php artisan koel:init [options]
 ```
 
+
 #### Options
 | Name             | Description                     |
 |------------------|---------------------------------|
 | `--no-assets`    | Do not compile front-end assets |
 | `--no-scheduler` | Do not install scheduler        |
+
+:::tip
+Instead of running `php artisan koel:init` directly, you should run `composer koel:init`, which calls this command
+under the hood after installing dependencies. To pass options to `php artisan koel:init`, use argument forwarding, e.g.,
+`composer koel:init -- --no-assets`.
+:::
 
 ### `koel:license:activate`
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -33,7 +33,7 @@ First, go to the [Releases page](https://github.com/koel/koel/releases) on GitHu
 following commands:
 
 ```bash
-php artisan koel:init --no-assets
+composer koel:init -- --no-assets
 
 # Follow the wizard to populate necessary configurations
 
@@ -48,8 +48,7 @@ From your console, run the following commands:
 cd <KOEL_ROOT_DIR>
 git clone https://github.com/koel/koel.git .
 git checkout latest # Check out the latest version at https://github.com/koel/koel/releases
-composer install
-php artisan koel:init
+composer koel:init
 
 # Follow the wizard to populate necessary configurations
 
@@ -107,8 +106,7 @@ If you installed Koel from source, upgrading is as simple as running the followi
 cd <KOEL_ROOT_DIR>
 git pull
 git checkout latest
-composer install
-php artisan koel:init
+composer koel:init
 ```
 
 ### Upgrade a pre-compiled archive installation
@@ -122,8 +120,7 @@ cd <KOEL_ROOT_DIR>
 rm -rf app config
 # assuming we're upgrading to v7.0.0
 wget -qO- https://github.com/koel/koel/releases/download/v7.0.0/koel-v7.0.0.tar.gz | tar -xvzC . --strip-components=1
-php artisan cache:clear
-php artisan koel:init --no-assets
+composer koel:init -- --no-assets
 ```
 
 ### Upgrade a Docker installation

--- a/scripts/koel-init.php
+++ b/scripts/koel-init.php
@@ -1,0 +1,7 @@
+#!/usr/bin/env php
+<?php
+
+$args = array_slice($argv, 1);
+
+passthru('composer install --ansi');
+passthru('php artisan koel:init --ansi ' . implode(' ', $args));


### PR DESCRIPTION
Add a composer script to execute `php artisan koel:init` only after resolving all PHP dependencies.