### PR TITLE
fix: align user card with album/artist card affordances

### DIFF
--- a/resources/assets/js/components/user/UserCard.spec.ts
+++ b/resources/assets/js/components/user/UserCard.spec.ts
@@ -10,7 +10,9 @@ import UserContextMenu from '@/components/user/UserContextMenu.vue'
 vi.mock('@/composables/useContextMenu')
 
 describe('userCard.vue', () => {
-  const h = createHarness()
+  const h = createHarness({
+    beforeEach: () => (useContextMenu().openContextMenu as Mock).mockClear(),
+  })
 
   const renderComponent = (user?: User) => {
     user = user ?? h.factory('user')
@@ -49,5 +51,21 @@ describe('userCard.vue', () => {
 
     await h.trigger(screen.getByTestId('user-card'), 'contextMenu')
     await assertOpenContextMenu(openContextMenu as Mock, UserContextMenu, { user })
+  })
+
+  it('requests the context menu via the More Actions button', async () => {
+    const { openContextMenu } = useContextMenu()
+    const { user } = renderComponent()
+
+    await h.user.click(screen.getByRole('button', { name: 'More Actions' }))
+    await assertOpenContextMenu(openContextMenu as Mock, UserContextMenu, { user })
+  })
+
+  it('does not show the More Actions button for the current user', () => {
+    const user = h.factory.states('current')('user') as CurrentUser
+    h.actingAsUser(user)
+    renderComponent(user)
+
+    expect(screen.queryByRole('button', { name: 'More Actions' })).toBeNull()
   })
 })

--- a/resources/assets/js/components/user/UserCard.spec.ts
+++ b/resources/assets/js/components/user/UserCard.spec.ts
@@ -29,20 +29,20 @@ describe('userCard.vue', () => {
     }
   }
 
-  it('shows profile link only for the current user', () => {
+  it('shows the profile link for the current user', () => {
     const user = h.factory.states('current')('user') as CurrentUser
     h.actingAsUser(user)
     renderComponent(user)
 
     screen.getByTitle('This is you!')
-    expect(screen.getByText('Your Profile').getAttribute('href')).toBe('/#/profile')
+    expect(screen.getByRole('link', { name: 'Your Profile' }).getAttribute('href')).toBe('/#/profile')
   })
 
   it('does not show profile link for other users', () => {
     h.actingAsUser(h.factory.states('current')('user') as CurrentUser)
     renderComponent(h.factory('user'))
 
-    expect(screen.queryByText('Your Profile')).toBeNull()
+    expect(screen.queryByRole('link', { name: 'Your Profile' })).toBeNull()
   })
 
   it('requests the context menu on right-click', async () => {

--- a/resources/assets/js/components/user/UserCard.spec.ts
+++ b/resources/assets/js/components/user/UserCard.spec.ts
@@ -27,21 +27,27 @@ describe('userCard.vue', () => {
     }
   }
 
-  it('has different behaviors for current user', () => {
+  it('shows profile link only for the current user', () => {
     const user = h.factory.states('current')('user') as CurrentUser
     h.actingAsUser(user)
     renderComponent(user)
 
     screen.getByTitle('This is you!')
     expect(screen.getByText('Your Profile').getAttribute('href')).toBe('/#/profile')
-    expect(screen.queryByRole('button', { name: 'More Actions' })).toBeNull()
   })
 
-  it('requests the context menu', async () => {
+  it('does not show profile link for other users', () => {
+    h.actingAsUser(h.factory.states('current')('user') as CurrentUser)
+    renderComponent(h.factory('user'))
+
+    expect(screen.queryByText('Your Profile')).toBeNull()
+  })
+
+  it('requests the context menu on right-click', async () => {
     const { openContextMenu } = useContextMenu()
     const { user } = renderComponent()
 
-    await h.user.click(screen.getByRole('button', { name: 'More Actions' }))
+    await h.trigger(screen.getByTestId('user-card'), 'contextMenu')
     await assertOpenContextMenu(openContextMenu as Mock, UserContextMenu, { user })
   })
 })

--- a/resources/assets/js/components/user/UserCard.vue
+++ b/resources/assets/js/components/user/UserCard.vue
@@ -1,54 +1,60 @@
 <template>
-  <article
-    :class="{ me: isCurrentUser }"
-    class="apply p-4 flex items-center rounded-md bg-k-fg-5 border border-k-fg-10 gap-3 transition-[border-color] duration-200 ease-in-out hover:border-k-fg-20"
+  <WithGradientBorder
+    border-width="1px"
+    :color="gradientColor"
+    border-color="color-mix(in srgb, var(--color-fg), transparent 97%)"
+    class="rounded-md"
   >
-    <UserAvatar :user width="48" />
+    <article
+      :class="{ me: isCurrentUser }"
+      class="p-4 flex items-center rounded-[inherit] bg-k-fg-5 gap-3"
+      data-testid="user-card"
+      @contextmenu.prevent="requestContextMenu"
+    >
+      <UserAvatar :user width="48" />
 
-    <main class="flex flex-col justify-between relative flex-1 gap-1">
-      <h3 class="font-medium flex gap-2 items-center text-k-fg">
-        <span v-if="user.name" class="name">{{ user.name }}</span>
-        <span v-else class="name font-light">Anonymous</span>
-        <Icon v-if="isCurrentUser" :icon="faCircleCheck" class="you text-k-highlight" title="This is you!" />
-        <Icon
-          v-if="hasAdminPrivileges"
-          :icon="faShield"
-          class="is-admin text-k-primary"
-          title="User has admin privileges"
-        />
-        <img
-          v-if="user.sso_provider === 'Google'"
-          :src="googleLogo"
-          alt="Google"
-          height="14"
-          title="Google SSO"
-          width="14"
-        />
-      </h3>
+      <main class="flex flex-col justify-between relative flex-1 gap-1">
+        <h3 class="font-medium flex gap-2 items-center text-k-fg">
+          <span v-if="user.name" class="name">{{ user.name }}</span>
+          <span v-else class="name font-light">Anonymous</span>
+          <Icon v-if="isCurrentUser" :icon="faCircleCheck" class="you text-k-highlight" title="This is you!" />
+          <Icon
+            v-if="hasAdminPrivileges"
+            :icon="faShield"
+            class="is-admin text-k-primary"
+            title="User has admin privileges"
+          />
+          <img
+            v-if="user.sso_provider === 'Google'"
+            :src="googleLogo"
+            alt="Google"
+            height="14"
+            title="Google SSO"
+            width="14"
+          />
+        </h3>
 
-      <p>{{ user.email }}</p>
-    </main>
+        <p>{{ user.email }}</p>
+      </main>
 
-    <Btn v-if="isCurrentUser" :href="url('profile')" highlight small tag="a">Your Profile</Btn>
-
-    <Btn v-else gray @click="requestContextMenu">
-      <Icon :icon="faEllipsis" fixed-width />
-      <span class="sr-only">More Actions</span>
-    </Btn>
-  </article>
+      <Btn v-if="isCurrentUser" :href="url('profile')" highlight small tag="a">Your Profile</Btn>
+    </article>
+  </WithGradientBorder>
 </template>
 
 <script lang="ts" setup>
 import googleLogo from '@/../img/logos/google.svg'
-import { faCircleCheck, faEllipsis, faShield } from '@fortawesome/free-solid-svg-icons'
+import { faCircleCheck, faShield } from '@fortawesome/free-solid-svg-icons'
 import { computed, toRefs } from 'vue'
 import { useRouter } from '@/composables/useRouter'
 import { useAuthorization } from '@/composables/useAuthorization'
 import { useContextMenu } from '@/composables/useContextMenu'
+import { textToHsl } from '@/utils/formatters'
 
 import Btn from '@/components/ui/form/Btn.vue'
 import UserAvatar from '@/components/user/UserAvatar.vue'
 import UserContextMenu from '@/components/user/UserContextMenu.vue'
+import WithGradientBorder from '@/components/ui/WithGradientBorder.vue'
 
 const props = defineProps<{ user: User }>()
 const { user } = toRefs(props)
@@ -60,6 +66,7 @@ const { currentUser } = useAuthorization()
 
 const isCurrentUser = computed(() => user.value.id === currentUser.value.id)
 const hasAdminPrivileges = computed(() => user.value.role === 'admin' || user.value.role === 'manager')
+const gradientColor = computed(() => textToHsl(user.value.id))
 
 const requestContextMenu = (event: MouseEvent) =>
   openContextMenu<'USER'>(UserContextMenu, event, {

--- a/resources/assets/js/components/user/UserCard.vue
+++ b/resources/assets/js/components/user/UserCard.vue
@@ -38,13 +38,18 @@
       </main>
 
       <Btn v-if="isCurrentUser" :href="url('profile')" highlight small tag="a">Your Profile</Btn>
+
+      <Btn v-else gray @click="requestContextMenu">
+        <Icon :icon="faEllipsis" fixed-width />
+        <span class="sr-only">More Actions</span>
+      </Btn>
     </article>
   </WithGradientBorder>
 </template>
 
 <script lang="ts" setup>
 import googleLogo from '@/../img/logos/google.svg'
-import { faCircleCheck, faShield } from '@fortawesome/free-solid-svg-icons'
+import { faCircleCheck, faEllipsis, faShield } from '@fortawesome/free-solid-svg-icons'
 import { computed, toRefs } from 'vue'
 import { useRouter } from '@/composables/useRouter'
 import { useAuthorization } from '@/composables/useAuthorization'


### PR DESCRIPTION
## Problem
Two consistency gaps between \`UserCard\` and its sibling cards (\`AlbumCard\`, \`ArtistCard\`, \`RadioStationCard\`, etc.):

1. **No gradient-border effect.** Album and artist cards wrap their content in \`WithGradientBorder\` which renders an animated, per-entity-color gradient that responds to pointer position. UserCard had a plain solid border with a hover transition.
2. **Context menu triggered by an ellipsis button** instead of the right-click pattern used by every other card in the app. \`AlbumCard\`'s pattern (\`@contextmenu.prevent="requestContextMenu"\`) is the convention.

## Fix
- Wrap the \`<article>\` in \`WithGradientBorder\` with a per-user gradient color computed via \`textToHsl(user.id)\` (same pattern as \`AlbumOrArtistCard.vue\`).
- Add \`@contextmenu.prevent="requestContextMenu"\` to the article.
- Remove the ellipsis "More Actions" button — right-click is the canonical trigger.
- Keep the "Your Profile" link for the current user. It's a *navigation* affordance, semantically distinct from a context-menu trigger, and matches the existing UX intent.

## Test plan
- [x] \`UserCard.spec\` updated and passing (3/3): the old "no More Actions button" assertion was meaningless after the change (the button is gone for everyone), so it was replaced with a positive "current user shows Your Profile" + a complementary "other users do not show Your Profile" test, plus the right-click test.
- [x] Lint + format clean.
- [ ] Manual verification: user list page → cards have gradient borders that animate with pointer movement; right-click on a non-self user opens the context menu; clicking "Your Profile" on self navigates to profile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User cards now display dynamic, per-user gradient borders.

* **UI/UX Changes**
  * Right-clicking a user card opens the context menu; the "More Actions" button remains available for other users and is hidden for your own profile.

* **Tests**
  * Expanded tests covering right-click context-menu invocation and separate assertions for current-user link/button visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->