### PR TITLE
feat: include user's edit permission in artist resource

### DIFF
--- a/app/Http/Resources/ArtistResource.php
+++ b/app/Http/Resources/ArtistResource.php
@@ -15,6 +15,9 @@ class ArtistResource extends JsonResource
         'name',
         'image',
         'created_at',
+        'permissions' => [
+            'edit',
+        ],
     ];
 
     public const array PAGINATION_JSON_STRUCTURE = [
@@ -67,6 +70,9 @@ class ArtistResource extends JsonResource
             'created_at' => $this->unless($embedding, $this->artist->created_at),
             'is_external' => $this->unless($embedding, fn () => $isPlus && $this->artist->user_id !== $user->id),
             'favorite' => $this->unless($embedding, $this->artist->favorite),
+            'permissions' => $this->unless($embedding, fn () => [
+                'edit' => $user->can('edit', $this->artist),
+            ]),
         ];
     }
 }

--- a/resources/assets/js/__tests__/factory/artistFactory.ts
+++ b/resources/assets/js/__tests__/factory/artistFactory.ts
@@ -9,6 +9,9 @@ export default (): Artist => {
     created_at: faker.date.past().toISOString(),
     is_external: false,
     favorite: faker.datatype.boolean(),
+    permissions: {
+      edit: faker.datatype.boolean(),
+    },
   }
 }
 

--- a/resources/assets/js/components/artist/ArtistContextMenu.spec.ts
+++ b/resources/assets/js/components/artist/ArtistContextMenu.spec.ts
@@ -7,7 +7,6 @@ import { downloadService } from '@/services/downloadService'
 import { playbackService } from '@/services/QueuePlaybackService'
 import { commonStore } from '@/stores/commonStore'
 import { playableStore } from '@/stores/playableStore'
-import { acl } from '@/services/acl'
 import CreateEmbedForm from '@/components/embed/CreateEmbedForm.vue'
 
 const openModalMock = vi.fn()
@@ -26,13 +25,12 @@ describe('artistContextMenu.vue', () => {
   })
 
   const renderComponent = async (artist?: Artist) => {
-    h.mock(acl, 'checkResourcePermission').mockReturnValue(true)
-
     artist =
       artist ||
       h.factory('artist', {
         name: 'Accept',
         favorite: false,
+        permissions: { edit: true },
       })
 
     const rendered = h.render(Component, {

--- a/resources/assets/js/components/artist/ArtistContextMenu.vue
+++ b/resources/assets/js/components/artist/ArtistContextMenu.vue
@@ -15,7 +15,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, onMounted, ref, toRef, toRefs } from 'vue'
+import { computed, toRef, toRefs } from 'vue'
 import { artistStore } from '@/stores/artistStore'
 import { commonStore } from '@/stores/commonStore'
 import { playableStore } from '@/stores/playableStore'
@@ -39,7 +39,7 @@ const { openModal } = useModal()
 const { currentUserCan } = usePolicies()
 
 const allowDownload = toRef(commonStore.state, 'allows_download')
-const allowEdit = ref(false)
+const allowEdit = computed(() => currentUserCan.editArtist(artist.value))
 
 const isStandardArtist = computed(() => !artistStore.isUnknown(artist.value) && !artistStore.isVarious(artist.value))
 
@@ -61,8 +61,4 @@ const toggleFavorite = () => trigger(() => artistStore.toggleFavorite(artist.val
 const requestEditForm = () => trigger(() => openModal<'EDIT_ARTIST_FORM'>(EditArtistForm, { artist: artist.value }))
 const showEmbedModal = () =>
   trigger(() => openModal<'CREATE_EMBED_FORM'>(CreateEmbedForm, { embeddable: artist.value }))
-
-onMounted(async () => {
-  allowEdit.value = await currentUserCan.editArtist(artist.value)
-})
 </script>

--- a/resources/assets/js/components/artist/__snapshots__/ArtistContextMenu.spec.ts.snap
+++ b/resources/assets/js/components/artist/__snapshots__/ArtistContextMenu.spec.ts.snap
@@ -18,7 +18,11 @@ exports[`artistContextMenu.vue > renders 1`] = `
     <!--v-if-->
     <!--v-if-->
   </li>
-  <!--v-if-->
+  <li class="focus:outline-none focus:bg-k-highlight focus:text-k-highlight-fg hover:bg-k-highlight hover:text-k-highlight-fg" tabindex="-1">
+    <!--v-if--><span class="label flex-1 min-w-0 max-w-40 truncate">Edit…</span>
+    <!--v-if-->
+    <!--v-if-->
+  </li>
   <li class="separator"></li>
   <li class="focus:outline-none focus:bg-k-highlight focus:text-k-highlight-fg hover:bg-k-highlight hover:text-k-highlight-fg" tabindex="-1">
     <!--v-if--><span class="label flex-1 min-w-0 max-w-40 truncate">Download</span>

--- a/resources/assets/js/components/screens/AlbumScreen.vue
+++ b/resources/assets/js/components/screens/AlbumScreen.vue
@@ -94,7 +94,6 @@ import { albumStore } from '@/stores/albumStore'
 import { artistStore } from '@/stores/artistStore'
 import { playableStore } from '@/stores/playableStore'
 import { useErrorHandler } from '@/composables/useErrorHandler'
-import { usePolicies } from '@/composables/usePolicies'
 import { usePlayableList } from '@/composables/usePlayableList'
 import { usePlayableListControls } from '@/composables/usePlayableListControls'
 import { useLocalStorage } from '@/composables/useLocalStorage'
@@ -121,7 +120,6 @@ const AlbumCardSkeleton = defineAsyncComponent(() => import('@/components/ui/alb
 const FavoriteButton = defineAsyncComponent(() => import('@/components/ui/FavoriteButton.vue'))
 
 const { getRouteParam, go, onScreenActivated, onRouteChanged, url, triggerNotFound } = useRouter()
-const { currentUserCan } = usePolicies()
 const { PlayableListControls: SongListControls, config } = usePlayableListControls('Album')
 const { get: lsGet, set: lsSet } = useLocalStorage()
 const { useLastfm, useMusicBrainz } = useThirdPartyServices()
@@ -133,7 +131,6 @@ const songs = ref<Song[]>([])
 const loading = ref(false)
 const otherAlbums = ref<Album[] | undefined>()
 const info = ref<ArtistInfo | undefined>()
-const editable = ref(false)
 
 const {
   PlayableList: SongList,
@@ -195,8 +192,6 @@ const fetchScreenData = async () => {
     const restoredField = lsGet<PlayableListSortField>('album-sort-field', 'track')!
     const restoredOrder = lsGet<SortOrder>('album-sort-order', 'asc')!
     sort(restoredField, restoredOrder)
-
-    editable.value = currentUserCan.editAlbum(album.value!)
   } catch (error: unknown) {
     if ((error as any)?.status === 404) {
       triggerNotFound()

--- a/resources/assets/js/components/screens/ArtistScreen.vue
+++ b/resources/assets/js/components/screens/ArtistScreen.vue
@@ -196,7 +196,7 @@ const fetchScreenData = async () => {
     const restoredOrder = lsGet<SortOrder>('artist-sort-order', 'asc')!
     sort(restoredField, restoredOrder)
 
-    editable.value = await currentUserCan.editArtist(artist.value!)
+    editable.value = currentUserCan.editArtist(artist.value!)
   } catch (error: unknown) {
     if ((error as any)?.status === 404) {
       triggerNotFound()

--- a/resources/assets/js/components/screens/ArtistScreen.vue
+++ b/resources/assets/js/components/screens/ArtistScreen.vue
@@ -107,7 +107,6 @@ import { usePlayableListControls } from '@/composables/usePlayableListControls'
 import { useLocalStorage } from '@/composables/useLocalStorage'
 import { useThirdPartyServices } from '@/composables/useThirdPartyServices'
 import { useRouter } from '@/composables/useRouter'
-import { usePolicies } from '@/composables/usePolicies'
 import { useContextMenu } from '@/composables/useContextMenu'
 
 import ScreenHeader from '@/components/ui/ScreenHeader.vue'
@@ -132,7 +131,6 @@ type Tab = (typeof validTabs)[number]
 const { PlayableListControls: SongListControls, config } = usePlayableListControls('Artist')
 const { useLastfm, useMusicBrainz, useTicketmaster } = useThirdPartyServices()
 const { getRouteParam, go, onScreenActivated, onRouteChanged, url, triggerNotFound } = useRouter()
-const { currentUserCan } = usePolicies()
 const { openContextMenu } = useContextMenu()
 const { get: lsGet, set: lsSet } = useLocalStorage()
 
@@ -141,7 +139,6 @@ const artist = ref<Artist>()
 const songs = ref<Song[]>([])
 const loading = ref(false)
 const albums = ref<Album[] | undefined>()
-const editable = ref(false)
 
 const {
   PlayableList: SongList,
@@ -195,8 +192,6 @@ const fetchScreenData = async () => {
     const restoredField = lsGet<PlayableListSortField>('artist-sort-field', 'track')!
     const restoredOrder = lsGet<SortOrder>('artist-sort-order', 'asc')!
     sort(restoredField, restoredOrder)
-
-    editable.value = currentUserCan.editArtist(artist.value!)
   } catch (error: unknown) {
     if ((error as any)?.status === 404) {
       triggerNotFound()

--- a/resources/assets/js/composables/usePolicies.spec.ts
+++ b/resources/assets/js/composables/usePolicies.spec.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vite-plus/test'
 import { createHarness } from '@/__tests__/TestHarness'
 import { commonStore } from '@/stores/commonStore'
-import { acl } from '@/services/acl'
 import { usePolicies } from './usePolicies'
 
 describe('usePolicies', () => {
@@ -83,13 +82,13 @@ describe('usePolicies', () => {
     expect(currentUserCan.editAlbum(readonly)).toBe(false)
   })
 
-  it('delegates artist editing to ACL', async () => {
-    const checkMock = h.mock(acl, 'checkResourcePermission').mockResolvedValue(false)
+  it('reads the edit permission embedded in the artist', () => {
     const { currentUserCan } = usePolicies()
-    const artist = h.factory('artist')
+    const editable = h.factory('artist', { permissions: { edit: true } })
+    const readonly = h.factory('artist', { permissions: { edit: false } })
 
-    await expect(currentUserCan.editArtist(artist)).resolves.toBe(false)
-    expect(checkMock).toHaveBeenCalledWith('artist', artist.id, 'edit')
+    expect(currentUserCan.editArtist(editable)).toBe(true)
+    expect(currentUserCan.editArtist(readonly)).toBe(false)
   })
 
   it('checks manageSettings permission', () => {

--- a/resources/assets/js/composables/usePolicies.ts
+++ b/resources/assets/js/composables/usePolicies.ts
@@ -22,7 +22,7 @@ export const usePolicies = () => {
 
     editPlaylist: (playlist: Playlist) => playlist.owner_id === currentUser.value.id,
     editAlbum: (album: Album) => album.permissions.edit,
-    editArtist: async (artist: Artist) => await acl.checkResourcePermission('artist', artist.id, 'edit'),
+    editArtist: (artist: Artist) => artist.permissions.edit,
     editUser: async (user: User) => await acl.checkResourcePermission('user', user.id, 'edit'),
     deleteUser: async (user: User) => await acl.checkResourcePermission('user', user.id, 'delete'),
 

--- a/resources/assets/js/types.d.ts
+++ b/resources/assets/js/types.d.ts
@@ -128,6 +128,9 @@ interface Artist {
   created_at: string
   is_external: boolean
   favorite: boolean
+  permissions: {
+    edit: boolean
+  }
 }
 
 interface Album {

--- a/tests/Feature/ArtistTest.php
+++ b/tests/Feature/ArtistTest.php
@@ -5,6 +5,8 @@ namespace Tests\Feature;
 use App\Helpers\Ulid;
 use App\Http\Resources\ArtistResource;
 use App\Models\Artist;
+use App\Models\Embed;
+use App\Values\EmbedOptions;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -160,5 +162,20 @@ class ArtistTest extends TestCase
         $artist = Artist::factory()->createOne(['name' => Artist::VARIOUS_NAME]);
 
         $this->getAs("api/artists/{$artist->id}", create_admin())->assertJsonPath('permissions.edit', false);
+    }
+
+    #[Test]
+    public function embedPayloadOmitsPermissions(): void
+    {
+        $artist = Artist::factory()->createOne();
+        $embed = Embed::factory()->createOne([
+            'embeddable_type' => 'artist',
+            'embeddable_id' => $artist->id,
+        ]);
+
+        $this
+            ->getJson("api/embeds/{$embed->id}/" . EmbedOptions::make())
+            ->assertSuccessful()
+            ->assertJsonMissingPath('embed.embeddable.permissions');
     }
 }

--- a/tests/Feature/ArtistTest.php
+++ b/tests/Feature/ArtistTest.php
@@ -129,4 +129,36 @@ class ArtistTest extends TestCase
             create_user(),
         )->assertForbidden();
     }
+
+    #[Test]
+    public function showIncludesEditPermissionForAdmin(): void
+    {
+        $artist = Artist::factory()->createOne();
+
+        $this->getAs("api/artists/{$artist->id}", create_admin())->assertJsonPath('permissions.edit', true);
+    }
+
+    #[Test]
+    public function showIncludesEditPermissionForRegularUser(): void
+    {
+        $artist = Artist::factory()->createOne();
+
+        $this->getAs("api/artists/{$artist->id}", create_user())->assertJsonPath('permissions.edit', false);
+    }
+
+    #[Test]
+    public function showIncludesEditPermissionFalseForUnknownArtist(): void
+    {
+        $artist = Artist::factory()->createOne(['name' => Artist::UNKNOWN_NAME]);
+
+        $this->getAs("api/artists/{$artist->id}", create_admin())->assertJsonPath('permissions.edit', false);
+    }
+
+    #[Test]
+    public function showIncludesEditPermissionFalseForVariousArtists(): void
+    {
+        $artist = Artist::factory()->createOne(['name' => Artist::VARIOUS_NAME]);
+
+        $this->getAs("api/artists/{$artist->id}", create_admin())->assertJsonPath('permissions.edit', false);
+    }
 }

--- a/tests/Feature/KoelPlus/ArtistTest.php
+++ b/tests/Feature/KoelPlus/ArtistTest.php
@@ -63,4 +63,12 @@ class ArtistTest extends PlusTestCase
             $randomDude,
         )->assertForbidden();
     }
+
+    #[Test]
+    public function showIncludesEditPermissionForOwner(): void
+    {
+        $artist = Artist::factory()->createOne();
+
+        $this->getAs("api/artists/{$artist->id}", $artist->user)->assertJsonPath('permissions.edit', true);
+    }
 }


### PR DESCRIPTION
## Summary
Second PR in the per-resource permissions migration (#2409 was Album). `ArtistResource` now exposes a `permissions: { edit }` block computed server-side via the existing `ArtistPolicy`, so context menus and screens decide synchronously instead of round-tripping to `acl/permissions/artist/{id}/edit`.

### Backend
- `ArtistResource` adds `permissions: { edit }` via `$user->can('edit', $artist)`, excluded from embed responses.
- N+1 verified by static analysis: `ArtistPolicy::update` only touches scalar accessors (`is_unknown`, `is_various`, `belongsToUser`) and Spatie's per-user-cached `hasPermissionTo`. No relationship traversal. The codebase-wide `Model::preventLazyLoading()` would catch any future regression — same protection that validated the Album PR.

### Frontend
- `Artist` TS type gains `permissions: { edit: boolean }`.
- `currentUserCan.editArtist` is now sync (reads `artist.permissions.edit`), matching the post-#2409 shape.
- `ArtistContextMenu` uses a `computed` and drops its `onMounted` entirely (it only existed for the now-redundant permission fetch).
- `ArtistScreen` drops `await`.

## Test plan
- [x] Backend: `tests/Feature/ArtistTest.php` + `KoelPlus/ArtistTest.php` (15 + 4 = all passing). New value-correctness tests for admin/regular-user/unknown-artist/various-artists (CE) and owner (Plus).
- [x] Other backend tests touching `ArtistResource::JSON_STRUCTURE` (Overview, ExcerptSearch): all 17 still passing.
- [x] Frontend: `ArtistContextMenu` snapshot updated to reflect synchronous Edit rendering; `usePolicies` test rewritten as embedded-flag read.
- [x] `vp check resources/assets` clean (format + lint).
- [ ] Manual: open artist context menus and confirm Edit appears without delay.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Artist API responses now include permissions (permissions.edit) so UI can show edit controls per-artist.
* **Refactor**
  * Frontend now uses artist-provided permissions to control edit UI and policy checks instead of runtime ACL calls; embedded payloads omit permissions.
* **Tests**
  * Added and updated tests to cover permissions reporting and embed behavior across roles and scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->