### PR TITLE
test: strengthen User::getAssignableRoles tests with exact assertions

### DIFF
--- a/tests/Unit/KoelPlus/Models/UserTest.php
+++ b/tests/Unit/KoelPlus/Models/UserTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Unit\KoelPlus\Models;
+
+use App\Enums\Acl\Role;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PlusTestCase;
+
+use function Tests\create_admin;
+use function Tests\create_manager;
+
+class UserTest extends PlusTestCase
+{
+    #[Test]
+    public function adminCanAssignAllRolesOrderedByLevel(): void
+    {
+        $admin = create_admin();
+
+        // In Plus, MANAGER is available; admin can manage every role. Ordered by level().
+        self::assertSame([Role::USER, Role::MANAGER, Role::ADMIN], $admin->getAssignableRoles()->all());
+    }
+
+    #[Test]
+    public function managerCannotAssignAdminRole(): void
+    {
+        $manager = create_manager();
+
+        // canManage() filter excludes ADMIN (level 3 > manager's level 2); MANAGER itself is
+        // available in Plus and the manager can canManage(MANAGER) = true (2 >= 2).
+        self::assertSame([Role::USER, Role::MANAGER], $manager->getAssignableRoles()->all());
+    }
+}

--- a/tests/Unit/KoelPlus/Models/UserTest.php
+++ b/tests/Unit/KoelPlus/Models/UserTest.php
@@ -11,22 +11,28 @@ use function Tests\create_manager;
 
 class UserTest extends PlusTestCase
 {
+    /**
+     * In Plus, Role::available() admits MANAGER. The admin's canManage() permits every role,
+     * so getAssignableRoles() returns all three ordered by level() ascending.
+     */
     #[Test]
     public function adminCanAssignAllRolesOrderedByLevel(): void
     {
         $admin = create_admin();
 
-        // In Plus, MANAGER is available; admin can manage every role. Ordered by level().
         self::assertSame([Role::USER, Role::MANAGER, Role::ADMIN], $admin->getAssignableRoles()->all());
     }
 
+    /**
+     * In Plus, MANAGER passes Role::available() and the manager satisfies canManage(MANAGER)
+     * since 2 >= 2; only ADMIN is filtered out by canManage() (level 3 > manager's 2). Net
+     * result of getAssignableRoles() is [USER, MANAGER].
+     */
     #[Test]
     public function managerCannotAssignAdminRole(): void
     {
         $manager = create_manager();
 
-        // canManage() filter excludes ADMIN (level 3 > manager's level 2); MANAGER itself is
-        // available in Plus and the manager can canManage(MANAGER) = true (2 >= 2).
         self::assertSame([Role::USER, Role::MANAGER], $manager->getAssignableRoles()->all());
     }
 }

--- a/tests/Unit/Models/UserTest.php
+++ b/tests/Unit/Models/UserTest.php
@@ -37,6 +37,6 @@ class UserTest extends TestCase
     {
         $user = create_user();
 
-        self::assertTrue($user->getAssignableRoles()->isEmpty());
+        self::assertSame([], $user->getAssignableRoles()->all());
     }
 }

--- a/tests/Unit/Models/UserTest.php
+++ b/tests/Unit/Models/UserTest.php
@@ -12,23 +12,29 @@ use function Tests\create_user;
 
 class UserTest extends TestCase
 {
+    /**
+     * In CE, MANAGER is filtered out by Role::available() (Plus-only). The admin can manage
+     * USER and ADMIN via canManage(), and getAssignableRoles() returns them ordered by level()
+     * ascending — hence [USER, ADMIN].
+     */
     #[Test]
     public function adminCanAssignAvailableRolesOrderedByLevel(): void
     {
         $admin = create_admin();
 
-        // In CE, MANAGER is not available (Plus-only); the admin can manage USER and ADMIN,
-        // ordered by level() ascending.
         self::assertSame([Role::USER, Role::ADMIN], $admin->getAssignableRoles()->all());
     }
 
+    /**
+     * Two filters apply for a manager (created via create_manager()): canManage() excludes
+     * ADMIN (level 3 > manager's level 2), and Role::available() also filters out MANAGER
+     * itself in CE. Net result of getAssignableRoles() is [USER] only.
+     */
     #[Test]
     public function managerCannotAssignRolesAboveTheirLevel(): void
     {
         $manager = create_manager();
 
-        // canManage() filter excludes ADMIN (level 3 > manager's level 2); MANAGER itself is
-        // also filtered out by Role::available() in CE. Net result: only USER.
         self::assertSame([Role::USER], $manager->getAssignableRoles()->all());
     }
 

--- a/tests/Unit/Models/UserTest.php
+++ b/tests/Unit/Models/UserTest.php
@@ -7,16 +7,29 @@ use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 use function Tests\create_admin;
+use function Tests\create_manager;
 use function Tests\create_user;
 
 class UserTest extends TestCase
 {
     #[Test]
-    public function adminCanAssignRolesTheyCanManage(): void
+    public function adminCanAssignAvailableRolesOrderedByLevel(): void
     {
         $admin = create_admin();
 
-        $admin->getAssignableRoles()->each(static fn (Role $role) => self::assertTrue($admin->role->canManage($role)));
+        // In CE, MANAGER is not available (Plus-only); the admin can manage USER and ADMIN,
+        // ordered by level() ascending.
+        self::assertSame([Role::USER, Role::ADMIN], $admin->getAssignableRoles()->all());
+    }
+
+    #[Test]
+    public function managerCannotAssignRolesAboveTheirLevel(): void
+    {
+        $manager = create_manager();
+
+        // canManage() filter excludes ADMIN (level 3 > manager's level 2); MANAGER itself is
+        // also filtered out by Role::available() in CE. Net result: only USER.
+        self::assertSame([Role::USER], $manager->getAssignableRoles()->all());
     }
 
     #[Test]


### PR DESCRIPTION
## Background
Follow-up to #2415, addressing review feedback on the new \`User::getAssignableRoles\` tests that landed there. The original tests used \`each(...assertTrue(canManage))\` which (a) would have passed vacuously if the collection were empty and (b) didn't verify ordering or the exclusion-side of the filter.

## Changes
Replace the iteration-based assertion with exact-collection \`assertSame\` checks. A single line proves non-emptiness, filtering correctness, AND ordering by \`level()\` ascending.

Split CE and Plus contexts because \`Role::MANAGER\` is gated by \`License::isPlus()\` in \`Role::available()\` — meaning the available-roles set itself differs between editions, not just the user's permissions. (This split was the discovery moment that the original test would have hidden indefinitely.)

### CE — \`tests/Unit/Models/UserTest.php\`
- \`adminCanAssignAvailableRolesOrderedByLevel\` — admin gets \`[USER, ADMIN]\` (MANAGER filtered out by \`available()\`)
- \`managerCannotAssignRolesAboveTheirLevel\` — manager gets \`[USER]\` (MANAGER filtered by \`available()\`, ADMIN by \`canManage()\`)
- \`userWithoutManageAbilityCannotAssignAnyRoles\` — gate denies, returns empty

### Plus — \`tests/Unit/KoelPlus/Models/UserTest.php\` (new file)
- \`adminCanAssignAllRolesOrderedByLevel\` — admin gets \`[USER, MANAGER, ADMIN]\`
- \`managerCannotAssignAdminRole\` — manager gets \`[USER, MANAGER]\` (only ADMIN filtered by \`canManage()\`)

Together these exercise:
- The \`manage\` policy gate at the top of the method
- \`Role::available()\` filtering (edition-conditional MANAGER)
- \`canManage()\` filtering (role-hierarchy)
- Ordering by \`level()\` ascending

## Test plan
- [x] 5/5 new and updated tests pass.
- [x] PHPStan/Larastan clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests verifying admins can assign all roles and that assignable roles are returned in ascending level order.
  * Added unit tests verifying managers cannot assign higher-level (admin) roles.
  * Tightened assertions to verify exact role lists (including order) rather than loose/non-empty checks.
  * Updated existing role-assignment tests to enforce precise expected outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->