### PR TITLE
fix: wikipedia connector and imagewriter got broken

### DIFF
--- a/app/Http/Integrations/Wikidata/WikidataConnector.php
+++ b/app/Http/Integrations/Wikidata/WikidataConnector.php
@@ -16,6 +16,8 @@ class WikidataConnector extends Connector
     {
         return [
             'Accept' => 'application/json',
+            'User-Agent' => config('koel.services.musicbrainz.user_agent')
+                ?: config('app.name') . '/' . koel_version() . ' ( ' . config('app.url') . ' )',
         ];
     }
 }

--- a/app/Http/Integrations/Wikipedia/WikipediaConnector.php
+++ b/app/Http/Integrations/Wikipedia/WikipediaConnector.php
@@ -16,6 +16,8 @@ class WikipediaConnector extends Connector
     {
         return [
             'Accept' => 'application/json',
+            'User-Agent' => config('koel.services.musicbrainz.user_agent')
+                ?: config('app.name') . '/' . koel_version() . ' ( ' . config('app.url') . ' )',
         ];
     }
 }

--- a/app/Pipelines/Encyclopedia/GetAlbumTracksUsingMbid.php
+++ b/app/Pipelines/Encyclopedia/GetAlbumTracksUsingMbid.php
@@ -6,10 +6,11 @@ use App\Http\Integrations\MusicBrainz\MusicBrainzConnector;
 use App\Http\Integrations\MusicBrainz\Requests\GetRecordingsRequest;
 use Closure;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\Cache;
 
 class GetAlbumTracksUsingMbid
 {
+    use RemembersForever;
+
     public function __construct(private readonly MusicBrainzConnector $connector)
     {
     }
@@ -20,9 +21,9 @@ class GetAlbumTracksUsingMbid
             return $next(null);
         }
 
-        $tracks = Cache::rememberForever(
-            cache_key('album tracks', $mbid),
-            function () use ($mbid): array {
+        $tracks = $this->tryRememberForever(
+            key: cache_key('album tracks', $mbid),
+            callback: function () use ($mbid): array {
                 $tracks = [];
 
                 // There can be multiple media entries (e.g. CDs) in a release, each with its own set of tracks.

--- a/app/Pipelines/Encyclopedia/GetAlbumWikidataIdUsingReleaseGroupMbid.php
+++ b/app/Pipelines/Encyclopedia/GetAlbumWikidataIdUsingReleaseGroupMbid.php
@@ -6,11 +6,12 @@ use App\Http\Integrations\MusicBrainz\MusicBrainzConnector;
 use App\Http\Integrations\MusicBrainz\Requests\GetReleaseGroupUrlRelationshipsRequest;
 use Closure;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
 
 class GetAlbumWikidataIdUsingReleaseGroupMbid
 {
+    use RemembersForever;
+
     public function __construct(private readonly MusicBrainzConnector $connector)
     {
     }
@@ -21,9 +22,9 @@ class GetAlbumWikidataIdUsingReleaseGroupMbid
             return $next(null);
         }
 
-        $wikidataId = Cache::rememberForever(
-            cache_key('album wikidata id from release group mbid', $mbid),
-            function () use ($mbid): ?string {
+        $wikidataId = $this->tryRememberForever(
+            key: cache_key('album wikidata id from release group mbid', $mbid),
+            callback: function () use ($mbid): ?string {
                 $wikidata = collect(Arr::where(
                     $this->connector->send(new GetReleaseGroupUrlRelationshipsRequest($mbid))->json('relations'),
                     static fn ($relation) => $relation['type'] === 'wikidata',

--- a/app/Pipelines/Encyclopedia/GetArtistWikidataIdUsingMbid.php
+++ b/app/Pipelines/Encyclopedia/GetArtistWikidataIdUsingMbid.php
@@ -6,11 +6,12 @@ use App\Http\Integrations\MusicBrainz\MusicBrainzConnector;
 use App\Http\Integrations\MusicBrainz\Requests\GetArtistUrlRelationshipsRequest;
 use Closure;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
 
 class GetArtistWikidataIdUsingMbid
 {
+    use RemembersForever;
+
     public function __construct(private readonly MusicBrainzConnector $connector)
     {
     }
@@ -21,9 +22,9 @@ class GetArtistWikidataIdUsingMbid
             return $next(null);
         }
 
-        $wikidataId = Cache::rememberForever(
-            cache_key('artist wikidata id from mbid', $mbid),
-            function () use ($mbid): ?string {
+        $wikidataId = $this->tryRememberForever(
+            key: cache_key('artist wikidata id from mbid', $mbid),
+            callback: function () use ($mbid): ?string {
                 $wikidata = collect(Arr::where(
                     $this->connector->send(new GetArtistUrlRelationshipsRequest($mbid))->json('relations'),
                     static fn ($relation) => $relation['type'] === 'wikidata',

--- a/app/Pipelines/Encyclopedia/GetMbidForArtist.php
+++ b/app/Pipelines/Encyclopedia/GetMbidForArtist.php
@@ -5,10 +5,11 @@ namespace App\Pipelines\Encyclopedia;
 use App\Http\Integrations\MusicBrainz\MusicBrainzConnector;
 use App\Http\Integrations\MusicBrainz\Requests\SearchForArtistRequest;
 use Closure;
-use Illuminate\Support\Facades\Cache;
 
 class GetMbidForArtist
 {
+    use RemembersForever;
+
     public function __construct(private readonly MusicBrainzConnector $connector)
     {
     }
@@ -19,9 +20,9 @@ class GetMbidForArtist
             return $next(null);
         }
 
-        $mbid = Cache::rememberForever(
-            cache_key('artist mbid', $name),
-            fn () => $this->connector->send(new SearchForArtistRequest($name))->json('artists.0.id'),
+        $mbid = $this->tryRememberForever(
+            key: cache_key('artist mbid', $name),
+            callback: fn () => $this->connector->send(new SearchForArtistRequest($name))->json('artists.0.id'),
         );
 
         return $next($mbid);

--- a/app/Pipelines/Encyclopedia/RemembersForever.php
+++ b/app/Pipelines/Encyclopedia/RemembersForever.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Pipelines\Encyclopedia;
+
+use Closure;
+use Illuminate\Support\Facades\Cache;
+
+trait RemembersForever
+{
+    private function tryRememberForever(string $key, Closure $callback): mixed
+    {
+        $value = Cache::get($key);
+
+        if ($value) {
+            return $value;
+        }
+
+        return rescue(static fn () => Cache::rememberForever($key, $callback));
+    }
+}

--- a/app/Services/ImageWriter.php
+++ b/app/Services/ImageWriter.php
@@ -3,6 +3,8 @@
 namespace App\Services;
 
 use App\Values\ImageWritingConfig;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
 use Intervention\Image\FileExtension;
 use Intervention\Image\Interfaces\ImageManagerInterface;
 use Intervention\Image\Laravel\Facades\Image;
@@ -36,7 +38,8 @@ class ImageWriter
     {
         $config ??= ImageWritingConfig::default();
 
-        $img = Image::read($source)->scale(width: $config->maxWidth);
+        $img = Image::read(Str::isUrl($source) ? Http::get($source)->body() : $source)
+            ->scale(width: $config->maxWidth);
 
         if ($config->blur) {
             $img->blur($config->blur);


### PR DESCRIPTION
## Description
Fixes two things:
- Broken Wikipedia/Wikimedia connector due to a recent [policy enforcement](https://phabricator.wikimedia.org/T400119).
- Broken image writing with Intervention not automatically fetching the image source from a remote URL anymore.

## Motivation
Closes #2129 

## Screenshots (if applicable)

## Checklist
- [x] I've tested my changes thoroughly and added tests where applicable
- [x] I've updated relevant documentation (if any)
- [x] My code follows the project's conventions
