### PR TITLE
fix: use most recent feed date for podcast sync freshness check

### DIFF
--- a/app/Services/PodcastService.php
+++ b/app/Services/PodcastService.php
@@ -95,15 +95,10 @@ class PodcastService
 
         // Some feeds have a stale pubDate (set once at creation) but an updated lastBuildDate.
         // We use the most recent of the two to determine if new content is available.
-        $pubDate = rescue(static fn () => Carbon::createFromFormat(
-            Carbon::RFC1123,
-            $parser->xmlReader->value('rss.channel.pubDate')->first(),
-        ));
-
-        $lastBuildDate = rescue(static fn () => Carbon::createFromFormat(
-            Carbon::RFC1123,
-            $parser->xmlReader->value('rss.channel.lastBuildDate')->first(),
-        ));
+        // Carbon::parse() is used instead of createFromFormat(RFC1123) because RSS feeds use
+        // varied timezone formats (GMT, EST, +0000) that strict RFC1123 parsing would reject.
+        $pubDate = self::parseFeedDate($parser->xmlReader->value('rss.channel.pubDate')->first());
+        $lastBuildDate = self::parseFeedDate($parser->xmlReader->value('rss.channel.lastBuildDate')->first());
 
         $feedDate = collect([$pubDate, $lastBuildDate])->filter()->sortDesc()->first();
 
@@ -264,6 +259,15 @@ class PodcastService
     public function deletePodcast(Podcast $podcast): void
     {
         $podcast->delete();
+    }
+
+    private static function parseFeedDate(?string $date): ?Carbon
+    {
+        if (!$date) {
+            return null;
+        }
+
+        return rescue(static fn (): Carbon => Carbon::parse($date));
     }
 
     private function createParser(string $url): Poddle

--- a/app/Services/PodcastService.php
+++ b/app/Services/PodcastService.php
@@ -93,14 +93,21 @@ class PodcastService
         $parser = $this->createParser($podcast->url);
         $channel = $parser->getChannel();
 
-        $pubDate = $parser->xmlReader->value('rss.channel.pubDate')->first() ?? $parser
-            ->xmlReader
-            ->value('rss.channel.lastBuildDate')
-            ->first();
+        // Some feeds have a stale pubDate (set once at creation) but an updated lastBuildDate.
+        // We use the most recent of the two to determine if new content is available.
+        $pubDate = rescue(static fn () => Carbon::createFromFormat(
+            Carbon::RFC1123,
+            $parser->xmlReader->value('rss.channel.pubDate')->first(),
+        ));
 
-        if ($pubDate && Carbon::createFromFormat(Carbon::RFC1123, $pubDate)?->isBefore($podcast->last_synced_at)) {
-            // The pubDate/lastBuildDate value indicates that there's been no new content since the last check.
-            // We'll simply return the podcast.
+        $lastBuildDate = rescue(static fn () => Carbon::createFromFormat(
+            Carbon::RFC1123,
+            $parser->xmlReader->value('rss.channel.lastBuildDate')->first(),
+        ));
+
+        $feedDate = collect([$pubDate, $lastBuildDate])->filter()->sortDesc()->first();
+
+        if ($feedDate?->isBefore($podcast->last_synced_at)) {
             return $podcast;
         }
 

--- a/tests/Integration/Services/PodcastServiceTest.php
+++ b/tests/Integration/Services/PodcastServiceTest.php
@@ -246,4 +246,30 @@ class PodcastServiceTest extends TestCase
         $this->service->deletePodcast($podcast);
         self::assertModelMissing($podcast);
     }
+
+    #[Test]
+    public function refreshPodcastUsesLastBuildDateWhenPubDateIsStale(): void
+    {
+        // The fixture has pubDate=2021 (stale) and lastBuildDate=2024-05-02 (the real update date).
+        // Set last_synced_at between the two: after pubDate but before lastBuildDate.
+        // With the old code, pubDate (2021) < last_synced_at (2023) would cause an early return.
+        // The fix picks the most recent date (lastBuildDate=2024) which is after last_synced_at.
+        $mock = new MockHandler([
+            new Response(200, [], file_get_contents(test_path('fixtures/podcast-stale-pubdate.xml'))),
+        ]);
+
+        $this->instance(ClientInterface::class, new Client(['handler' => HandlerStack::create($mock)]));
+        $service = app(PodcastService::class);
+
+        $podcast = Podcast::factory()->createOne([
+            'url' => 'https://example.com/feed.xml',
+            'title' => 'Old Title',
+            'last_synced_at' => '2023-01-01 00:00:00',
+        ]);
+
+        $service->refreshPodcast($podcast);
+
+        self::assertSame('Podcast Feed Parser', $podcast->fresh()->title);
+        self::assertCount(8, $podcast->episodes);
+    }
 }

--- a/tests/fixtures/podcast-stale-pubdate.xml
+++ b/tests/fixtures/podcast-stale-pubdate.xml
@@ -79,7 +79,7 @@
             <itunes:image
                 href="http://example.com/podcasts/everything/AllAboutEverything/Episode2.jpg"
             />
-            <link>href="http://example.com/podcasts/everything/</link>
+            <link>http://example.com/podcasts/everything/</link>
             <enclosure
                 length="5650889"
                 type="video/mp4"

--- a/tests/fixtures/podcast-stale-pubdate.xml
+++ b/tests/fixtures/podcast-stale-pubdate.xml
@@ -1,0 +1,189 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"
+     xmlns:atom="http://www.w3.org/2005/Atom"
+     xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"
+     xmlns:podcast="https://podcastindex.org/namespace/1.0">
+
+    <channel>
+        <title>Podcast Feed Parser</title>
+        <link>https://github.com/phanan/podcast-feed-parser</link>
+        <description><![CDATA[Parse podcast feeds with PHP following PSP-1 Podcast RSS Standard]]></description>
+        <pubDate>Tue, 31 Aug 2021 12:03:00 +0000</pubDate>
+        <lastBuildDate>Thu, 02 May 2024 06:44:38 +0000</lastBuildDate>
+
+        <image>
+            <url>https://github.com/phanan.png</url>
+            <title>Phan An</title>
+            <link>https://phanan.net</link>
+        </image>
+        <atom:link rel="self" type="application/rss+xml" title="Podcast Feed Parser" href="https://phanan.net"/>
+        <language>en-US</language>
+        <generator>Rice Cooker</generator>
+        <copyright>Phan An © 2024</copyright>
+        <itunes:author>Phan An (phanan)</itunes:author>
+        <itunes:type>episodic</itunes:type>
+        <itunes:category text="News">
+            <itunes:category text="Tech News"/>
+        </itunes:category>
+
+        <itunes:image href="https://github.com/phanan.png"/>
+        <itunes:block>no</itunes:block>
+        <itunes:explicit>no</itunes:explicit>
+
+        <podcast:funding url="https://github.com/sponsors/phanan">Sponsor me on GitHub</podcast:funding>
+        <podcast:funding url="https://opencollective.com/koel">My other Open Collective</podcast:funding>
+
+        <podcast:txt>naj3eEZaWVVY9a38uhX8FekACyhtqP4JN</podcast:txt>
+        <podcast:txt purpose="verify">S6lpp-7ZCn8-dZfGc-OoyaG</podcast:txt>
+
+        <item>
+            <itunes:episodeType>trailer</itunes:episodeType>
+            <itunes:title>Hiking Treks Trailer</itunes:title>
+            <description><![CDATA[The Sunset Explorers share tips, techniques and recommendations for great hikes]]></description>
+            <enclosure
+                length="498537"
+                type="audio/mpeg"
+                url="http://example.com/podcasts/everything/AllAboutEverythingEpisode4.mp3"
+            />
+            <guid>D03EEC9B-B1B4-475B-92C8-54F853FA2A22</guid>
+            <pubDate>Tue, 8 Jan 2019 01:15:00 GMT</pubDate>
+            <itunes:duration>1079</itunes:duration>
+            <itunes:explicit>false</itunes:explicit>
+        </item>
+        <item>
+            <itunes:episodeType>full</itunes:episodeType>
+            <itunes:episode>4</itunes:episode>
+            <itunes:season>2</itunes:season>
+            <title>S02 EP04 Mt. Hood, Oregon</title>
+            <description>
+                Tips for trekking around the tallest mountain in Oregon
+            </description>
+            <enclosure
+                length="8727310"
+                type="audio/x-m4a"
+                url="http://example.com/podcasts/everything/mthood.m4a"
+            />
+            <guid>22BCFEBF-44FB-4A19-8229-7AC678629F57</guid>
+            <pubDate>Tue, 07 May 2019 12:00:00 GMT</pubDate>
+            <itunes:duration>1024</itunes:duration>
+            <itunes:explicit>false</itunes:explicit>
+        </item>
+        <item>
+            <itunes:episodeType>full</itunes:episodeType>
+            <itunes:episode>3</itunes:episode>
+            <itunes:season>2</itunes:season>
+            <title>S02 EP03 Bouldering Around Boulder</title>
+            <description>
+                We explore fun walks to climbing areas about the beautiful Colorado city of Boulder.
+            </description>
+            <itunes:image
+                href="http://example.com/podcasts/everything/AllAboutEverything/Episode2.jpg"
+            />
+            <link>href="http://example.com/podcasts/everything/</link>
+            <enclosure
+                length="5650889"
+                type="video/mp4"
+                url="http://example.com/podcasts/boulder.mp4"
+            />
+            <guid>BE486CAA-B3D5-4FB0-8298-EFEBE71C5982</guid>
+            <pubDate>Tue, 30 Apr 2019 13:00:00 EST</pubDate>
+            <itunes:duration>3627</itunes:duration>
+            <itunes:explicit>false</itunes:explicit>
+        </item>
+        <item>
+            <itunes:episodeType>full</itunes:episodeType>
+            <itunes:episode>2</itunes:episode>
+            <itunes:season>2</itunes:season>
+            <title>S02 EP02 Caribou Mountain, Maine</title>
+            <description>
+                Put your fitness to the test with this invigorating hill climb.
+            </description>
+            <itunes:image
+                href="http://example.com/podcasts/everything/AllAboutEverything/Episode3.jpg"
+            />
+            <enclosure
+                length="5650889"
+                type="audio/x-m4v"
+                url="http://example.com/podcasts/everything/caribou.m4v"
+            />
+            <guid>142FAFE9-B1DF-4F6D-BAA8-79BDBAF653A9</guid>
+            <pubDate>Tue, 23 May 2019 02:00:00 -0700</pubDate>
+            <itunes:duration>2434</itunes:duration>
+            <itunes:explicit>false</itunes:explicit>
+        </item>
+        <item>
+            <itunes:episodeType>full</itunes:episodeType>
+            <itunes:episode>4</itunes:episode>
+            <itunes:season>1</itunes:season>
+            <title>S01 EP04 Kuliouou Ridge Trail</title>
+            <description>
+                Oahu, Hawaii, has some picturesque hikes and this is one of the best!
+            </description>
+            <enclosure
+                length="498537"
+                type="audio/mpeg"
+                url="http://example.com/podcasts/everything/AllAboutEverythingEpisode4.mp3"
+            />
+            <guid>B5FCEB80-317C-4CD0-A84B-807065B43FB9</guid>
+            <pubDate>Tue, 27 Nov 2018 01:15:00 +0000</pubDate>
+            <itunes:duration>929</itunes:duration>
+            <itunes:explicit>false</itunes:explicit>
+        </item>
+        <item>
+            <itunes:episodeType>full</itunes:episodeType>
+            <itunes:episode>3</itunes:episode>
+            <itunes:season>1</itunes:season>
+            <title>S01 EP03 Blood Mountain Loop</title>
+            <description>
+                Hiking the Appalachian Trail and Freeman Trail in Georgia
+            </description>
+            <enclosure
+                length="498537"
+                type="audio/mpeg"
+                url="http://example.com/podcasts/everything/AllAboutEverythingEpisode4.mp3"
+            />
+            <guid>F0C5D763-ED85-4449-9C09-81FEBDF6F126</guid>
+            <pubDate>Tue, 23 Oct 2018 01:15:00 +0000</pubDate>
+            <itunes:duration>1440</itunes:duration>
+            <itunes:explicit>false</itunes:explicit>
+        </item>
+        <item>
+            <itunes:episodeType>full</itunes:episodeType>
+            <itunes:episode>2</itunes:episode>
+            <itunes:season>1</itunes:season>
+            <title>S01 EP02 Garden of the Gods Wilderness</title>
+            <description>
+                Wilderness Area Garden of the Gods in Illinois is a delightful spot for
+                an extended hike.
+            </description>
+            <enclosure
+                length="498537"
+                type="audio/mpeg"
+                url="http://example.com/podcasts/everything/AllAboutEverythingEpisode4.mp3"
+            />
+            <guid>821DD0B2-571D-4DFD-8E11-556E8C1EFE6A</guid>
+            <pubDate>Tue, 18 Sep 2018 01:15:00 +0000</pubDate>
+            <itunes:duration>839</itunes:duration>
+            <itunes:explicit>false</itunes:explicit>
+        </item>
+        <item>
+            <itunes:episodeType>full</itunes:episodeType>
+            <itunes:episode>1</itunes:episode>
+            <itunes:season>1</itunes:season>
+            <title>S01 EP01 Upper Priest Lake Trail to Continental Creek Trail</title>
+            <description>
+                We check out this powerfully scenic hike following the river in the Idaho
+                Panhandle National Forests.
+            </description>
+            <enclosure
+                length="498537"
+                type="audio/mpeg"
+                url="http://example.com/podcasts/everything/AllAboutEverythingEpisode4.mp3"
+            />
+            <guid>EABDA7EE-1AC6-4B60-9E11-6B3F30B72F87</guid>
+            <pubDate>Tue, 14 Aug 2018 01:15:00 +0000</pubDate>
+            <itunes:duration>1399</itunes:duration>
+            <itunes:explicit>false</itunes:explicit>
+        </item>
+    </channel>
+</rss>

--- a/tests/fixtures/podcast.xml
+++ b/tests/fixtures/podcast.xml
@@ -78,7 +78,7 @@
             <itunes:image
                 href="http://example.com/podcasts/everything/AllAboutEverything/Episode2.jpg"
             />
-            <link>href="http://example.com/podcasts/everything/</link>
+            <link>http://example.com/podcasts/everything/</link>
             <enclosure
                 length="5650889"
                 type="video/mp4"


### PR DESCRIPTION
## Summary

Fixes #2160

Some podcast feeds have a stale `pubDate` (set once at creation and never updated) while only updating `lastBuildDate` when new episodes are published. For example, the Lanz + Precht podcast:

```xml
<pubDate>Tue, 31 Aug 2021 12:03:00 +0200</pubDate>
<lastBuildDate>Mon, 20 Apr 2026 21:02:10 +0200</lastBuildDate>
```

The old code used `pubDate ?? lastBuildDate` (null coalescing), so when `pubDate` existed but was stale, `lastBuildDate` was never checked. The freshness comparison `pubDate < last_synced_at` evaluated to true, causing `refreshPodcast()` to return early without syncing any episodes.

**Fix:** Parse both dates, pick the most recent one, and use that for the freshness check.

## Test plan
- [x] New test: `refreshPodcastUsesLastBuildDateWhenPubDateIsStale` — verifies sync proceeds when `pubDate` is stale but `lastBuildDate` is recent
- [x] New fixture: `podcast-stale-pubdate.xml` — feed with both dates where pubDate is years behind lastBuildDate
- [x] All 24 podcast tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved podcast refresh so it derives and compares both feed pubDate and lastBuildDate, picking the most recent to avoid missing updates when pubDate is stale.

* **Tests**
  * Added an integration test for feeds with stale pubDate but newer lastBuildDate.
  * Added a new podcast feed fixture and fixed a malformed link in an existing fixture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->