### PR TITLE
feat: add configuration to lock playlists

### DIFF
--- a/app/Ai/Tools/RemoveFromPlaylist.php
+++ b/app/Ai/Tools/RemoveFromPlaylist.php
@@ -68,6 +68,13 @@ class RemoveFromPlaylist implements Tool
             );
         }
 
+        if ($playlist->is_locked) {
+            return sprintf(
+                'Cannot remove songs from "%s" because editing is disabled for this playlist via configuration',
+                $playlist->name,
+            );
+        }
+
         $songs = $this->songResolver->resolveSongs($request, $this->context);
 
         if ($songs->isEmpty()) {

--- a/app/Http/Controllers/API/MovePlaylistSongsController.php
+++ b/app/Http/Controllers/API/MovePlaylistSongsController.php
@@ -7,12 +7,14 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\API\Playlist\MovePlaylistSongsRequest;
 use App\Models\Playlist;
 use App\Services\PlaylistService;
+use Illuminate\Http\Response;
 
 class MovePlaylistSongsController extends Controller
 {
     public function __invoke(MovePlaylistSongsRequest $request, Playlist $playlist, PlaylistService $service)
     {
         $this->authorize('collaborate', $playlist);
+        abort_if($playlist->is_locked, Response::HTTP_FORBIDDEN, 'Editing is disabled for this playlist.');
 
         $service->movePlayablesInPlaylist(
             $playlist,

--- a/app/Http/Controllers/API/PlaylistSongController.php
+++ b/app/Http/Controllers/API/PlaylistSongController.php
@@ -42,6 +42,7 @@ class PlaylistSongController extends Controller
     public function store(Playlist $playlist, AddSongsToPlaylistRequest $request)
     {
         abort_if($playlist->is_smart, Response::HTTP_FORBIDDEN, 'Smart playlist content is automatically generated');
+        abort_if($playlist->is_locked, Response::HTTP_FORBIDDEN, 'Editing is disabled for this playlist.');
 
         $this->authorize('collaborate', $playlist);
 
@@ -62,6 +63,7 @@ class PlaylistSongController extends Controller
     public function destroy(Playlist $playlist, RemoveSongsFromPlaylistRequest $request)
     {
         abort_if($playlist->is_smart, Response::HTTP_FORBIDDEN, 'Smart playlist content is automatically generated');
+        abort_if($playlist->is_locked, Response::HTTP_FORBIDDEN, 'Editing is disabled for this playlist.');
 
         $this->authorize('collaborate', $playlist);
         $this->playlistService->removePlayablesFromPlaylist($playlist, $request->songs);

--- a/app/Http/Requests/API/Playlist/PlaylistUpdateRequest.php
+++ b/app/Http/Requests/API/Playlist/PlaylistUpdateRequest.php
@@ -15,6 +15,7 @@ use Illuminate\Validation\Rule;
  * @property-read string $name
  * @property-read ?string $description
  * @property-read ?string $folder_id
+ * @property-read bool $is_locked
  * @property-read array $rules
  * @property-read ?string $cover
  */
@@ -26,6 +27,7 @@ class PlaylistUpdateRequest extends Request
         return [
             'name' => 'required',
             'description' => 'string|sometimes|nullable',
+            'is_locked' => 'boolean|sometimes',
             'rules' => ['array', 'nullable', new ValidSmartPlaylistRulePayload()],
             'folder_id' => [
                 'nullable',
@@ -47,6 +49,7 @@ class PlaylistUpdateRequest extends Request
             folderName: $this->folder_name,
             cover: $this->has('cover') ? $this->string('cover') : null,
             ruleGroups: $this->rules ? SmartPlaylistRuleGroupCollection::create(Arr::wrap($this->rules)) : null,
+            isLocked: $this->has('is_locked') ? $this->boolean('is_locked') : null,
         );
     }
 }

--- a/app/Http/Resources/PlaylistResource.php
+++ b/app/Http/Resources/PlaylistResource.php
@@ -18,6 +18,7 @@ class PlaylistResource extends JsonResource
         'folder_id',
         'user_id',
         'is_smart',
+        'is_locked',
         'rules',
         'created_at',
     ];
@@ -49,6 +50,7 @@ class PlaylistResource extends JsonResource
             'user_id' => $this->unless($embedding, $this->playlist->owner->public_id), // backwards compatibility
             'owner_id' => $this->unless($embedding, $this->playlist->owner->public_id),
             'is_smart' => $this->unless($embedding, $this->playlist->is_smart),
+            'is_locked' => $this->unless($embedding, $this->playlist->is_locked),
             'is_collaborative' => $this->unless($embedding, $playlistService->isPlaylistCollaborative($this->playlist)),
             'rules' => $this->unless($embedding, $this->playlist->rules),
             'cover' => image_storage_url($this->playlist->cover),

--- a/app/Models/Playlist.php
+++ b/app/Models/Playlist.php
@@ -29,6 +29,7 @@ use OwenIt\Auditing\Contracts\Auditable as AuditableContract;
  * @property string $name
  * @property string $description
  * @property bool $is_smart
+ * @property bool $is_locked
  * @property User $owner
  * @property ?SmartPlaylistRuleGroupCollection $rule_groups
  * @property ?SmartPlaylistRuleGroupCollection $rules
@@ -56,10 +57,15 @@ class Playlist extends Model implements AuditableContract, Embeddable
     protected $hidden = ['created_at', 'updated_at'];
     protected $guarded = [];
 
+    protected $attributes = [
+        'is_locked' => false,
+    ];
+
     protected function casts(): array
     {
         return [
             'rules' => SmartPlaylistRulesCast::class,
+            'is_locked' => 'boolean',
         ];
     }
 

--- a/app/Services/PlaylistService.php
+++ b/app/Services/PlaylistService.php
@@ -63,6 +63,7 @@ class PlaylistService
             'name' => $dto->name,
             'description' => $dto->description,
             'rules' => $dto->ruleGroups,
+            'is_locked' => $dto->isLocked ?? $playlist->is_locked ?? false,
         ];
 
         if (is_string($dto->cover)) {

--- a/app/Values/Playlist/PlaylistUpdateData.php
+++ b/app/Values/Playlist/PlaylistUpdateData.php
@@ -14,6 +14,7 @@ final readonly class PlaylistUpdateData implements Arrayable
         public ?string $folderName,
         public ?string $cover,
         public ?SmartPlaylistRuleGroupCollection $ruleGroups,
+        public ?bool $isLocked = null,
     ) {}
 
     public static function make(
@@ -23,6 +24,7 @@ final readonly class PlaylistUpdateData implements Arrayable
         ?string $folderName = null,
         ?string $cover = null,
         ?SmartPlaylistRuleGroupCollection $ruleGroups = null,
+        ?bool $isLocked = null,
     ): self {
         return new self(
             name: $name,
@@ -31,6 +33,7 @@ final readonly class PlaylistUpdateData implements Arrayable
             folderName: $folderName,
             cover: $cover,
             ruleGroups: $ruleGroups,
+            isLocked: $isLocked,
         );
     }
 
@@ -43,6 +46,7 @@ final readonly class PlaylistUpdateData implements Arrayable
             'folder_id' => $this->folderId,
             'cover' => $this->cover,
             'rule_groups' => $this->ruleGroups,
+            'is_locked' => $this->isLocked,
         ];
     }
 }

--- a/database/factories/PlaylistFactory.php
+++ b/database/factories/PlaylistFactory.php
@@ -21,6 +21,7 @@ class PlaylistFactory extends Factory
             'name' => $this->faker->name,
             'rules' => null,
             'description' => $this->faker->realText(),
+            'is_locked' => false,
             'cover' => Ulid::generate() . '.webp',
         ];
     }

--- a/database/migrations/2026_04_15_183000_add_is_locked_to_playlists_table.php
+++ b/database/migrations/2026_04_15_183000_add_is_locked_to_playlists_table.php
@@ -1,0 +1,14 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('playlists', static function (Blueprint $table): void {
+            $table->boolean('is_locked')->default(false)->after('rules');
+        });
+    }
+};

--- a/resources/assets/js/components/layout/main-wrapper/sidebar/PlaylistSidebarItem.vue
+++ b/resources/assets/js/components/layout/main-wrapper/sidebar/PlaylistSidebarItem.vue
@@ -16,6 +16,7 @@
     <template #icon>
       <Icon v-if="isRecentlyPlayedList(list)" :icon="faClockRotateLeft" fixed-width />
       <Icon v-else-if="isFavoriteList(list)" :icon="faStar" fixed-width />
+      <Icon v-else-if="isPlaylist(list) && list.is_locked" :icon="faLock" />
       <Icon v-else-if="list.is_smart" :icon="faWandMagicSparkles" fixed-width />
       <Icon v-else-if="list.is_collaborative" :icon="faUsers" fixed-width />
       <ListMusicIcon v-else :size="16" />
@@ -25,7 +26,7 @@
 </template>
 
 <script lang="ts" setup>
-import { faClockRotateLeft, faStar, faUsers, faWandMagicSparkles } from '@fortawesome/free-solid-svg-icons'
+import { faClockRotateLeft, faLock, faStar, faUsers, faWandMagicSparkles } from '@fortawesome/free-solid-svg-icons'
 import { ListMusicIcon } from 'lucide-vue-next'
 import { computed, ref, toRefs } from 'vue'
 import { defineAsyncComponent } from '@/utils/helpers'
@@ -88,6 +89,9 @@ const contentEditable = computed(() => {
   }
   if (isFavoriteList(list.value)) {
     return true
+  }
+  if (isPlaylist(list.value) && list.value.is_locked) {
+    return false
   }
 
   return !list.value.is_smart

--- a/resources/assets/js/components/playable/PlayableContextMenu.spec.ts
+++ b/resources/assets/js/components/playable/PlayableContextMenu.spec.ts
@@ -273,6 +273,15 @@ describe('playableContextMenu.vue', () => {
     expect(screen.queryByText('My Smart Playlist')).toBeNull()
   })
 
+  it('does not list locked playlists', async () => {
+    playlistStore.state.playlists = h.factory('playlist', 3)
+    playlistStore.state.playlists.push(h.factory('playlist', { name: 'My locked Playlist', is_locked: true }))
+
+    await renderComponent()
+
+    expect(screen.queryByText('My locked Playlist')).toBeNull()
+  })
+
   it('removes from playlist', async () => {
     const playlist = h.factory('playlist')
     playlistStore.state.playlists.push(playlist)
@@ -289,6 +298,16 @@ describe('playableContextMenu.vue', () => {
       expect(removeContentMock).toHaveBeenCalledWith(playlist, playables)
       expect(emitMock).toHaveBeenCalledWith('PLAYLIST_CONTENT_REMOVED', playlist, playables)
     })
+  })
+
+  it('does not have an option to remove from playlist if playlist is locked', async () => {
+    const playlist = h.factory('playlist', { is_locked: true })
+    playlistStore.state.playlists.push(playlist)
+
+    h.visit(`/playlists/${playlist.id}`)
+    await renderComponent()
+
+    expect(screen.queryByText('Remove from Playlist')).toBeNull()
   })
 
   it('does not have an option to remove from playlist if not on Playlist screen', async () => {

--- a/resources/assets/js/components/playable/PlayableContextMenu.vue
+++ b/resources/assets/js/components/playable/PlayableContextMenu.vue
@@ -59,10 +59,10 @@
           <Separator />
           <MenuItem @click="addToFavorites">Favorites</MenuItem>
         </template>
-        <Separator v-if="normalPlaylists.length" />
+        <Separator v-if="editablePlaylists.length" />
         <template class="block">
-          <ul v-if="normalPlaylists.length" v-koel-overflow-fade class="relative max-h-48 overflow-y-auto">
-            <MenuItem v-for="p in normalPlaylists" :key="p.id" @click="addToExistingPlaylist(p)">
+          <ul v-if="editablePlaylists.length" v-koel-overflow-fade class="relative max-h-48 overflow-y-auto">
+            <MenuItem v-for="p in editablePlaylists" :key="p.id" @click="addToExistingPlaylist(p)">
               {{ p.name }}
             </MenuItem>
           </ul>
@@ -206,7 +206,7 @@ const onlyOneSelected = computed(() => playables.value.length === 1)
 const firstSongPlaying = computed(() =>
   playables.value.length ? playables.value[0].playback_state === 'Playing' : false,
 )
-const normalPlaylists = computed(() => playlists.value.filter(({ is_smart }) => !is_smart))
+const editablePlaylists = computed(() => playlists.value.filter(({ is_smart, is_locked }) => !is_smart && !is_locked))
 const canBeShared = computed(() => !isPlus.value || (isSong(playables.value[0]) && playables.value[0].is_public))
 
 const makePublic = () =>
@@ -276,7 +276,7 @@ const canBeRemovedFromPlaylist = computed(() => {
     return false
   }
   const playlist = playlistStore.byId(getRouteParam('id')!)
-  return playlist && !playlist.is_smart
+  return playlist && !playlist.is_smart && !playlist.is_locked
 })
 
 const isQueueScreen = computed(() => isCurrentScreen('Queue'))

--- a/resources/assets/js/components/playlist/EditPlaylistForm.spec.ts
+++ b/resources/assets/js/components/playlist/EditPlaylistForm.spec.ts
@@ -109,4 +109,21 @@ describe('editPlaylistForm.vue', () => {
       })
     })
   })
+
+  it('locks the playlist', async () => {
+    const updateMock = h.mock(playlistStore, 'update')
+    const { playlist, container } = renderComponent(h.factory('playlist', { is_locked: false }))
+
+    await h.user.click(container.querySelector('input[name="is_locked"]')!)
+    await h.user.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(updateMock).toHaveBeenCalledWith(
+        playlist,
+        expect.objectContaining({
+          is_locked: true,
+        }),
+      )
+    })
+  })
 })

--- a/resources/assets/js/components/playlist/EditPlaylistForm.vue
+++ b/resources/assets/js/components/playlist/EditPlaylistForm.vue
@@ -19,6 +19,10 @@
           <TextArea v-model="data.description" class="h-28" name="description" />
         </FormRow>
         <ArtworkField v-model="data.cover">Pick or paste a cover (optional)</ArtworkField>
+        <FormRow class="col-span-2">
+          <CheckBox v-model="data.is_locked" name="is_locked" />
+          <span class="ml-1">Disable Editing</span>
+        </FormRow>
       </div>
     </main>
 
@@ -43,6 +47,7 @@ import FormRow from '@/components/ui/form/FormRow.vue'
 import FolderSelect from '@/components/ui/form/FolderSelect.vue'
 import TextArea from '@/components/ui/form/TextArea.vue'
 import ArtworkField from '@/components/ui/form/ArtworkField.vue'
+import CheckBox from '@/components/ui/form/CheckBox.vue'
 
 const props = defineProps<{ playlist: Playlist }>()
 const emit = defineEmits<{ (e: 'close'): void }>()
@@ -55,7 +60,7 @@ const { showConfirmDialog } = useDialogBox()
 const close = () => emit('close')
 
 const { data, isPristine, handleSubmit } = useForm<UpdatePlaylistData>({
-  initialValues: { ...pick(playlist, 'name', 'folder_id', 'description', 'cover'), folder_name: null },
+  initialValues: { ...pick(playlist, 'name', 'folder_id', 'description', 'cover', 'is_locked'), folder_name: null },
   onSubmit: async data => {
     const formData = cloneDeep(data)
 

--- a/resources/assets/js/components/screens/PlaylistScreen.vue
+++ b/resources/assets/js/components/screens/PlaylistScreen.vue
@@ -226,6 +226,10 @@ const fetchDetails = async (refresh = false) => {
 }
 
 const onReorder = (target: Playable, placement: Placement) => {
+  if (playlist.value?.is_locked) {
+    return
+  }
+
   playlistStore.moveItemsInPlaylist(playlist.value!, selectedPlayables.value, target, placement)
 }
 
@@ -255,7 +259,7 @@ watch(playlistId, async id => {
 
   await fetchDetails()
 
-  listConfig.reorderable = currentState.sortField === 'position'
+  listConfig.reorderable = currentState.sortField === 'position' && !playlist.value.is_locked
   listConfig.collaborative = playlist.value.is_collaborative
   listConfig.hasCustomOrderSort = !playlist.value.is_smart
 

--- a/resources/assets/js/composables/usePlaylistContentManagement.spec.ts
+++ b/resources/assets/js/composables/usePlaylistContentManagement.spec.ts
@@ -44,6 +44,17 @@ describe('usePlaylistContentManagement', () => {
     expect(playlistStore.addContent).not.toHaveBeenCalled()
   })
 
+  it('does not add to locked playlists', async () => {
+    const playlist = h.factory('playlist', { is_locked: true })
+    const songs = [h.factory('song')]
+    h.mock(playlistStore, 'addContent')
+
+    const { addToPlaylist } = usePlaylistContentManagement()
+    await addToPlaylist(playlist, songs)
+
+    expect(playlistStore.addContent).not.toHaveBeenCalled()
+  })
+
   it('removes content from a playlist', async () => {
     const playlist = h.factory('playlist', { is_smart: false })
     const songs = [h.factory('song')]
@@ -55,5 +66,18 @@ describe('usePlaylistContentManagement', () => {
 
     expect(playlistStore.removeContent).toHaveBeenCalledWith(playlist, songs)
     expect(emitMock).toHaveBeenCalledWith('PLAYLIST_CONTENT_REMOVED', playlist, songs)
+  })
+
+  it('does not remove from locked playlists', async () => {
+    const playlist = h.factory('playlist', { is_locked: true })
+    const songs = [h.factory('song')]
+    const emitMock = h.mock(eventBus, 'emit')
+    h.mock(playlistStore, 'removeContent').mockResolvedValue(undefined)
+
+    const { removeFromPlaylist } = usePlaylistContentManagement()
+    await removeFromPlaylist(playlist, songs)
+
+    expect(playlistStore.removeContent).not.toHaveBeenCalledWith(playlist, songs)
+    expect(emitMock).not.toHaveBeenCalledWith('PLAYLIST_CONTENT_REMOVED', playlist, songs)
   })
 })

--- a/resources/assets/js/composables/usePlaylistContentManagement.ts
+++ b/resources/assets/js/composables/usePlaylistContentManagement.ts
@@ -20,7 +20,7 @@ export const usePlaylistContentManagement = () => {
   }
 
   const addToPlaylist = async (playlist: Playlist, playables: Playable[]) => {
-    if (playlist.is_smart || playables.length === 0) {
+    if (playlist.is_smart || playables.length === 0 || playlist.is_locked) {
       return
     }
 
@@ -34,7 +34,7 @@ export const usePlaylistContentManagement = () => {
   }
 
   const removeFromPlaylist = async (playlist: Playlist, playables: Playable[]) => {
-    if (playlist.is_smart) {
+    if (playlist.is_smart || playlist.is_locked) {
       return
     }
 

--- a/resources/assets/js/stores/playlistStore.ts
+++ b/resources/assets/js/stores/playlistStore.ts
@@ -28,6 +28,7 @@ export type CreatePlaylistData = Pick<Playlist, 'name' | 'description' | 'folder
 export interface UpdatePlaylistData {
   name: Playlist['name']
   description: Playlist['description']
+  is_locked?: boolean
   folder_id?: PlaylistFolder['id'] | null
   folder_name?: string | null
   cover?: string | null

--- a/resources/assets/js/types.d.ts
+++ b/resources/assets/js/types.d.ts
@@ -320,6 +320,7 @@ interface Playlist {
   description: string
   folder_id: PlaylistFolder['id'] | null
   is_smart: boolean
+  is_locked: boolean
   is_collaborative: boolean
   rules: SmartPlaylistRuleGroup[]
   cover: string | null

--- a/tests/Feature/PlaylistLockTest.php
+++ b/tests/Feature/PlaylistLockTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Song;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+use function Tests\create_playlist;
+use function Tests\create_user;
+
+class PlaylistLockTest extends TestCase
+{
+    #[Test]
+    public function ownerCanLockPlaylist(): void
+    {
+        $playlist = create_playlist();
+
+        $this->putAs(
+            "api/playlists/{$playlist->id}",
+            [
+                'name' => $playlist->name,
+                'is_locked' => true,
+            ],
+            $playlist->owner,
+        )->assertSuccessful();
+
+        self::assertTrue($playlist->refresh()->is_locked);
+    }
+
+    #[Test]
+    public function ownerCanUnlockPlaylist(): void
+    {
+        $playlist = create_playlist(['is_locked' => true]);
+
+        $this->putAs(
+            "api/playlists/{$playlist->id}",
+            [
+                'name' => $playlist->name,
+                'is_locked' => false,
+            ],
+            $playlist->owner,
+        )->assertSuccessful();
+
+        self::assertFalse($playlist->refresh()->is_locked);
+    }
+
+    #[Test]
+    public function nonOwnerCannotLockOrUnlockPlaylist(): void
+    {
+        $playlist = create_playlist();
+        $otherUser = create_user();
+
+        $this->putAs(
+            "api/playlists/{$playlist->id}",
+            [
+                'name' => 'Changed',
+                'is_locked' => true,
+            ],
+            $otherUser,
+        )->assertForbidden();
+
+        self::assertFalse($playlist->refresh()->is_locked);
+    }
+
+    #[Test]
+    public function lockedPlaylistCannotHaveSongsAdded(): void
+    {
+        $playlist = create_playlist(['is_locked' => true]);
+        $song = Song::factory()->createOne();
+
+        $this->postAs(
+            "api/playlists/{$playlist->id}/songs",
+            [
+                'songs' => [$song->id],
+            ],
+            $playlist->owner,
+        )->assertForbidden();
+
+        self::assertCount(0, $playlist->playables);
+    }
+
+    #[Test]
+    public function lockedPlaylistCannotHaveSongsRemoved(): void
+    {
+        $playlist = create_playlist(['is_locked' => true]);
+        $song = Song::factory()->createOne();
+        $playlist->is_locked = false;
+        $playlist->save();
+        $playlist->addPlayables([$song->id]);
+        $playlist->is_locked = true;
+        $playlist->save();
+
+        $this->deleteAs(
+            "api/playlists/{$playlist->id}/songs",
+            [
+                'songs' => [$song->id],
+            ],
+            $playlist->owner,
+        )->assertForbidden();
+
+        self::assertCount(1, $playlist->refresh()->playables);
+    }
+
+    #[Test]
+    public function collaboratorCannotAddSongsToLockedPlaylist(): void
+    {
+        $owner = create_user();
+        $collaborator = create_user();
+        $playlist = create_playlist(['is_locked' => true]);
+        $playlist->users()->detach();
+        $playlist->users()->attach($owner, ['role' => 'owner']);
+        $playlist->users()->attach($collaborator, ['role' => 'collaborator']);
+
+        $song = Song::factory()->createOne();
+
+        $this->postAs(
+            "api/playlists/{$playlist->id}/songs",
+            [
+                'songs' => [$song->id],
+            ],
+            $collaborator,
+        )->assertForbidden();
+    }
+
+    #[Test]
+    public function deletingSongStillRemovesItFromLockedPlaylist(): void
+    {
+        $playlist = create_playlist(['is_locked' => true]);
+        $song = Song::factory()->createOne();
+
+        $playlist->is_locked = false;
+        $playlist->save();
+        $playlist->addPlayables([$song->id]);
+        $playlist->is_locked = true;
+        $playlist->save();
+
+        self::assertCount(1, $playlist->refresh()->playables);
+
+        $song->delete();
+
+        self::assertCount(0, $playlist->refresh()->playables);
+    }
+}

--- a/tests/Integration/Services/PlaylistServiceTest.php
+++ b/tests/Integration/Services/PlaylistServiceTest.php
@@ -132,10 +132,20 @@ class PlaylistServiceTest extends TestCase
     {
         $playlist = create_playlist(['name' => 'foo']);
 
-        $this->service->updatePlaylist($playlist, PlaylistUpdateData::make(name: 'bar', description: 'baz'));
+        $this->service->updatePlaylist($playlist, PlaylistUpdateData::make(
+            name: 'bar',
+            description: 'baz',
+            isLocked: true,
+        ));
 
         self::assertSame('bar', $playlist->name);
         self::assertSame('baz', $playlist->description);
+        self::assertTrue($playlist->is_locked);
+
+        $this->service->updatePlaylist($playlist, PlaylistUpdateData::make(name: 'qux', isLocked: false));
+
+        self::assertSame('qux', $playlist->name);
+        self::assertFalse($playlist->is_locked);
     }
 
     #[Test]


### PR DESCRIPTION
## Description
Adds the ability to lock playlists via configuration.  

When a playlist is marked as locked, no tracks can be added to or removed from it.

## Motivation
1. Prevent accidental modifications of playlists, such as unintentionally adding or removing songs. A scenario could be a mis-click when selecting the wrong playlist during song addition. This is especially relevant for playlists that are rarely changed (e.g., best-of lists).
2. Improve the usability of the playlist selection when adding songs, by reducing the number of available playlists, making it easier to find the desired one.
3. Enable read-only collaborative playlists, so owners can prevent others from making changes when the playlist is intended to be shared without edit access.

## Screenshots 
<img width="600" height="618" alt="Screenshot 2026-04-20 at 17-57-42 Koel" src="https://github.com/user-attachments/assets/ec708c22-a9a5-4d0b-b28a-2ba83be0822b" />


## Checklist
- [x] I've tested my changes thoroughly and added tests where applicable
- [x] I've updated relevant documentation (if any)
- [x] My code follows the project's conventions

## Notes:
I was unable to test the mobile app because I don’t have a local mobile development setup. Since it is still unclear whether this feature will be supported, I don’t want to invest too much time in setting up and learning the mobile development environment yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Lock playlists to prevent editing: new toggle in playlist settings controls whether songs can be added, removed, or reordered.
  * Locked playlists display a lock icon in the sidebar.
  * Locked playlists are excluded from quick-add menus.
  * Full API enforcement across all song management operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->