### PR TITLE
feat: include viewer's edit and delete permissions on user resource

### DIFF
--- a/app/Http/Resources/UserResource.php
+++ b/app/Http/Resources/UserResource.php
@@ -37,8 +37,8 @@ class UserResource extends JsonResource
     /** @inheritdoc */
     public function toArray(Request $request): array
     {
-        $viewer = $request->user();
-        $isCurrentUser = $this->user->is($viewer);
+        $currentUser = $request->user();
+        $isCurrentUser = $this->user->is($currentUser);
 
         return [
             'type' => 'users',
@@ -57,8 +57,8 @@ class UserResource extends JsonResource
                 ->pluck('name')
                 ->toArray()),
             'permissions' => [
-                'edit' => $viewer->can('update', $this->user),
-                'delete' => $viewer->can('destroy', $this->user),
+                'edit' => $currentUser->can('update', $this->user),
+                'delete' => $currentUser->can('destroy', $this->user),
             ],
         ];
     }

--- a/app/Http/Resources/UserResource.php
+++ b/app/Http/Resources/UserResource.php
@@ -21,7 +21,11 @@ class UserResource extends JsonResource
         'sso_id',
         'is_admin',
         'role',
-        'permissions',
+        'abilities',
+        'permissions' => [
+            'edit',
+            'delete',
+        ],
     ];
 
     public function __construct(
@@ -33,7 +37,8 @@ class UserResource extends JsonResource
     /** @inheritdoc */
     public function toArray(Request $request): array
     {
-        $isCurrentUser = $this->user->is($request->user());
+        $viewer = $request->user();
+        $isCurrentUser = $this->user->is($viewer);
 
         return [
             'type' => 'users',
@@ -47,10 +52,14 @@ class UserResource extends JsonResource
             'sso_id' => $this->user->sso_id,
             'is_admin' => $this->user->role === Role::ADMIN, // @todo remove this backward-compatibility field
             'role' => $this->user->role,
-            'permissions' => $this->when($isCurrentUser, fn () => $this->user
+            'abilities' => $this->when($isCurrentUser, fn () => $this->user
                 ->getPermissionsViaRoles()
                 ->pluck('name')
                 ->toArray()),
+            'permissions' => [
+                'edit' => $viewer->can('update', $this->user),
+                'delete' => $viewer->can('destroy', $this->user),
+            ],
         ];
     }
 }

--- a/resources/assets/js/__tests__/factory/userFactory.ts
+++ b/resources/assets/js/__tests__/factory/userFactory.ts
@@ -50,13 +50,17 @@ export default (): User => ({
   avatar: 'https://gravatar.com/foo',
   sso_provider: null,
   sso_id: null,
+  permissions: {
+    edit: faker.datatype.boolean(),
+    delete: faker.datatype.boolean(),
+  },
 })
 
 export const states: Record<string, Omit<Partial<User>, 'type'>> = {
   admin: {
     role: 'admin',
     preferences,
-    permissions: ['manage settings', 'manage users', 'manage songs', 'manage podcasts', 'manage radio stations'],
+    abilities: ['manage settings', 'manage users', 'manage songs', 'manage podcasts', 'manage radio stations'],
   },
   manager: {
     role: 'manager',
@@ -66,6 +70,6 @@ export const states: Record<string, Omit<Partial<User>, 'type'>> = {
   },
   current: {
     preferences,
-    permissions: [],
+    abilities: [],
   },
 }

--- a/resources/assets/js/components/user/UserContextMenu.spec.ts
+++ b/resources/assets/js/components/user/UserContextMenu.spec.ts
@@ -11,7 +11,7 @@ describe('userContextMenu.vue', () => {
   const h = createHarness()
 
   const renderComponent = async (user?: User) => {
-    user = user || h.factory('user', { permissions: { edit: true, delete: true } })
+    user = user || h.factory('user')
 
     const rendered = h.render(Component, {
       props: {
@@ -27,7 +27,7 @@ describe('userContextMenu.vue', () => {
 
   it('deletes user if confirmed', async () => {
     h.mock(DialogBoxStub.value, 'confirm').mockResolvedValue(true)
-    const { user } = await renderComponent()
+    const { user } = await renderComponent(h.factory('user', { permissions: { edit: true, delete: true } }))
     const destroyMock = h.mock(userStore, 'destroy')
 
     await h.user.click(screen.getByText('Delete'))
@@ -37,7 +37,7 @@ describe('userContextMenu.vue', () => {
 
   it('does not delete user if not confirmed', async () => {
     h.mock(DialogBoxStub.value, 'confirm').mockResolvedValue(false)
-    await renderComponent()
+    await renderComponent(h.factory('user', { permissions: { edit: true, delete: true } }))
     const destroyMock = h.mock(userStore, 'destroy')
 
     await h.user.click(screen.getByText('Delete'))

--- a/resources/assets/js/components/user/UserContextMenu.spec.ts
+++ b/resources/assets/js/components/user/UserContextMenu.spec.ts
@@ -1,37 +1,22 @@
 import { describe, expect, it } from 'vite-plus/test'
 import { DialogBoxStub } from '@/__tests__/stubs'
 import { userStore } from '@/stores/userStore'
-import { screen, waitFor } from '@testing-library/vue'
+import { screen } from '@testing-library/vue'
 import factory from '@/__tests__/factory'
 import { invitationService } from '@/services/invitationService'
 import { createHarness } from '@/__tests__/TestHarness'
-import { acl } from '@/services/acl'
 import Component from './UserContextMenu.vue'
 
 describe('userContextMenu.vue', () => {
   const h = createHarness()
 
   const renderComponent = async (user?: User, editable = true, deletable = true) => {
-    user = user || h.factory('user')
-
-    const permissionMock = h.mock(acl, 'checkResourcePermission').mockImplementation((_, __, action) => {
-      if (action === 'edit') {
-        return editable
-      }
-      if (action === 'delete') {
-        return deletable
-      }
-    })
+    user = user || h.factory('user', { permissions: { edit: editable, delete: deletable } })
 
     const rendered = h.render(Component, {
       props: {
         user,
       },
-    })
-
-    await waitFor(() => {
-      screen.getByRole('listitem')
-      expect(permissionMock).toHaveBeenCalledTimes(user.is_prospect ? 1 : 2)
     })
 
     return {
@@ -62,7 +47,7 @@ describe('userContextMenu.vue', () => {
 
   it('revokes invite for prospects', async () => {
     h.mock(DialogBoxStub.value, 'confirm').mockResolvedValue(true)
-    const prospect = factory.states('prospect')('user')
+    const prospect = factory.states('prospect')('user', { permissions: { edit: true, delete: true } })
     await renderComponent(prospect)
     const revokeMock = h.mock(invitationService, 'revoke')
 
@@ -73,7 +58,7 @@ describe('userContextMenu.vue', () => {
 
   it('does not revoke invite for prospects if not confirmed', async () => {
     h.mock(DialogBoxStub.value, 'confirm').mockResolvedValue(false)
-    await renderComponent(factory.states('prospect')('user'))
+    await renderComponent(factory.states('prospect')('user', { permissions: { edit: true, delete: true } }))
     await h.user.click(screen.getByText('Revoke Invitation'))
     const revokeMock = h.mock(invitationService, 'revoke')
 

--- a/resources/assets/js/components/user/UserContextMenu.spec.ts
+++ b/resources/assets/js/components/user/UserContextMenu.spec.ts
@@ -10,8 +10,8 @@ import Component from './UserContextMenu.vue'
 describe('userContextMenu.vue', () => {
   const h = createHarness()
 
-  const renderComponent = async (user?: User, editable = true, deletable = true) => {
-    user = user || h.factory('user', { permissions: { edit: editable, delete: deletable } })
+  const renderComponent = async (user?: User) => {
+    user = user || h.factory('user', { permissions: { edit: true, delete: true } })
 
     const rendered = h.render(Component, {
       props: {
@@ -68,7 +68,7 @@ describe('userContextMenu.vue', () => {
   })
 
   it('respects the permissions', async () => {
-    await renderComponent(undefined, false, false)
+    await renderComponent(h.factory('user', { permissions: { edit: false, delete: false } }))
     expect(screen.queryByText('Edit')).toBeNull()
     expect(screen.queryByText('Delete')).toBeNull()
   })

--- a/resources/assets/js/components/user/UserContextMenu.spec.ts
+++ b/resources/assets/js/components/user/UserContextMenu.spec.ts
@@ -47,7 +47,7 @@ describe('userContextMenu.vue', () => {
 
   it('revokes invite for prospects', async () => {
     h.mock(DialogBoxStub.value, 'confirm').mockResolvedValue(true)
-    const prospect = factory.states('prospect')('user', { permissions: { edit: true, delete: true } })
+    const prospect = factory.states('prospect')('user', { permissions: { edit: false, delete: true } })
     await renderComponent(prospect)
     const revokeMock = h.mock(invitationService, 'revoke')
 
@@ -58,7 +58,7 @@ describe('userContextMenu.vue', () => {
 
   it('does not revoke invite for prospects if not confirmed', async () => {
     h.mock(DialogBoxStub.value, 'confirm').mockResolvedValue(false)
-    await renderComponent(factory.states('prospect')('user', { permissions: { edit: true, delete: true } }))
+    await renderComponent(factory.states('prospect')('user', { permissions: { edit: false, delete: true } }))
     await h.user.click(screen.getByText('Revoke Invitation'))
     const revokeMock = h.mock(invitationService, 'revoke')
 

--- a/resources/assets/js/components/user/UserContextMenu.vue
+++ b/resources/assets/js/components/user/UserContextMenu.vue
@@ -7,14 +7,12 @@
       <MenuItem v-if="user.is_prospect" @click="revokeInvite">Revoke Invitation</MenuItem>
       <MenuItem v-else @click="destroy">Delete</MenuItem>
     </template>
-    <MenuItem v-if="allowEdit === false && allowDelete === false" class="italic pointer-events-none">
-      No available actions
-    </MenuItem>
+    <MenuItem v-if="!allowEdit && !allowDelete" class="italic pointer-events-none"> No available actions </MenuItem>
   </ul>
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref, toRefs } from 'vue'
+import { computed, toRefs } from 'vue'
 import { defineAsyncComponent } from '@/utils/helpers'
 import { userStore } from '@/stores/userStore'
 import { usePolicies } from '@/composables/usePolicies'
@@ -28,9 +26,6 @@ import { useErrorHandler } from '@/composables/useErrorHandler'
 const props = defineProps<{ user: User }>()
 const { user } = toRefs(props)
 
-const allowEdit = ref<boolean | null>(null)
-const allowDelete = ref<boolean | null>(null)
-
 const { toastSuccess } = useMessageToaster()
 const { showConfirmDialog } = useDialogBox()
 const EditUserForm = defineAsyncComponent(() => import('@/components/user/EditUserForm.vue'))
@@ -38,6 +33,9 @@ const EditUserForm = defineAsyncComponent(() => import('@/components/user/EditUs
 const { MenuItem, trigger } = useContextMenu()
 const { openModal } = useModal()
 const { currentUserCan } = usePolicies()
+
+const allowEdit = computed(() => !user.value.is_prospect && currentUserCan.editUser(user.value))
+const allowDelete = computed(() => currentUserCan.deleteUser(user.value))
 
 const edit = () => trigger(() => openModal<'EDIT_USER_FORM'>(EditUserForm, { user: user.value }))
 
@@ -65,9 +63,4 @@ const revokeInvite = async () => {
     })
   }
 }
-
-onMounted(async () => {
-  allowEdit.value = user.value.is_prospect ? false : await currentUserCan.editUser(user.value)
-  allowDelete.value = await currentUserCan.deleteUser(user.value)
-})
 </script>

--- a/resources/assets/js/composables/usePolicies.spec.ts
+++ b/resources/assets/js/composables/usePolicies.spec.ts
@@ -9,7 +9,7 @@ describe('usePolicies', () => {
   it('allows admin to edit any song', () => {
     h.actingAsUser({
       ...h.factory('user'),
-      permissions: ['manage songs'],
+      abilities: ['manage songs'],
     } as CurrentUser)
 
     const { currentUserCan } = usePolicies()
@@ -19,7 +19,7 @@ describe('usePolicies', () => {
   })
 
   it('allows Plus user to edit their own songs', async () => {
-    const user = h.factory('user', { permissions: [] }) as CurrentUser
+    const user = h.factory('user', { abilities: [] }) as CurrentUser
     h.actingAsUser(user)
 
     await h.withPlusEdition(async () => {
@@ -31,7 +31,7 @@ describe('usePolicies', () => {
   })
 
   it('denies Plus user editing others songs', async () => {
-    const user = h.factory('user', { permissions: [] }) as CurrentUser
+    const user = h.factory('user', { abilities: [] }) as CurrentUser
     h.actingAsUser(user)
 
     await h.withPlusEdition(async () => {
@@ -45,7 +45,7 @@ describe('usePolicies', () => {
   it('denies non-Plus non-admin editing songs', () => {
     h.actingAsUser({
       ...h.factory('user'),
-      permissions: [],
+      abilities: [],
     } as CurrentUser)
 
     commonStore.state.koel_plus.active = false
@@ -93,7 +93,7 @@ describe('usePolicies', () => {
   it('checks manageSettings permission', () => {
     h.actingAsUser({
       ...h.factory('user'),
-      permissions: ['manage settings'],
+      abilities: ['manage settings'],
     } as CurrentUser)
 
     const { currentUserCan } = usePolicies()
@@ -103,7 +103,7 @@ describe('usePolicies', () => {
   it('checks manageUsers permission', () => {
     h.actingAsUser({
       ...h.factory('user'),
-      permissions: [],
+      abilities: [],
     } as CurrentUser)
 
     const { currentUserCan } = usePolicies()
@@ -111,7 +111,7 @@ describe('usePolicies', () => {
   })
 
   it('allows upload for Plus users', async () => {
-    const user = h.factory('user', { permissions: [] }) as CurrentUser
+    const user = h.factory('user', { abilities: [] }) as CurrentUser
     h.actingAsUser(user)
 
     await h.withPlusEdition(async () => {
@@ -123,11 +123,29 @@ describe('usePolicies', () => {
   it('allows upload for users with manage songs permission', () => {
     h.actingAsUser({
       ...h.factory('user'),
-      permissions: ['manage songs'],
+      abilities: ['manage songs'],
     } as CurrentUser)
 
     const { currentUserCan } = usePolicies()
     expect(currentUserCan.uploadSongs()).toBe(true)
+  })
+
+  it('reads the edit permission embedded in the user', () => {
+    const { currentUserCan } = usePolicies()
+    const editable = h.factory('user', { permissions: { edit: true, delete: false } })
+    const readonly = h.factory('user', { permissions: { edit: false, delete: false } })
+
+    expect(currentUserCan.editUser(editable)).toBe(true)
+    expect(currentUserCan.editUser(readonly)).toBe(false)
+  })
+
+  it('reads the delete permission embedded in the user', () => {
+    const { currentUserCan } = usePolicies()
+    const deletable = h.factory('user', { permissions: { edit: false, delete: true } })
+    const readonly = h.factory('user', { permissions: { edit: false, delete: false } })
+
+    expect(currentUserCan.deleteUser(deletable)).toBe(true)
+    expect(currentUserCan.deleteUser(readonly)).toBe(false)
   })
 
   it('reads the edit permission embedded in the radio station', () => {

--- a/resources/assets/js/composables/usePolicies.ts
+++ b/resources/assets/js/composables/usePolicies.ts
@@ -1,7 +1,6 @@
 import { arrayify } from '@/utils/helpers'
 import { useAuthorization } from '@/composables/useAuthorization'
 import { useKoelPlus } from '@/composables/useKoelPlus'
-import { acl } from '@/services/acl'
 
 export const usePolicies = () => {
   const { currentUser } = useAuthorization()
@@ -9,7 +8,7 @@ export const usePolicies = () => {
 
   const currentUserCan = {
     editSong: (songs: MaybeArray<Song>) => {
-      if (currentUser.value.permissions.includes('manage songs')) {
+      if (currentUser.value.abilities.includes('manage songs')) {
         return true
       }
 
@@ -24,18 +23,18 @@ export const usePolicies = () => {
     deletePlaylist: (playlist: Playlist) => playlist.permissions.delete,
     editAlbum: (album: Album) => album.permissions.edit,
     editArtist: (artist: Artist) => artist.permissions.edit,
-    editUser: async (user: User) => await acl.checkResourcePermission('user', user.id, 'edit'),
-    deleteUser: async (user: User) => await acl.checkResourcePermission('user', user.id, 'delete'),
+    editUser: (user: User) => user.permissions.edit,
+    deleteUser: (user: User) => user.permissions.delete,
 
     editRadioStation: (station: RadioStation) => station.permissions.edit,
     deleteRadioStation: (station: RadioStation) => station.permissions.delete,
 
     // If the user has the permission, they can always add a radio station, even in demo mode.
-    addRadioStation: () => !window.IS_DEMO || currentUser.value.permissions.includes('manage radio stations'),
+    addRadioStation: () => !window.IS_DEMO || currentUser.value.abilities.includes('manage radio stations'),
 
-    manageSettings: () => currentUser.value.permissions.includes('manage settings'),
-    manageUsers: () => currentUser.value.permissions.includes('manage users'),
-    uploadSongs: () => isPlus.value || currentUser.value.permissions.includes('manage songs'),
+    manageSettings: () => currentUser.value.abilities.includes('manage settings'),
+    manageUsers: () => currentUser.value.abilities.includes('manage users'),
+    uploadSongs: () => isPlus.value || currentUser.value.abilities.includes('manage songs'),
   }
 
   return {

--- a/resources/assets/js/types.d.ts
+++ b/resources/assets/js/types.d.ts
@@ -438,10 +438,10 @@ interface User {
    */
   abilities?: Ability[]
   /**
-   * What the *current viewer* is permitted to do *to this user* — the result
-   * of running UserPolicy from the viewer's perspective. Distinct from
-   * `abilities` above, which is the user's own globally-granted capabilities.
-   * Always populated, regardless of whether this is the current user.
+   * What the *current user* (the one making the request) is permitted to do
+   * *to this user* — the result of running UserPolicy from their perspective.
+   * Distinct from `abilities` above, which is the user's own globally-granted
+   * capabilities. Always populated, regardless of who is being looked at.
    */
   permissions: {
     edit: boolean

--- a/resources/assets/js/types.d.ts
+++ b/resources/assets/js/types.d.ts
@@ -415,7 +415,7 @@ interface UserPreferences extends Record<string, any> {
   lastfm_session_key?: string
 }
 
-type Permission = 'manage settings' | 'manage users' | 'manage songs' | 'manage podcasts' | 'manage radio stations'
+type Ability = 'manage settings' | 'manage users' | 'manage songs' | 'manage podcasts' | 'manage radio stations'
 type Role = ('admin' | 'manager' | 'user') & string
 
 interface User {
@@ -430,12 +430,28 @@ interface User {
   sso_provider: SSOProvider | null
   sso_id: string | null
   preferences?: UserPreferences
-  permissions?: Permission[]
+  /**
+   * Capabilities this user has been granted (via their role) — i.e. "what *I*
+   * have the ability to do globally". Things like "manage settings" or
+   * "manage songs". Only populated for the current user (the one making the
+   * request); undefined for other users in a list.
+   */
+  abilities?: Ability[]
+  /**
+   * What the *current viewer* is permitted to do *to this user* — the result
+   * of running UserPolicy from the viewer's perspective. Distinct from
+   * `abilities` above, which is the user's own globally-granted capabilities.
+   * Always populated, regardless of whether this is the current user.
+   */
+  permissions: {
+    edit: boolean
+    delete: boolean
+  }
 }
 
 type CurrentUser = User & {
   preferences: UserPreferences
-  permissions: Permission[]
+  abilities: Ability[]
 }
 
 interface Settings {

--- a/tests/Feature/UserTest.php
+++ b/tests/Feature/UserTest.php
@@ -242,4 +242,30 @@ class UserTest extends TestCase
 
         $this->assertModelExists($user);
     }
+
+    #[Test]
+    public function listingIncludesEditAndDeletePermissionsForAdminViewingLowerRoleUser(): void
+    {
+        $admin = create_admin();
+        $regular = create_user();
+
+        $response = $this->getAs('api/users', $admin)->json();
+        $regularRow = collect($response)->firstWhere('id', $regular->public_id);
+
+        self::assertTrue($regularRow['permissions']['edit']);
+        self::assertTrue($regularRow['permissions']['delete']);
+    }
+
+    #[Test]
+    public function listingDeniesDeletePermissionForSelfButAllowsEdit(): void
+    {
+        $admin = create_admin();
+
+        $response = $this->getAs('api/users', $admin)->json();
+        $selfRow = collect($response)->firstWhere('id', $admin->public_id);
+
+        // Admin can edit themselves but cannot self-destroy.
+        self::assertTrue($selfRow['permissions']['edit']);
+        self::assertFalse($selfRow['permissions']['delete']);
+    }
 }


### PR DESCRIPTION
## Summary
Final PR in the per-resource permissions migration (after Album #2409, Artist #2410, Playlist #2411, RadioStation #2412). \`UserResource\` now exposes \`permissions: { edit, delete }\` computed from \`UserPolicy\` for the *current viewer*, mirroring the shape used by every other resource.

This was the trickiest of the five because \`UserResource\` already had a \`permissions\` field that meant something different — a string array of the user's *role-granted* capabilities ("manage settings", etc.). Resolving the naming collision required reframing both fields:

- \`abilities\` (string array, was \`permissions\`) — "what *I* have the ability to do globally" (granted by role).
- \`permissions: { edit, delete }\` (new) — "what the *current viewer* is permitted to do *to me*" (UserPolicy result).

The TS type carries explanatory comments to lock in the distinction. The \`Permission\` TS type is also renamed to \`Ability\` for symmetry with the field rename.

### Backend
- \`UserResource\` exposes \`permissions: { edit, delete }\` via \`\$viewer->can('update', \$user)\` and \`\$viewer->can('destroy', \$user)\`.
- The string-array field formerly known as \`permissions\` is now \`abilities\` (still gated on \`\$isCurrentUser\`).
- \`UserPolicy\` already had \`update\` and \`destroy\` methods (the canonical Laravel naming), no policy changes needed.

### Frontend
- \`User\` TS type:
    - \`permissions?: Permission[]\` → \`abilities?: Ability[]\`
    - new required \`permissions: { edit, delete }\`
    - both fields documented with JSDoc comments to differentiate them clearly
- \`Permission\` type renamed to \`Ability\`
- \`usePolicies.editUser\` / \`deleteUser\` are now sync, reading the embedded flags
- All five callers of \`currentUser.permissions.includes(...)\` migrated to \`currentUser.abilities.includes(...)\`
- \`UserContextMenu.vue\` uses \`computed\`s, drops its \`onMounted\`
- Factory and tests updated for the rename

## Migration milestone
**With this PR, no consumer of \`acl.checkResourcePermission\` remains in \`usePolicies\`.** The \`acl\` import was dropped from \`usePolicies.ts\` (lint flagged it as unused). The next cleanup PR can:
- Delete \`resources/assets/js/services/acl.ts\` (and \`acl.spec.ts\`)
- Delete the \`Permissionable\` interface (backend)
- Delete the \`acl/permissions/{type}/{id}/{action}\` route + controller
- Verify no remaining callers via \`grep -r checkResourcePermission\`
- Note: \`acl.assignableRoles\` (role picker) is a separate concern and should be preserved.

## Test plan
- [x] Backend: \`UserTest.php\` — 16/16 passing including 2 new tests:
    - \`listingIncludesEditAndDeletePermissionsForAdminViewingLowerRoleUser\`
    - \`listingDeniesDeletePermissionForSelfButAllowsEdit\` (admin can edit self but not self-destroy)
- [x] Backend: ProfileTest, related tests still passing.
- [x] Frontend: full suite (1462 tests, all passing) — caught no regressions from the \`Permission\` → \`Ability\` rename or \`permissions\` → \`abilities\` rename.
- [x] PHPStan/Larastan clean.
- [x] \`vp check resources/assets\` clean.
- [ ] Manual: open user list as admin, confirm Edit/Delete menu items appear correctly per role and that you cannot self-destroy.

## Migration progress
Album ✅ → Artist ✅ → Playlist ✅ → RadioStation ✅ → **User** (this PR) → cleanup of \`acl.ts\` + \`Permissionable\` + ACL endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API responses now include per-user boolean flags for edit/delete plus a separate list of global abilities for the current viewer.

* **Refactor**
  * Client-side authorization now distinguishes global abilities from per-user boolean permissions; user action checks are synchronous and driven by those flags.

* **Tests**
  * Updated and added tests to validate abilities vs per-user permissions and admin/self edit/delete behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->