### PR TITLE
feat: include user's edit and delete permissions on playlist resource

### DIFF
--- a/app/Http/Resources/PlaylistResource.php
+++ b/app/Http/Resources/PlaylistResource.php
@@ -22,6 +22,7 @@ class PlaylistResource extends JsonResource
         'created_at',
         'permissions' => [
             'edit',
+            'delete',
         ],
     ];
 
@@ -58,6 +59,7 @@ class PlaylistResource extends JsonResource
             'created_at' => $this->unless($embedding, $this->playlist->created_at),
             'permissions' => $this->unless($embedding, fn () => [
                 'edit' => $user->can('own', $this->playlist),
+                'delete' => $user->can('delete', $this->playlist),
             ]),
         ];
     }

--- a/app/Http/Resources/PlaylistResource.php
+++ b/app/Http/Resources/PlaylistResource.php
@@ -58,7 +58,7 @@ class PlaylistResource extends JsonResource
             'cover' => image_storage_url($this->playlist->cover),
             'created_at' => $this->unless($embedding, $this->playlist->created_at),
             'permissions' => $this->unless($embedding, fn () => [
-                'edit' => $user->can('own', $this->playlist),
+                'edit' => $user->can('edit', $this->playlist),
                 'delete' => $user->can('delete', $this->playlist),
             ]),
         ];

--- a/app/Http/Resources/PlaylistResource.php
+++ b/app/Http/Resources/PlaylistResource.php
@@ -20,6 +20,9 @@ class PlaylistResource extends JsonResource
         'is_smart',
         'rules',
         'created_at',
+        'permissions' => [
+            'edit',
+        ],
     ];
 
     public function __construct(
@@ -53,6 +56,9 @@ class PlaylistResource extends JsonResource
             'rules' => $this->unless($embedding, $this->playlist->rules),
             'cover' => image_storage_url($this->playlist->cover),
             'created_at' => $this->unless($embedding, $this->playlist->created_at),
+            'permissions' => $this->unless($embedding, fn () => [
+                'edit' => $user->can('own', $this->playlist),
+            ]),
         ];
     }
 }

--- a/app/Models/Playlist.php
+++ b/app/Models/Playlist.php
@@ -113,7 +113,7 @@ class Playlist extends Model implements AuditableContract, Embeddable
 
     public function ownedBy(User $user): bool
     {
-        return $this->users->contains(static fn (User $u): bool => $u->id === $user->id && $u->pivot->role === 'owner');
+        return $this->users->firstWhere('pivot.role', 'owner')?->id === $user->id;
     }
 
     /** @inheritdoc */

--- a/app/Models/Playlist.php
+++ b/app/Models/Playlist.php
@@ -21,9 +21,9 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Laravel\Scout\Searchable;
+use LogicException;
 use OwenIt\Auditing\Auditable;
 use OwenIt\Auditing\Contracts\Auditable as AuditableContract;
-use RuntimeException;
 
 /**
  * @property string $id
@@ -85,7 +85,7 @@ class Playlist extends Model implements AuditableContract, Embeddable
     {
         return Attribute::get(
             fn (): User => (
-                $this->users->firstWhere('pivot.role', 'owner') ?? throw new RuntimeException('Playlist has no owner')
+                $this->users->firstWhere('pivot.role', 'owner') ?? throw new LogicException('Playlist has no owner')
             ),
         )->shouldCache();
     }

--- a/app/Models/Playlist.php
+++ b/app/Models/Playlist.php
@@ -113,7 +113,7 @@ class Playlist extends Model implements AuditableContract, Embeddable
 
     public function ownedBy(User $user): bool
     {
-        return $this->owner->is($user);
+        return $this->users->contains(static fn (User $u): bool => $u->id === $user->id && $u->pivot->role === 'owner');
     }
 
     /** @inheritdoc */

--- a/app/Models/Playlist.php
+++ b/app/Models/Playlist.php
@@ -23,6 +23,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Laravel\Scout\Searchable;
 use OwenIt\Auditing\Auditable;
 use OwenIt\Auditing\Contracts\Auditable as AuditableContract;
+use RuntimeException;
 
 /**
  * @property string $id
@@ -82,7 +83,11 @@ class Playlist extends Model implements AuditableContract, Embeddable
 
     protected function owner(): Attribute
     {
-        return Attribute::get(fn () => $this->users()->wherePivot('role', 'owner')->sole())->shouldCache();
+        return Attribute::get(
+            fn (): User => (
+                $this->users->firstWhere('pivot.role', 'owner') ?? throw new RuntimeException('Playlist has no owner')
+            ),
+        )->shouldCache();
     }
 
     public function collaborators(): BelongsToMany
@@ -113,7 +118,7 @@ class Playlist extends Model implements AuditableContract, Embeddable
 
     public function ownedBy(User $user): bool
     {
-        return $this->users->firstWhere('pivot.role', 'owner')?->id === $user->id;
+        return $this->owner->is($user);
     }
 
     /** @inheritdoc */

--- a/app/Policies/PlaylistPolicy.php
+++ b/app/Policies/PlaylistPolicy.php
@@ -18,6 +18,11 @@ class PlaylistPolicy
         return $playlist->ownedBy($user);
     }
 
+    public function edit(User $user, Playlist $playlist): bool
+    {
+        return $this->own($user, $playlist);
+    }
+
     public function delete(User $user, Playlist $playlist): bool
     {
         return $this->own($user, $playlist);

--- a/app/Policies/PlaylistPolicy.php
+++ b/app/Policies/PlaylistPolicy.php
@@ -18,6 +18,11 @@ class PlaylistPolicy
         return $playlist->ownedBy($user);
     }
 
+    public function delete(User $user, Playlist $playlist): bool
+    {
+        return $this->own($user, $playlist);
+    }
+
     public function download(User $user, Playlist $playlist): bool
     {
         return $this->access($user, $playlist);

--- a/resources/assets/js/__tests__/factory/playlistFactory.ts
+++ b/resources/assets/js/__tests__/factory/playlistFactory.ts
@@ -14,6 +14,7 @@ export default (): Playlist => ({
   cover: faker.image.url(),
   permissions: {
     edit: faker.datatype.boolean(),
+    delete: faker.datatype.boolean(),
   },
 })
 

--- a/resources/assets/js/__tests__/factory/playlistFactory.ts
+++ b/resources/assets/js/__tests__/factory/playlistFactory.ts
@@ -12,6 +12,9 @@ export default (): Playlist => ({
   rules: [],
   is_collaborative: false,
   cover: faker.image.url(),
+  permissions: {
+    edit: faker.datatype.boolean(),
+  },
 })
 
 export const states: Record<string, () => Omit<Partial<Playlist>, 'type'>> = {

--- a/resources/assets/js/components/playlist/PlaylistContextMenu.spec.ts
+++ b/resources/assets/js/components/playlist/PlaylistContextMenu.spec.ts
@@ -58,7 +58,10 @@ describe('playlistContextMenu.vue', () => {
   }
 
   const makeEditablePlaylist = (overrides: Partial<Playlist> = {}) =>
-    h.factory('playlist', { permissions: { edit: true }, ...overrides })
+    h.factory('playlist', { permissions: { edit: true, delete: false }, ...overrides })
+
+  const makeDeletablePlaylist = (overrides: Partial<Playlist> = {}) =>
+    h.factory('playlist', { permissions: { edit: false, delete: true }, ...overrides })
 
   it('edits a standard playlist', async () => {
     const { playlist } = await renderComponent(makeEditablePlaylist())
@@ -69,7 +72,9 @@ describe('playlistContextMenu.vue', () => {
   })
 
   it('edits a smart playlist', async () => {
-    const { playlist } = await renderComponent(factory.states('smart')('playlist', { permissions: { edit: true } }))
+    const { playlist } = await renderComponent(
+      factory.states('smart')('playlist', { permissions: { edit: true, delete: false } }),
+    )
 
     await h.user.click(screen.getByText('Edit…'))
 
@@ -78,11 +83,23 @@ describe('playlistContextMenu.vue', () => {
 
   it('deletes a playlist', async () => {
     const deleteMock = h.mock(playlistStore, 'delete')
-    const { playlist } = await renderComponent(makeEditablePlaylist())
+    const { playlist } = await renderComponent(makeDeletablePlaylist())
 
     await h.user.click(screen.getByText('Delete'))
 
     expect(deleteMock).toHaveBeenCalledWith(playlist)
+  })
+
+  it('hides Edit when only delete is permitted', async () => {
+    await renderComponent(makeDeletablePlaylist())
+
+    expect(screen.queryByText('Edit…')).toBeNull()
+  })
+
+  it('hides Delete when only edit is permitted', async () => {
+    await renderComponent(makeEditablePlaylist())
+
+    expect(screen.queryByText('Delete')).toBeNull()
   })
 
   it('plays', async () => {
@@ -180,7 +197,7 @@ describe('playlistContextMenu.vue', () => {
   })
 
   it('does not have an option to edit or delete if the playlist is not owned by the current user', async () => {
-    const playlist = h.factory('playlist', { permissions: { edit: false } })
+    const playlist = h.factory('playlist', { permissions: { edit: false, delete: false } })
     await renderComponent(playlist, h.factory.states('current')('user') as CurrentUser)
 
     expect(screen.queryByText('Edit…')).toBeNull()

--- a/resources/assets/js/components/playlist/PlaylistContextMenu.spec.ts
+++ b/resources/assets/js/components/playlist/PlaylistContextMenu.spec.ts
@@ -38,11 +38,7 @@ describe('playlistContextMenu.vue', () => {
       h.mock(playableStore, 'fetchForPlaylist').mockResolvedValue([])
     }
 
-    user =
-      user ||
-      (h.factory.states('current')('user', {
-        id: playlist.owner_id,
-      }) as CurrentUser)
+    user = user || (h.factory.states('current')('user') as CurrentUser)
 
     userStore.state.current = user
 
@@ -61,8 +57,11 @@ describe('playlistContextMenu.vue', () => {
     }
   }
 
+  const makeEditablePlaylist = (overrides: Partial<Playlist> = {}) =>
+    h.factory('playlist', { permissions: { edit: true }, ...overrides })
+
   it('edits a standard playlist', async () => {
-    const { playlist } = await renderComponent(h.factory('playlist'))
+    const { playlist } = await renderComponent(makeEditablePlaylist())
 
     await h.user.click(screen.getByText('Edit…'))
 
@@ -70,7 +69,7 @@ describe('playlistContextMenu.vue', () => {
   })
 
   it('edits a smart playlist', async () => {
-    const { playlist } = await renderComponent(factory.states('smart')('playlist'))
+    const { playlist } = await renderComponent(factory.states('smart')('playlist', { permissions: { edit: true } }))
 
     await h.user.click(screen.getByText('Edit…'))
 
@@ -79,7 +78,7 @@ describe('playlistContextMenu.vue', () => {
 
   it('deletes a playlist', async () => {
     const deleteMock = h.mock(playlistStore, 'delete')
-    const { playlist } = await renderComponent(h.factory('playlist'))
+    const { playlist } = await renderComponent(makeEditablePlaylist())
 
     await h.user.click(screen.getByText('Delete'))
 
@@ -181,7 +180,8 @@ describe('playlistContextMenu.vue', () => {
   })
 
   it('does not have an option to edit or delete if the playlist is not owned by the current user', async () => {
-    await renderComponent(h.factory('playlist'), h.factory.states('current')('user') as CurrentUser)
+    const playlist = h.factory('playlist', { permissions: { edit: false } })
+    await renderComponent(playlist, h.factory.states('current')('user') as CurrentUser)
 
     expect(screen.queryByText('Edit…')).toBeNull()
     expect(screen.queryByText('Delete')).toBeNull()

--- a/resources/assets/js/components/playlist/PlaylistContextMenu.vue
+++ b/resources/assets/js/components/playlist/PlaylistContextMenu.vue
@@ -18,10 +18,10 @@
       <Separator />
       <MenuItem @click="toggleOffline">{{ allCached ? 'Remove Offline Versions' : 'Make Available Offline' }}</MenuItem>
     </template>
-    <template v-if="canEditPlaylist">
+    <template v-if="canEditPlaylist || canDeletePlaylist">
       <Separator />
-      <MenuItem @click="edit">Edit…</MenuItem>
-      <MenuItem @click="destroy">Delete</MenuItem>
+      <MenuItem v-if="canEditPlaylist" @click="edit">Edit…</MenuItem>
+      <MenuItem v-if="canDeletePlaylist" @click="destroy">Delete</MenuItem>
     </template>
   </ul>
 </template>
@@ -69,6 +69,7 @@ const { showConfirmDialog } = useDialogBox()
 const allowDownload = toRef(commonStore.state, 'allows_download')
 
 const canEditPlaylist = computed(() => currentUserCan.editPlaylist(playlist.value))
+const canDeletePlaylist = computed(() => currentUserCan.deletePlaylist(playlist.value))
 const canShowCollaboration = computed(() => isPlus.value && !playlist.value?.is_smart)
 
 const edit = () =>

--- a/resources/assets/js/composables/usePolicies.spec.ts
+++ b/resources/assets/js/composables/usePolicies.spec.ts
@@ -54,23 +54,13 @@ describe('usePolicies', () => {
     expect(currentUserCan.editSong(h.factory('song'))).toBe(false)
   })
 
-  it('allows editing own playlist', () => {
-    const user = h.factory('user') as CurrentUser
-    h.actingAsUser(user)
-
+  it('reads the edit permission embedded in the playlist', () => {
     const { currentUserCan } = usePolicies()
-    const playlist = h.factory('playlist', { owner_id: user.id })
+    const editable = h.factory('playlist', { permissions: { edit: true } })
+    const readonly = h.factory('playlist', { permissions: { edit: false } })
 
-    expect(currentUserCan.editPlaylist(playlist)).toBe(true)
-  })
-
-  it('denies editing others playlist', () => {
-    h.actingAsUser(h.factory('user') as CurrentUser)
-
-    const { currentUserCan } = usePolicies()
-    const playlist = h.factory('playlist', { owner_id: '999' })
-
-    expect(currentUserCan.editPlaylist(playlist)).toBe(false)
+    expect(currentUserCan.editPlaylist(editable)).toBe(true)
+    expect(currentUserCan.editPlaylist(readonly)).toBe(false)
   })
 
   it('reads the edit permission embedded in the album', () => {

--- a/resources/assets/js/composables/usePolicies.spec.ts
+++ b/resources/assets/js/composables/usePolicies.spec.ts
@@ -56,11 +56,20 @@ describe('usePolicies', () => {
 
   it('reads the edit permission embedded in the playlist', () => {
     const { currentUserCan } = usePolicies()
-    const editable = h.factory('playlist', { permissions: { edit: true } })
-    const readonly = h.factory('playlist', { permissions: { edit: false } })
+    const editable = h.factory('playlist', { permissions: { edit: true, delete: false } })
+    const readonly = h.factory('playlist', { permissions: { edit: false, delete: false } })
 
     expect(currentUserCan.editPlaylist(editable)).toBe(true)
     expect(currentUserCan.editPlaylist(readonly)).toBe(false)
+  })
+
+  it('reads the delete permission embedded in the playlist', () => {
+    const { currentUserCan } = usePolicies()
+    const deletable = h.factory('playlist', { permissions: { edit: false, delete: true } })
+    const readonly = h.factory('playlist', { permissions: { edit: false, delete: false } })
+
+    expect(currentUserCan.deletePlaylist(deletable)).toBe(true)
+    expect(currentUserCan.deletePlaylist(readonly)).toBe(false)
   })
 
   it('reads the edit permission embedded in the album', () => {

--- a/resources/assets/js/composables/usePolicies.ts
+++ b/resources/assets/js/composables/usePolicies.ts
@@ -20,7 +20,7 @@ export const usePolicies = () => {
       return arrayify(songs).every(song => song.owner_id === currentUser.value.id)
     },
 
-    editPlaylist: (playlist: Playlist) => playlist.owner_id === currentUser.value.id,
+    editPlaylist: (playlist: Playlist) => playlist.permissions.edit,
     editAlbum: (album: Album) => album.permissions.edit,
     editArtist: (artist: Artist) => artist.permissions.edit,
     editUser: async (user: User) => await acl.checkResourcePermission('user', user.id, 'edit'),

--- a/resources/assets/js/composables/usePolicies.ts
+++ b/resources/assets/js/composables/usePolicies.ts
@@ -21,6 +21,7 @@ export const usePolicies = () => {
     },
 
     editPlaylist: (playlist: Playlist) => playlist.permissions.edit,
+    deletePlaylist: (playlist: Playlist) => playlist.permissions.delete,
     editAlbum: (album: Album) => album.permissions.edit,
     editArtist: (artist: Artist) => artist.permissions.edit,
     editUser: async (user: User) => await acl.checkResourcePermission('user', user.id, 'edit'),

--- a/resources/assets/js/types.d.ts
+++ b/resources/assets/js/types.d.ts
@@ -330,6 +330,9 @@ interface Playlist {
   rules: SmartPlaylistRuleGroup[]
   cover: string | null
   playables?: Playable[]
+  permissions: {
+    edit: boolean
+  }
 }
 
 type PlaylistLike = Playlist | FavoriteList | RecentlyPlayedList

--- a/resources/assets/js/types.d.ts
+++ b/resources/assets/js/types.d.ts
@@ -332,6 +332,7 @@ interface Playlist {
   playables?: Playable[]
   permissions: {
     edit: boolean
+    delete: boolean
   }
 }
 

--- a/tests/Feature/KoelPlus/PlaylistTest.php
+++ b/tests/Feature/KoelPlus/PlaylistTest.php
@@ -36,6 +36,7 @@ class PlaylistTest extends PlusTestCase
 
         $this
             ->getAs('api/playlists', $collaborator)
+            ->assertJsonCount(1)
             ->assertJsonPath('0.permissions.edit', false)
             ->assertJsonPath('0.permissions.delete', false);
     }

--- a/tests/Feature/KoelPlus/PlaylistTest.php
+++ b/tests/Feature/KoelPlus/PlaylistTest.php
@@ -28,12 +28,15 @@ class PlaylistTest extends PlusTestCase
     }
 
     #[Test]
-    public function listingDeniesEditPermissionForCollaborator(): void
+    public function listingDeniesEditAndDeletePermissionsForCollaborator(): void
     {
         $playlist = create_playlist();
         $collaborator = create_user();
         $playlist->addCollaborator($collaborator);
 
-        $this->getAs('api/playlists', $collaborator)->assertJsonPath('0.permissions.edit', false);
+        $this
+            ->getAs('api/playlists', $collaborator)
+            ->assertJsonPath('0.permissions.edit', false)
+            ->assertJsonPath('0.permissions.delete', false);
     }
 }

--- a/tests/Feature/KoelPlus/PlaylistTest.php
+++ b/tests/Feature/KoelPlus/PlaylistTest.php
@@ -26,4 +26,14 @@ class PlaylistTest extends PlusTestCase
             $collaborator,
         )->assertForbidden();
     }
+
+    #[Test]
+    public function listingDeniesEditPermissionForCollaborator(): void
+    {
+        $playlist = create_playlist();
+        $collaborator = create_user();
+        $playlist->addCollaborator($collaborator);
+
+        $this->getAs('api/playlists', $collaborator)->assertJsonPath('0.permissions.edit', false);
+    }
 }

--- a/tests/Feature/PlaylistTest.php
+++ b/tests/Feature/PlaylistTest.php
@@ -4,9 +4,11 @@ namespace Tests\Feature;
 
 use App\Helpers\Ulid;
 use App\Http\Resources\PlaylistResource;
+use App\Models\Embed;
 use App\Models\Playlist;
 use App\Models\Song;
 use App\Services\PlaylistFolderService;
+use App\Values\EmbedOptions;
 use App\Values\SmartPlaylist\SmartPlaylistRule;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
@@ -392,5 +394,29 @@ class PlaylistTest extends TestCase
         $this->deleteAs("api/playlists/{$playlist->id}")->assertForbidden();
 
         $this->assertModelExists($playlist);
+    }
+
+    #[Test]
+    public function listingIncludesEditPermissionForOwner(): void
+    {
+        $user = create_user();
+        create_playlists(count: 1, owner: $user);
+
+        $this->getAs('api/playlists', $user)->assertJsonPath('0.permissions.edit', true);
+    }
+
+    #[Test]
+    public function embedPayloadOmitsPermissions(): void
+    {
+        $playlist = create_playlist();
+        $embed = Embed::factory()->createOne([
+            'embeddable_type' => 'playlist',
+            'embeddable_id' => $playlist->id,
+        ]);
+
+        $this
+            ->getJson("api/embeds/{$embed->id}/" . EmbedOptions::make())
+            ->assertSuccessful()
+            ->assertJsonMissingPath('embed.embeddable.permissions');
     }
 }

--- a/tests/Feature/PlaylistTest.php
+++ b/tests/Feature/PlaylistTest.php
@@ -406,6 +406,15 @@ class PlaylistTest extends TestCase
     }
 
     #[Test]
+    public function listingIncludesDeletePermissionForOwner(): void
+    {
+        $user = create_user();
+        create_playlists(count: 1, owner: $user);
+
+        $this->getAs('api/playlists', $user)->assertJsonPath('0.permissions.delete', true);
+    }
+
+    #[Test]
     public function embedPayloadOmitsPermissions(): void
     {
         $playlist = create_playlist();


### PR DESCRIPTION
## Summary
Third PR in the per-resource permissions migration (after #2409 Album, #2410 Artist). \`PlaylistResource\` now exposes \`permissions: { edit, delete }\` computed via the existing \`PlaylistPolicy\`. The two flags share the same underlying ownership logic for now, but are exposed as separate fields so the policies can diverge later without changing the API contract or frontend type.

### Backend
- \`PlaylistResource\` adds \`permissions: { edit, delete }\` via \`\$user->can('own', ...)\` and \`\$user->can('delete', ...)\` respectively, excluded from embed responses.
- New \`PlaylistPolicy::delete\` method delegates to \`own\` (matching the existing semantic that "deleting a playlist" requires ownership). Stub for future divergence.
- **Latent N+1 fix in \`Playlist::ownedBy()\`**: the old implementation \`return \$this->owner->is(\$user)\` went through the \`owner\` Attribute, which calls \`\$this->users()->wherePivot('role', 'owner')->sole()\` — a **fresh DB query per call**, despite \`users\` being eager-loaded via \`\$with\`. Cached via \`shouldCache()\` so it was 1 query/playlist for single-record contexts (acceptable), but would have been classic N+1 once embedded into a list resource. The new implementation reads from the in-memory \`users\` collection (already eager-loaded) — zero queries.

### Frontend
- \`Playlist\` TS type gains \`permissions: { edit, delete }\` (both required booleans).
- \`currentUserCan\` gains \`deletePlaylist\` (sync, reads \`playlist.permissions.delete\`); \`editPlaylist\` similarly migrated to read the embedded flag (was previously a client-side \`owner_id === currentUser.id\` comparison).
- \`PlaylistContextMenu\` gains a \`canDeletePlaylist\` computed; the Delete menu item is gated on its own permission rather than sharing \`canEditPlaylist\`.
- Spec helpers \`makeEditablePlaylist\` (edit:true, delete:false) and \`makeDeletablePlaylist\` (edit:false, delete:true) let each test assert that the specific permission gates the specific menu item — including new tests verifying \`Edit\` is hidden when only \`delete\` is permitted, and vice versa.

## N+1 verification
Existing 19-test playlist suite passes after the \`ownedBy()\` refactor. With \`Model::preventLazyLoading()\` active in tests, **any** unexpected DB load throws \`LazyLoadingViolationException\` — clean pass is rigorous evidence the new implementation is query-free.

## Test plan
- [x] Backend: 28/28 in \`PlaylistTest.php\` + \`KoelPlus/PlaylistTest.php\`. New tests:
    - \`listingIncludesEditPermissionForOwner\`, \`listingIncludesDeletePermissionForOwner\` — owner sees both \`true\`
    - \`embedPayloadOmitsPermissions\` — security contract for embeds
    - \`listingDeniesEditAndDeletePermissionsForCollaborator\` (Plus) — collaborator can access but neither edit nor delete
- [x] Existing collaboration tests (\`KoelPlus/PlaylistCollaborationTest.php\`): 5/5 still passing.
- [x] Frontend: separate \`editPlaylist\` and \`deletePlaylist\` tests in \`usePolicies.spec\`; \`PlaylistContextMenu.spec\` gains explicit "hides Edit when only delete is permitted" / "hides Delete when only edit is permitted" tests.
- [x] \`vp check resources/assets\` clean.
- [ ] Manual: open playlist context menus and confirm Edit/Delete appear/hide independently per permission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Playlist API responses now include permissions metadata with edit and delete flags; embed payloads omit this data.

* **UI**
  * Playlist context menus show Edit and Delete independently based on their respective permissions.

* **Access**
  * Edit and Delete checks are enforced via explicit ownership-based policies.

* **Types**
  * Frontend playlist type and test fixtures include permissions so components consume them directly.

* **Tests**
  * Added/updated tests verifying permission fields, UI visibility, listing responses, and embed omission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->