### PR TITLE
fix: use default cursor on context menu items instead of text cursor

### DIFF
--- a/resources/assets/css/partials/context-menu.pcss
+++ b/resources/assets/css/partials/context-menu.pcss
@@ -6,7 +6,7 @@
   }
 
   li {
-    @apply relative px-4 py-1.5 text-k-fg leading-7;
+    @apply relative px-4 py-1.5 text-k-fg leading-7 cursor-default;
     @apply whitespace-nowrap;
 
     &.with-icon,


### PR DESCRIPTION
## Problem
The items in the profile dropdown (and every other context menu) show the text cursor (I-beam) on hover, because `.context-menu li` had no explicit `cursor` declaration — the browser falls back to `auto`, which renders as I-beam over text content.

## Fix
Add `cursor-default` (an arrow cursor) to `.context-menu li` in the global context-menu partial. This affects every context menu in the app — the bug was reported on the profile dropdown but is the same root cause everywhere.

## Test plan
- [x] All `ContextMenu*` unit tests still pass (10/10)
- [x] `vp check` clean
- [ ] Visually verify in a browser: hover over the profile dropdown items → cursor is the default arrow, not the I-beam
- [ ] Verify other context menus (e.g. song right-click menu) still look correct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated cursor styling for context menu items to display the default cursor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->