### PR TITLE
feat: implement Google Mobile SSO for the app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -230,6 +230,10 @@ SSO_GOOGLE_CLIENT_SECRET=
 # The domain that users must belong to in order to be able to log in.
 SSO_GOOGLE_HOSTED_DOMAIN=yourdomain.com
 
+# URLs for legal documents shown to new users during mobile Google SSO consent.
+LEGAL_TERMS_URL=
+LEGAL_PRIVACY_URL=
+
 
 # Koel can be configured to authenticate users via a reverse proxy.
 # To enable this feature, set PROXY_AUTH_ENABLED to true and provide the necessary configuration below.

--- a/app/Http/Controllers/API/GoogleMobileSsoController.php
+++ b/app/Http/Controllers/API/GoogleMobileSsoController.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\API\GoogleMobileConsentRequest;
+use App\Http\Requests\API\GoogleMobileLoginRequest;
+use App\Repositories\UserRepository;
+use App\Services\AuthenticationService;
+use App\Services\ConsentService;
+use App\Services\GoogleIdTokenVerifier;
+use App\Services\SettingService;
+use App\Services\UserService;
+use App\Values\User\SsoUser;
+use Illuminate\Foundation\Auth\ThrottlesLogins;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Response;
+use Throwable;
+
+class GoogleMobileSsoController extends Controller
+{
+    use ThrottlesLogins;
+
+    public function __construct(
+        private readonly GoogleIdTokenVerifier $verifier,
+        private readonly AuthenticationService $auth,
+        private readonly UserService $userService,
+        private readonly UserRepository $userRepository,
+        private readonly SettingService $settingService,
+        private readonly ConsentService $consentService,
+    ) {}
+
+    public function login(GoogleMobileLoginRequest $request): JsonResponse
+    {
+        if ($this->hasTooManyLoginAttempts($request)) {
+            $this->fireLockoutEvent($request);
+            $this->sendLockoutResponse($request);
+        }
+
+        try {
+            $ssoUser = $this->verifier->verify($request->id_token);
+        } catch (Throwable) {
+            $this->incrementLoginAttempts($request);
+            abort(Response::HTTP_UNAUTHORIZED, 'Invalid Google ID token');
+        }
+
+        $existingUser = $this->userRepository->findOneBySso($ssoUser);
+
+        if ($existingUser) {
+            $user = $this->userService->createOrUpdateUserFromSso($ssoUser);
+
+            return response()->json($this->auth->logUserIn($user)->toArray());
+        }
+
+        return response()->json([
+            'requires_consent' => true,
+            'sso_user' => $ssoUser->toArray(),
+            'legal_urls' => $this->settingService->getConsentLegalUrls(),
+        ]);
+    }
+
+    public function consent(GoogleMobileConsentRequest $request): JsonResponse
+    {
+        $ssoUser = SsoUser::fromArray($request->sso_user);
+        $user = $this->userService->createOrUpdateUserFromSso($ssoUser);
+
+        $this->consentService->recordConsent($user, $request);
+
+        return response()->json($this->auth->logUserIn($user)->toArray());
+    }
+
+    protected function username(): string
+    {
+        return 'id_token';
+    }
+}

--- a/app/Http/Controllers/API/GoogleMobileSsoController.php
+++ b/app/Http/Controllers/API/GoogleMobileSsoController.php
@@ -11,7 +11,6 @@ use App\Services\ConsentService;
 use App\Services\GoogleIdTokenVerifier;
 use App\Services\SettingService;
 use App\Services\UserService;
-use App\Values\User\SsoUser;
 use Illuminate\Foundation\Auth\ThrottlesLogins;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Response;
@@ -61,9 +60,13 @@ class GoogleMobileSsoController extends Controller
 
     public function consent(GoogleMobileConsentRequest $request): JsonResponse
     {
-        $ssoUser = SsoUser::fromArray($request->sso_user);
-        $user = $this->userService->createOrUpdateUserFromSso($ssoUser);
+        try {
+            $ssoUser = $this->verifier->verify($request->id_token);
+        } catch (Throwable) {
+            abort(Response::HTTP_UNAUTHORIZED, 'Invalid Google ID token');
+        }
 
+        $user = $this->userService->createOrUpdateUserFromSso($ssoUser);
         $this->consentService->recordConsent($user, $request);
 
         return response()->json($this->auth->logUserIn($user)->toArray());

--- a/app/Http/Requests/API/GoogleMobileConsentRequest.php
+++ b/app/Http/Requests/API/GoogleMobileConsentRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests\API;
+
+/**
+ * @property-read array $sso_user
+ * @property-read bool $terms_accepted
+ * @property-read bool $privacy_accepted
+ * @property-read bool $age_verified
+ */
+class GoogleMobileConsentRequest extends Request
+{
+    /** @inheritdoc */
+    public function rules(): array
+    {
+        return [
+            'sso_user' => 'required|array',
+            'sso_user.provider' => 'required|string',
+            'sso_user.id' => 'required|string',
+            'sso_user.email' => 'required|email',
+            'sso_user.name' => 'required|string',
+            'sso_user.avatar' => 'nullable|string',
+            'terms_accepted' => 'required|accepted',
+            'privacy_accepted' => 'required|accepted',
+            'age_verified' => 'required|accepted',
+        ];
+    }
+}

--- a/app/Http/Requests/API/GoogleMobileConsentRequest.php
+++ b/app/Http/Requests/API/GoogleMobileConsentRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\API;
 
 /**
- * @property-read array $sso_user
+ * @property-read string $id_token
  * @property-read bool $terms_accepted
  * @property-read bool $privacy_accepted
  * @property-read bool $age_verified
@@ -14,12 +14,7 @@ class GoogleMobileConsentRequest extends Request
     public function rules(): array
     {
         return [
-            'sso_user' => 'required|array',
-            'sso_user.provider' => 'required|string',
-            'sso_user.id' => 'required|string',
-            'sso_user.email' => 'required|email',
-            'sso_user.name' => 'required|string',
-            'sso_user.avatar' => 'nullable|string',
+            'id_token' => 'required|string',
             'terms_accepted' => 'required|accepted',
             'privacy_accepted' => 'required|accepted',
             'age_verified' => 'required|accepted',

--- a/app/Http/Requests/API/GoogleMobileLoginRequest.php
+++ b/app/Http/Requests/API/GoogleMobileLoginRequest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Requests\API;
+
+/**
+ * @property-read string $id_token
+ */
+class GoogleMobileLoginRequest extends Request
+{
+    /** @inheritdoc */
+    public function rules(): array
+    {
+        return [
+            'id_token' => 'required|string',
+        ];
+    }
+}

--- a/app/Services/ConsentService.php
+++ b/app/Services/ConsentService.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+class ConsentService
+{
+    public function recordConsent(User $user, Request $request): void
+    {
+        Log::info('User consent recorded', [
+            'user_id' => $user->id,
+            'email' => $user->email,
+            'terms_accepted' => (bool) $request->terms_accepted,
+            'privacy_accepted' => (bool) $request->privacy_accepted,
+            'age_verified' => (bool) $request->age_verified,
+            'ip' => $request->ip(),
+            'user_agent' => $request->userAgent(),
+        ]);
+    }
+}

--- a/app/Services/GoogleIdTokenVerifier.php
+++ b/app/Services/GoogleIdTokenVerifier.php
@@ -44,7 +44,13 @@ class GoogleIdTokenVerifier
     private function getPublicKeys(): array
     {
         $jwks = Cache::remember('google-jwk-keys', 3600, static function (): array {
-            return Http::get(self::CERTS_URL)->json();
+            $response = Http::timeout(10)->get(self::CERTS_URL);
+
+            if ($response->failed()) {
+                throw new UnexpectedValueException('Failed to fetch Google public keys');
+            }
+
+            return $response->json();
         });
 
         return JWK::parseKeySet($jwks, 'RS256');

--- a/app/Services/GoogleIdTokenVerifier.php
+++ b/app/Services/GoogleIdTokenVerifier.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Services;
+
+use App\Values\User\SsoUser;
+use Firebase\JWT\JWK;
+use Firebase\JWT\JWT;
+use Illuminate\Container\Attributes\Config;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use UnexpectedValueException;
+
+class GoogleIdTokenVerifier
+{
+    private const CERTS_URL = 'https://www.googleapis.com/oauth2/v3/certs';
+    private const VALID_ISSUERS = ['accounts.google.com', 'https://accounts.google.com'];
+
+    public function __construct(
+        #[Config('services.google.client_id')] private readonly string $clientId,
+    ) {}
+
+    public function verify(string $idToken): SsoUser
+    {
+        $keys = $this->getPublicKeys();
+        $payload = JWT::decode($idToken, $keys);
+
+        if (!in_array($payload->iss, self::VALID_ISSUERS, true)) {
+            throw new UnexpectedValueException('Invalid issuer');
+        }
+
+        if ($payload->aud !== $this->clientId) {
+            throw new UnexpectedValueException('Invalid audience');
+        }
+
+        return SsoUser::fromArray([
+            'provider' => 'Google',
+            'id' => $payload->sub,
+            'email' => $payload->email,
+            'name' => $payload->name ?? $payload->email,
+            'avatar' => $payload->picture ?? null,
+        ]);
+    }
+
+    private function getPublicKeys(): array
+    {
+        $jwks = Cache::remember('google-jwk-keys', 3600, static function (): array {
+            return Http::get(self::CERTS_URL)->json();
+        });
+
+        return JWK::parseKeySet($jwks, 'RS256');
+    }
+}

--- a/app/Services/SettingService.php
+++ b/app/Services/SettingService.php
@@ -5,13 +5,25 @@ namespace App\Services;
 use App\Facades\License;
 use App\Models\Setting;
 use App\Values\Branding;
+use Illuminate\Container\Attributes\Config;
 use Illuminate\Support\Arr;
 
 class SettingService
 {
     public function __construct(
         private readonly ImageStorage $imageStorage,
+        #[Config('koel.legal.terms_url')] private readonly ?string $termsUrl = null,
+        #[Config('koel.legal.privacy_url')] private readonly ?string $privacyUrl = null,
     ) {}
+
+    /** @return array{terms_url: ?string, privacy_url: ?string} */
+    public function getConsentLegalUrls(): array
+    {
+        return [
+            'terms_url' => $this->termsUrl,
+            'privacy_url' => $this->privacyUrl,
+        ];
+    }
 
     public function getBranding(): Branding
     {

--- a/app/Values/User/SsoUser.php
+++ b/app/Values/User/SsoUser.php
@@ -43,6 +43,28 @@ final readonly class SsoUser
         );
     }
 
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            provider: $data['provider'],
+            id: $data['id'],
+            email: $data['email'],
+            name: $data['name'],
+            avatar: $data['avatar'] ?? null,
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'provider' => $this->provider,
+            'id' => $this->id,
+            'email' => $this->email,
+            'name' => $this->name,
+            'avatar' => $this->avatar,
+        ];
+    }
+
     public static function assertValidProvider(string $provider): void
     {
         Assert::oneOf($provider, ['Google', 'Reverse Proxy']);

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,8 @@
     "spatie/laravel-permission": "^6.21",
     "enshrined/svg-sanitize": "^0.22.0",
     "phanan/poddle": "^1.2",
-    "laravel/ai": "^0.2.6"
+    "laravel/ai": "^0.2.6",
+    "firebase/php-jwt": "^7.0"
   },
   "require-dev": {
     "roave/security-advisories": "dev-latest",

--- a/config/koel.php
+++ b/config/koel.php
@@ -206,6 +206,11 @@ return [
         'enabled' => env('AI_ENABLED', false),
     ],
 
+    'legal' => [
+        'terms_url' => env('LEGAL_TERMS_URL'),
+        'privacy_url' => env('LEGAL_PRIVACY_URL'),
+    ],
+
     'misc' => [
         'home_url' => 'https://koel.dev',
         'docs_url' => 'https://docs.koel.dev',

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -111,6 +111,8 @@ Koel Plus only. See [Single Sign-On](plus/sso).
 | `SSO_GOOGLE_CLIENT_ID` | Your Google OAuth client ID. | _(empty)_ |
 | `SSO_GOOGLE_CLIENT_SECRET` | Your Google OAuth client secret. | _(empty)_ |
 | `SSO_GOOGLE_HOSTED_DOMAIN` | The Google Workspace domain users must belong to. | _(empty)_ |
+| `LEGAL_TERMS_URL` | URL to Terms of Service shown during mobile Google SSO consent. | _(empty)_ |
+| `LEGAL_PRIVACY_URL` | URL to Privacy Policy shown during mobile Google SSO consent. | _(empty)_ |
 
 ## Proxy Authentication
 

--- a/routes/api.base.php
+++ b/routes/api.base.php
@@ -14,6 +14,7 @@ use App\Http\Controllers\API\Artist\ArtistSongController;
 use App\Http\Controllers\API\Artist\FetchArtistEventsController;
 use App\Http\Controllers\API\Artist\FetchArtistInformationController;
 use App\Http\Controllers\API\AuthController;
+use App\Http\Controllers\API\GoogleMobileSsoController;
 use App\Http\Controllers\API\DisconnectFromLastfmController;
 use App\Http\Controllers\API\Embed\EmbedController;
 use App\Http\Controllers\API\Embed\EmbedOptionsController;
@@ -92,6 +93,9 @@ Route::prefix('api')
         Route::middleware('throttle:10,1')->group(static function (): void {
             Route::post('me', [AuthController::class, 'login'])->name('auth.login');
             Route::post('me/otp', [AuthController::class, 'loginUsingOneTimeToken']);
+
+            Route::post('me/google', [GoogleMobileSsoController::class, 'login']);
+            Route::post('me/google/consent', [GoogleMobileSsoController::class, 'consent']);
 
             Route::delete('me', [AuthController::class, 'logout']);
 

--- a/tests/Feature/GoogleMobileSsoTest.php
+++ b/tests/Feature/GoogleMobileSsoTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Services\GoogleIdTokenVerifier;
+use App\Values\User\SsoUser;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+use UnexpectedValueException;
+
+use function Tests\create_user;
+
+class GoogleMobileSsoTest extends TestCase
+{
+    private function mockVerifier(?SsoUser $returnUser = null, bool $throws = false): void
+    {
+        $mock = $this->mock(GoogleIdTokenVerifier::class);
+
+        if ($throws) {
+            $mock->shouldReceive('verify')->andThrow(new UnexpectedValueException('Invalid token'));
+        } else {
+            $mock->shouldReceive('verify')->andReturn($returnUser);
+        }
+    }
+
+    private function ssoUser(): SsoUser
+    {
+        return SsoUser::fromArray([
+            'provider' => 'Google',
+            'id' => 'google-123',
+            'email' => 'test@gmail.com',
+            'name' => 'Test User',
+            'avatar' => 'https://lh3.googleusercontent.com/photo.jpg',
+        ]);
+    }
+
+    #[Test]
+    public function loginWithExistingUser(): void
+    {
+        $ssoUser = $this->ssoUser();
+
+        create_user([
+            'email' => $ssoUser->email,
+            'sso_id' => $ssoUser->id,
+            'sso_provider' => 'Google',
+        ]);
+
+        $this->mockVerifier($ssoUser);
+
+        $this
+            ->post('api/me/google', ['id_token' => 'valid-token'])
+            ->assertOk()
+            ->assertJsonStructure(['token', 'audio-token']);
+    }
+
+    #[Test]
+    public function loginWithNewUserRequiresConsent(): void
+    {
+        $this->mockVerifier($this->ssoUser());
+
+        $this
+            ->post('api/me/google', ['id_token' => 'valid-token'])
+            ->assertOk()
+            ->assertJsonStructure([
+                'requires_consent',
+                'sso_user' => ['provider', 'id', 'email', 'name', 'avatar'],
+                'legal_urls' => ['terms_url', 'privacy_url'],
+            ])
+            ->assertJson(['requires_consent' => true]);
+    }
+
+    #[Test]
+    public function loginWithInvalidTokenReturns401(): void
+    {
+        $this->mockVerifier(throws: true);
+
+        $this
+            ->post('api/me/google', ['id_token' => 'invalid-token'])
+            ->assertUnauthorized();
+    }
+
+    #[Test]
+    public function loginWithoutIdTokenReturns422(): void
+    {
+        $this
+            ->postJson('api/me/google', [])
+            ->assertUnprocessable();
+    }
+
+    #[Test]
+    public function consentCreatesUserAndReturnsTokens(): void
+    {
+        $ssoUser = $this->ssoUser();
+
+        $this
+            ->post('api/me/google/consent', [
+                'sso_user' => $ssoUser->toArray(),
+                'terms_accepted' => true,
+                'privacy_accepted' => true,
+                'age_verified' => true,
+            ])
+            ->assertOk()
+            ->assertJsonStructure(['token', 'audio-token']);
+
+        $this->assertDatabaseHas('users', [
+            'email' => $ssoUser->email,
+            'sso_id' => $ssoUser->id,
+            'sso_provider' => 'Google',
+        ]);
+    }
+
+    #[Test]
+    public function consentFailsWithoutRequiredFields(): void
+    {
+        $this
+            ->postJson('api/me/google/consent', [
+                'sso_user' => $this->ssoUser()->toArray(),
+            ])
+            ->assertUnprocessable();
+    }
+}

--- a/tests/Feature/GoogleMobileSsoTest.php
+++ b/tests/Feature/GoogleMobileSsoTest.php
@@ -91,10 +91,11 @@ class GoogleMobileSsoTest extends TestCase
     public function consentCreatesUserAndReturnsTokens(): void
     {
         $ssoUser = $this->ssoUser();
+        $this->mockVerifier($ssoUser);
 
         $this
             ->post('api/me/google/consent', [
-                'sso_user' => $ssoUser->toArray(),
+                'id_token' => 'valid-token',
                 'terms_accepted' => true,
                 'privacy_accepted' => true,
                 'age_verified' => true,
@@ -110,11 +111,26 @@ class GoogleMobileSsoTest extends TestCase
     }
 
     #[Test]
+    public function consentWithInvalidTokenReturns401(): void
+    {
+        $this->mockVerifier(throws: true);
+
+        $this
+            ->postJson('api/me/google/consent', [
+                'id_token' => 'invalid-token',
+                'terms_accepted' => true,
+                'privacy_accepted' => true,
+                'age_verified' => true,
+            ])
+            ->assertUnauthorized();
+    }
+
+    #[Test]
     public function consentFailsWithoutRequiredFields(): void
     {
         $this
             ->postJson('api/me/google/consent', [
-                'sso_user' => $this->ssoUser()->toArray(),
+                'id_token' => 'valid-token',
             ])
             ->assertUnprocessable();
     }


### PR DESCRIPTION
### This functionality may be an inspiration

feat: implement Google Mobile SSO functionality with login and consent endpoints, including JWT verification and user management

### These are the server-side changes the app would require 
🫱  https://github.com/koel/player/pull/170

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Google Mobile Single Sign-On (SSO) for signing in with Google accounts
  * Consent flow for new users to accept Terms and Privacy before account creation
  * Rate-limited login attempts to reduce abuse

* **Documentation**
  * Added environment variables for legal URLs (terms & privacy) and docs updated

* **Tests**
  * Feature tests covering login, consent, validation, and error cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->