### PR TITLE
feat: include user's edit permission in album resource

### DIFF
--- a/app/Http/Resources/AlbumResource.php
+++ b/app/Http/Resources/AlbumResource.php
@@ -19,6 +19,9 @@ class AlbumResource extends JsonResource
         'cover',
         'created_at',
         'year',
+        'permissions' => [
+            'edit',
+        ],
     ];
 
     public const array PAGINATION_JSON_STRUCTURE = [
@@ -74,6 +77,9 @@ class AlbumResource extends JsonResource
             'year' => $this->album->year,
             'is_external' => $this->unless($embedding, fn () => $isPlus && $this->album->user_id !== $user->id),
             'favorite' => $this->unless($embedding, $this->album->favorite),
+            'permissions' => $this->unless($embedding, fn () => [
+                'edit' => $user->can('edit', $this->album),
+            ]),
         ];
     }
 }

--- a/resources/assets/js/__tests__/factory/albumFactory.ts
+++ b/resources/assets/js/__tests__/factory/albumFactory.ts
@@ -12,6 +12,9 @@ export default (): Album => {
     year: faker.date.past().getFullYear(),
     is_external: false,
     favorite: faker.datatype.boolean(),
+    permissions: {
+      edit: faker.datatype.boolean(),
+    },
   }
 }
 

--- a/resources/assets/js/components/album/AlbumContextMenu.spec.ts
+++ b/resources/assets/js/components/album/AlbumContextMenu.spec.ts
@@ -109,9 +109,6 @@ describe('albumContextMenu.vue', () => {
   it('requests edit form', async () => {
     const { album } = await renderComponent()
 
-    // for the "Edit…" menu item to show up
-    await h.tick(2)
-
     await h.user.click(screen.getByText('Edit…'))
 
     await assertOpenModal(openModalMock, EditAlbumForm, { album })

--- a/resources/assets/js/components/album/AlbumContextMenu.spec.ts
+++ b/resources/assets/js/components/album/AlbumContextMenu.spec.ts
@@ -7,7 +7,6 @@ import { downloadService } from '@/services/downloadService'
 import { playbackService } from '@/services/QueuePlaybackService'
 import { commonStore } from '@/stores/commonStore'
 import { playableStore } from '@/stores/playableStore'
-import { acl } from '@/services/acl'
 import EditAlbumForm from '@/components/album/EditAlbumForm.vue'
 import CreateEmbedForm from '@/components/embed/CreateEmbedForm.vue'
 
@@ -27,8 +26,6 @@ describe('albumContextMenu.vue', () => {
   })
 
   const renderComponent = async (album?: Album) => {
-    h.mock(acl, 'checkResourcePermission').mockReturnValue(true)
-
     if (!vi.isMockFunction(playableStore.fetchSongsForAlbum)) {
       h.mock(playableStore, 'fetchSongsForAlbum').mockResolvedValue([])
     }
@@ -38,6 +35,7 @@ describe('albumContextMenu.vue', () => {
       h.factory('album', {
         name: 'IV',
         favorite: false,
+        permissions: { edit: true },
       })
 
     const rendered = h.actingAsAdmin().render(Component, {

--- a/resources/assets/js/components/album/AlbumContextMenu.vue
+++ b/resources/assets/js/components/album/AlbumContextMenu.vue
@@ -48,7 +48,7 @@ const { openModal } = useModal()
 const { currentUserCan } = usePolicies()
 
 const allowDownload = toRef(commonStore.state, 'allows_download')
-const allowEdit = ref(false)
+const allowEdit = computed(() => currentUserCan.editAlbum(album.value))
 
 const isStandardAlbum = computed(() => !albumStore.isUnknown(album.value))
 
@@ -90,7 +90,6 @@ const toggleOffline = () =>
   })
 
 onMounted(async () => {
-  allowEdit.value = await currentUserCan.editAlbum(album.value)
   albumSongs.value = await playableStore.fetchSongsForAlbum(album.value)
 })
 </script>

--- a/resources/assets/js/components/album/__snapshots__/AlbumContextMenu.spec.ts.snap
+++ b/resources/assets/js/components/album/__snapshots__/AlbumContextMenu.spec.ts.snap
@@ -18,7 +18,11 @@ exports[`albumContextMenu.vue > renders 1`] = `
     <!--v-if-->
     <!--v-if-->
   </li>
-  <!--v-if-->
+  <li class="focus:outline-none focus:bg-k-highlight focus:text-k-highlight-fg hover:bg-k-highlight hover:text-k-highlight-fg" tabindex="-1">
+    <!--v-if--><span class="label flex-1 min-w-0 max-w-40 truncate">Edit…</span>
+    <!--v-if-->
+    <!--v-if-->
+  </li>
   <li class="separator"></li>
   <li class="focus:outline-none focus:bg-k-highlight focus:text-k-highlight-fg hover:bg-k-highlight hover:text-k-highlight-fg" tabindex="-1">
     <!--v-if--><span class="label flex-1 min-w-0 max-w-40 truncate">Download</span>

--- a/resources/assets/js/components/screens/AlbumScreen.vue
+++ b/resources/assets/js/components/screens/AlbumScreen.vue
@@ -196,7 +196,7 @@ const fetchScreenData = async () => {
     const restoredOrder = lsGet<SortOrder>('album-sort-order', 'asc')!
     sort(restoredField, restoredOrder)
 
-    editable.value = await currentUserCan.editAlbum(album.value!)
+    editable.value = currentUserCan.editAlbum(album.value!)
   } catch (error: unknown) {
     if ((error as any)?.status === 404) {
       triggerNotFound()

--- a/resources/assets/js/composables/usePolicies.spec.ts
+++ b/resources/assets/js/composables/usePolicies.spec.ts
@@ -74,13 +74,13 @@ describe('usePolicies', () => {
     expect(currentUserCan.editPlaylist(playlist)).toBe(false)
   })
 
-  it('delegates album editing to ACL', async () => {
-    const checkMock = h.mock(acl, 'checkResourcePermission').mockResolvedValue(true)
+  it('reads the edit permission embedded in the album', () => {
     const { currentUserCan } = usePolicies()
-    const album = h.factory('album')
+    const editable = h.factory('album', { permissions: { edit: true } })
+    const readonly = h.factory('album', { permissions: { edit: false } })
 
-    await expect(currentUserCan.editAlbum(album)).resolves.toBe(true)
-    expect(checkMock).toHaveBeenCalledWith('album', album.id, 'edit')
+    expect(currentUserCan.editAlbum(editable)).toBe(true)
+    expect(currentUserCan.editAlbum(readonly)).toBe(false)
   })
 
   it('delegates artist editing to ACL', async () => {

--- a/resources/assets/js/composables/usePolicies.ts
+++ b/resources/assets/js/composables/usePolicies.ts
@@ -21,7 +21,7 @@ export const usePolicies = () => {
     },
 
     editPlaylist: (playlist: Playlist) => playlist.owner_id === currentUser.value.id,
-    editAlbum: async (album: Album) => await acl.checkResourcePermission('album', album.id, 'edit'),
+    editAlbum: (album: Album) => album.permissions.edit,
     editArtist: async (artist: Artist) => await acl.checkResourcePermission('artist', artist.id, 'edit'),
     editUser: async (user: User) => await acl.checkResourcePermission('user', user.id, 'edit'),
     deleteUser: async (user: User) => await acl.checkResourcePermission('user', user.id, 'delete'),

--- a/resources/assets/js/types.d.ts
+++ b/resources/assets/js/types.d.ts
@@ -142,6 +142,9 @@ interface Album {
   year: number | null
   is_external: boolean
   favorite: boolean
+  permissions: {
+    edit: boolean
+  }
 }
 
 interface IStreamable {

--- a/tests/Feature/AlbumTest.php
+++ b/tests/Feature/AlbumTest.php
@@ -157,4 +157,12 @@ class AlbumTest extends TestCase
 
         $this->getAs("api/albums/{$album->id}", create_user())->assertJsonPath('permissions.edit', false);
     }
+
+    #[Test]
+    public function showIncludesEditPermissionFalseForUnknownAlbum(): void
+    {
+        $album = Album::factory()->createOne(['name' => Album::UNKNOWN_NAME]);
+
+        $this->getAs("api/albums/{$album->id}", create_admin())->assertJsonPath('permissions.edit', false);
+    }
 }

--- a/tests/Feature/AlbumTest.php
+++ b/tests/Feature/AlbumTest.php
@@ -141,4 +141,20 @@ class AlbumTest extends TestCase
             create_user(),
         )->assertForbidden();
     }
+
+    #[Test]
+    public function showIncludesEditPermissionForAdmin(): void
+    {
+        $album = Album::factory()->createOne();
+
+        $this->getAs("api/albums/{$album->id}", create_admin())->assertJsonPath('permissions.edit', true);
+    }
+
+    #[Test]
+    public function showIncludesEditPermissionForRegularUser(): void
+    {
+        $album = Album::factory()->createOne();
+
+        $this->getAs("api/albums/{$album->id}", create_user())->assertJsonPath('permissions.edit', false);
+    }
 }

--- a/tests/Feature/KoelPlus/AlbumTest.php
+++ b/tests/Feature/KoelPlus/AlbumTest.php
@@ -67,4 +67,12 @@ class AlbumTest extends PlusTestCase
             $randomDude,
         )->assertForbidden();
     }
+
+    #[Test]
+    public function showIncludesEditPermissionForOwner(): void
+    {
+        $album = Album::factory()->createOne();
+
+        $this->getAs("api/albums/{$album->id}", $album->user)->assertJsonPath('permissions.edit', true);
+    }
 }


### PR DESCRIPTION
## Problem
Right-clicking an album triggers `currentUserCan.editAlbum`, which makes a synchronous HTTP call to `GET /acl/permissions/album/{id}/edit`. Every menu open pays a round trip just to decide whether to show "Edit…", visibly delaying the menu. The same call is made when entering an album screen.

## Fix
Embed the current user's edit ability on `AlbumResource` (the same Policy, computed server-side once per album). Frontend reads `album.permissions.edit` synchronously — zero extra HTTP per menu open or screen mount.

### Backend
- `AlbumResource` exposes a `permissions: { edit: bool }` object, computed via `$user->can('edit', $album)` (existing `AlbumPolicy::edit`).
- Excluded from public embed responses via the existing `unless($embedding, ...)` pattern.
- No N+1: `AlbumPolicy` only inspects scalar columns (`is_unknown`, `user_id`) plus a per-user-cached Spatie permission check. Codebase-wide `Model::preventLazyLoading()` would catch any future regression.

### Frontend
- `Album` TypeScript type gains `permissions: { edit: boolean }`.
- `currentUserCan.editAlbum` is now sync (returns `album.permissions.edit`), matching the existing `editPlaylist`/`editSong` pattern.
- `AlbumContextMenu` and `AlbumScreen` updated accordingly; `useMounted` async permission fetch dropped.

### Scope
Only `Album` for this PR. Other resources (`Artist`, `User`, `RadioStation`) still call the ACL endpoint and can be migrated separately following the same pattern.

## Test plan
- [x] Backend: `php artisan test tests/Feature/AlbumTest.php tests/Feature/KoelPlus/AlbumTest.php` (13/13 passing, includes new `permissions.edit` value assertions for admin/user/owner).
- [x] Frontend: `npx vp test run resources/assets/js/components/album resources/assets/js/composables/usePolicies.spec.ts resources/assets/js/components/screens/AlbumScreen.spec.ts` (45/45 passing, snapshot updated to reflect synchronous Edit menu rendering).
- [x] `vp check resources/assets` clean (format + lint).
- [x] PHPStan clean on changed files.
- [ ] Manual: open album context menus repeatedly and confirm Edit appears without delay.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Album API now includes a permissions object indicating whether the current user can edit an album.

* **Refactor**
  * UI and policy logic now read edit permission directly from album data, driving menu visibility and editable state synchronously.

* **Tests**
  * Updated and added tests and fixtures to assert permissions are present and correctly influence UI and API behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->