### PR TITLE
feat: include user's edit and delete permissions on radio station resource

### DIFF
--- a/app/Http/Resources/RadioStationResource.php
+++ b/app/Http/Resources/RadioStationResource.php
@@ -17,6 +17,10 @@ class RadioStationResource extends JsonResource
         'description',
         'is_public',
         'created_at',
+        'permissions' => [
+            'edit',
+            'delete',
+        ],
     ];
 
     public function __construct(
@@ -28,6 +32,8 @@ class RadioStationResource extends JsonResource
     /** @inheritdoc */
     public function toArray(Request $request): array
     {
+        $user = $request->user();
+
         return [
             'type' => 'radio-stations',
             'name' => $this->station->name,
@@ -38,6 +44,10 @@ class RadioStationResource extends JsonResource
             'is_public' => $this->station->is_public,
             'created_at' => $this->station->created_at,
             'favorite' => $this->station->favorite,
+            'permissions' => [
+                'edit' => $user->can('edit', $this->station),
+                'delete' => $user->can('delete', $this->station),
+            ],
         ];
     }
 }

--- a/resources/assets/js/__tests__/factory/radioStationFactory.ts
+++ b/resources/assets/js/__tests__/factory/radioStationFactory.ts
@@ -12,5 +12,9 @@ export default (): RadioStation => {
     is_public: faker.datatype.boolean(),
     favorite: faker.datatype.boolean(),
     playback_state: 'Stopped',
+    permissions: {
+      edit: faker.datatype.boolean(),
+      delete: faker.datatype.boolean(),
+    },
   }
 }

--- a/resources/assets/js/components/radio/RadioStationContextMenu.spec.ts
+++ b/resources/assets/js/components/radio/RadioStationContextMenu.spec.ts
@@ -3,7 +3,6 @@ import { screen } from '@testing-library/vue'
 import { createHarness } from '@/__tests__/TestHarness'
 import { assertOpenModal } from '@/__tests__/assertions'
 import { playbackService } from '@/services/RadioPlaybackService'
-import { acl } from '@/services/acl'
 import { radioStationStore } from '@/stores/radioStationStore'
 import EditRadioStationForm from '@/components/radio/EditRadioStationForm.vue'
 
@@ -23,12 +22,11 @@ describe('radioStationContextMenu.vue', () => {
   })
 
   const renderComponent = async (station?: RadioStation, manageable = true) => {
-    h.mock(acl, 'checkResourcePermission').mockReturnValue(manageable)
-
     station =
       station ||
       h.factory('radio-station', {
         favorite: false,
+        permissions: { edit: manageable, delete: manageable },
       })
 
     const rendered = h.render(Component, {
@@ -36,9 +34,6 @@ describe('radioStationContextMenu.vue', () => {
         station,
       },
     })
-
-    // For all menu items (including Delete and Edit, which require permission checks) to be rendered
-    await h.tick(7)
 
     return {
       ...rendered,
@@ -62,6 +57,20 @@ describe('radioStationContextMenu.vue', () => {
     expect(screen.queryByText('Delete')).toBeNull()
     screen.getByText('Play')
     screen.getByText('Favorite')
+  })
+
+  it('hides Edit when only delete is permitted', async () => {
+    await renderComponent(h.factory('radio-station', { permissions: { edit: false, delete: true } }))
+
+    expect(screen.queryByText('Edit…')).toBeNull()
+    screen.getByText('Delete')
+  })
+
+  it('hides Delete when only edit is permitted', async () => {
+    await renderComponent(h.factory('radio-station', { permissions: { edit: true, delete: false } }))
+
+    expect(screen.queryByText('Delete')).toBeNull()
+    screen.getByText('Edit…')
   })
 
   it('plays', async () => {

--- a/resources/assets/js/components/radio/RadioStationContextMenu.vue
+++ b/resources/assets/js/components/radio/RadioStationContextMenu.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script lang="ts" setup>
-import { onMounted, ref, toRefs } from 'vue'
+import { computed, toRefs } from 'vue'
 import { defineAsyncComponent } from '@/utils/helpers'
 import { useContextMenu } from '@/composables/useContextMenu'
 import { useModal } from '@/composables/useModal'
@@ -33,8 +33,8 @@ const { toastSuccess } = useMessageToaster()
 const { showConfirmDialog } = useDialogBox()
 const { currentUserCan } = usePolicies()
 
-const allowEdit = ref(false)
-const allowDelete = ref(false)
+const allowEdit = computed(() => currentUserCan.editRadioStation(station.value))
+const allowDelete = computed(() => currentUserCan.deleteRadioStation(station.value))
 
 const togglePlayback = () =>
   trigger(async () => {
@@ -59,9 +59,4 @@ const maybeDelete = () =>
       toastSuccess(`Radio station deleted.`)
     }
   })
-
-onMounted(async () => {
-  allowEdit.value = await currentUserCan.editRadioStation(station.value)
-  allowDelete.value = await currentUserCan.deleteRadioStation(station.value)
-})
 </script>

--- a/resources/assets/js/composables/usePolicies.spec.ts
+++ b/resources/assets/js/composables/usePolicies.spec.ts
@@ -129,4 +129,22 @@ describe('usePolicies', () => {
     const { currentUserCan } = usePolicies()
     expect(currentUserCan.uploadSongs()).toBe(true)
   })
+
+  it('reads the edit permission embedded in the radio station', () => {
+    const { currentUserCan } = usePolicies()
+    const editable = h.factory('radio-station', { permissions: { edit: true, delete: false } })
+    const readonly = h.factory('radio-station', { permissions: { edit: false, delete: false } })
+
+    expect(currentUserCan.editRadioStation(editable)).toBe(true)
+    expect(currentUserCan.editRadioStation(readonly)).toBe(false)
+  })
+
+  it('reads the delete permission embedded in the radio station', () => {
+    const { currentUserCan } = usePolicies()
+    const deletable = h.factory('radio-station', { permissions: { edit: false, delete: true } })
+    const readonly = h.factory('radio-station', { permissions: { edit: false, delete: false } })
+
+    expect(currentUserCan.deleteRadioStation(deletable)).toBe(true)
+    expect(currentUserCan.deleteRadioStation(readonly)).toBe(false)
+  })
 })

--- a/resources/assets/js/composables/usePolicies.ts
+++ b/resources/assets/js/composables/usePolicies.ts
@@ -27,13 +27,8 @@ export const usePolicies = () => {
     editUser: async (user: User) => await acl.checkResourcePermission('user', user.id, 'edit'),
     deleteUser: async (user: User) => await acl.checkResourcePermission('user', user.id, 'delete'),
 
-    editRadioStation: async (station: RadioStation) => {
-      return await acl.checkResourcePermission('radio-station', station.id, 'edit')
-    },
-
-    deleteRadioStation: async (station: RadioStation) => {
-      return await acl.checkResourcePermission('radio-station', station.id, 'delete')
-    },
+    editRadioStation: (station: RadioStation) => station.permissions.edit,
+    deleteRadioStation: (station: RadioStation) => station.permissions.delete,
 
     // If the user has the permission, they can always add a radio station, even in demo mode.
     addRadioStation: () => !window.IS_DEMO || currentUser.value.permissions.includes('manage radio stations'),

--- a/resources/assets/js/types.d.ts
+++ b/resources/assets/js/types.d.ts
@@ -214,6 +214,10 @@ interface RadioStation extends IStreamable {
   logo: string | null
   description: string
   is_public: boolean
+  permissions: {
+    edit: boolean
+    delete: boolean
+  }
 }
 
 type Playable = Song | Episode

--- a/tests/Feature/RadioStationTest.php
+++ b/tests/Feature/RadioStationTest.php
@@ -240,4 +240,41 @@ class RadioStationTest extends TestCase
 
         $this->assertModelMissing($station);
     }
+
+    #[Test]
+    public function listingIncludesEditAndDeletePermissionsForOwner(): void
+    {
+        $user = create_user();
+        RadioStation::factory()->for($user)->createOne();
+
+        $this
+            ->getAs('/api/radio/stations', $user)
+            ->assertJsonCount(1, '*')
+            ->assertJsonPath('0.permissions.edit', true)
+            ->assertJsonPath('0.permissions.delete', true);
+    }
+
+    #[Test]
+    public function listingIncludesEditAndDeletePermissionsForAdminInSameOrg(): void
+    {
+        RadioStation::factory()->createOne(['is_public' => true]);
+
+        $this
+            ->getAs('/api/radio/stations', create_admin())
+            ->assertJsonCount(1, '*')
+            ->assertJsonPath('0.permissions.edit', true)
+            ->assertJsonPath('0.permissions.delete', true);
+    }
+
+    #[Test]
+    public function listingDeniesEditAndDeletePermissionsForRandomUser(): void
+    {
+        RadioStation::factory()->createOne(['is_public' => true]);
+
+        $this
+            ->getAs('/api/radio/stations', create_user())
+            ->assertJsonCount(1, '*')
+            ->assertJsonPath('0.permissions.edit', false)
+            ->assertJsonPath('0.permissions.delete', false);
+    }
 }


### PR DESCRIPTION
## Summary
Fourth PR in the per-resource permissions migration (after #2409 Album, #2410 Artist, #2411 Playlist). \`RadioStationResource\` now exposes \`permissions: { edit, delete }\` computed via the existing \`RadioStationPolicy\`, so the context menu reads them synchronously instead of round-tripping per action.

### Backend
- \`RadioStationResource\` adds \`permissions: { edit, delete }\` via \`\$user->can('edit', ...)\` and \`\$user->can('delete', ...)\` respectively.
- **No policy changes needed**: \`RadioStationPolicy\` already has both \`edit\` and \`delete\` methods (delete delegates to update which delegates to edit).
- **No embed-exclusion needed**: RadioStation isn't an embeddable type (only Playable/Playlist/Album/Artist are).

### N+1 audit
\`RadioStationPolicy::edit\` accesses \`\$station->user->organization_id\` — a relationship traversal that would N+1 if not handled. Verified safe:
- \`RadioStation::\$with = ['user']\` auto-eager-loads the \`user\` relationship.
- \`organization_id\` is a scalar column on User (not an accessor).
- \`hasPermissionTo\` is Spatie-cached per request.
All policy checks are scalar after the eager load — zero per-row queries. The 19 existing radio-station tests pass under \`Model::preventLazyLoading()\` as confirmation.

### Frontend
- \`RadioStation\` TS type gains \`permissions: { edit, delete }\`.
- \`currentUserCan.editRadioStation\` and \`deleteRadioStation\` are now sync, reading the embedded flags. ACL HTTP path removed for these two actions.
- \`RadioStationContextMenu\` uses two \`computed\`s and drops its \`onMounted\` entirely.
- Spec gains "hides Edit when only delete is permitted" / "hides Delete when only edit is permitted" tests, mirroring the Playlist PR's pattern.

## Test plan
- [x] Backend: 18/18 in \`RadioStationTest.php\`. Three new tests cover the policy branches:
    - \`listingIncludesEditAndDeletePermissionsForOwner\` — owner sees both \`true\`
    - \`listingIncludesEditAndDeletePermissionsForAdminInSameOrg\` — same-org admin sees both \`true\`
    - \`listingDeniesEditAndDeletePermissionsForRandomUser\` — random user sees both \`false\` on a public station
- [x] Frontend: 39/39 affected tests passing. New \`editRadioStation\`/\`deleteRadioStation\` tests in \`usePolicies.spec\`; new asymmetric "hides X when only Y" tests in \`RadioStationContextMenu.spec\`.
- [x] PHPStan/Larastan clean.
- [x] \`vp check resources/assets\` clean.
- [ ] Manual: open radio station context menu, confirm Edit and Delete appear/hide based on permissions without delay.

## Migration progress
Album ✅ → Artist ✅ → Playlist ✅ → **RadioStation** (this PR) → User → cleanup of \`acl.ts\` + \`Permissionable\`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Radio station API responses now include permission metadata with edit and delete capability flags for the authenticated user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->