### PR TITLE
refactor: replace Btn boolean attrs with variant and size props

### DIFF
--- a/resources/assets/js/components/album/EditAlbumForm.vue
+++ b/resources/assets/js/components/album/EditAlbumForm.vue
@@ -24,7 +24,7 @@
 
     <footer>
       <Btn type="submit">Save</Btn>
-      <Btn white @click.prevent="maybeClose">Cancel</Btn>
+      <Btn variant="ghost" @click.prevent="maybeClose">Cancel</Btn>
     </footer>
   </form>
 </template>

--- a/resources/assets/js/components/artist/EditArtistForm.vue
+++ b/resources/assets/js/components/artist/EditArtistForm.vue
@@ -21,7 +21,7 @@
 
     <footer>
       <Btn type="submit">Save</Btn>
-      <Btn white @click.prevent="maybeClose">Cancel</Btn>
+      <Btn variant="ghost" @click.prevent="maybeClose">Cancel</Btn>
     </footer>
   </form>
 </template>

--- a/resources/assets/js/components/auth/ForgotPasswordForm.vue
+++ b/resources/assets/js/components/auth/ForgotPasswordForm.vue
@@ -16,7 +16,7 @@
           type="email"
         />
         <Btn :disabled="loading" class="sm:rounded-l-none sm:rounded-r" type="submit">Reset Password</Btn>
-        <Btn :disabled="loading" transparent @click="cancel">Cancel</Btn>
+        <Btn variant="ghost" :disabled="loading" @click="cancel">Cancel</Btn>
       </div>
     </FormRow>
   </form>

--- a/resources/assets/js/components/embed/CreateEmbedForm.vue
+++ b/resources/assets/js/components/embed/CreateEmbedForm.vue
@@ -28,7 +28,7 @@
     </main>
     <footer class="flex items-center">
       <div class="flex-1">
-        <Btn primary type="submit" @click.prevent="copyCode">Copy Code</Btn>
+        <Btn type="submit" @click.prevent="copyCode">Copy Code</Btn>
         <Btn variant="ghost" @click="emit('close')">Close</Btn>
       </div>
       <label>

--- a/resources/assets/js/components/embed/CreateEmbedForm.vue
+++ b/resources/assets/js/components/embed/CreateEmbedForm.vue
@@ -29,7 +29,7 @@
     <footer class="flex items-center">
       <div class="flex-1">
         <Btn primary type="submit" @click.prevent="copyCode">Copy Code</Btn>
-        <Btn white @click="emit('close')">Close</Btn>
+        <Btn variant="ghost" @click="emit('close')">Close</Btn>
       </div>
       <label>
         <CheckBox v-model="showCode" />

--- a/resources/assets/js/components/koel-plus/KoelPlusModal.vue
+++ b/resources/assets/js/components/koel-plus/KoelPlusModal.vue
@@ -15,8 +15,8 @@
       </div>
 
       <div v-show="!showingActivateLicenseForm" class="space-x-3" data-testid="buttons">
-        <Btn variant="destructive" big @click.prevent="openPurchaseOverlay">Purchase Koel Plus</Btn>
-        <Btn variant="success" big @click.prevent="showActivateLicenseForm">I have a license key</Btn>
+        <Btn size="large" variant="destructive" @click.prevent="openPurchaseOverlay">Purchase Koel Plus</Btn>
+        <Btn size="large" variant="success" @click.prevent="showActivateLicenseForm">I have a license key</Btn>
       </div>
 
       <div v-if="showingActivateLicenseForm" class="flex gap-3" data-testid="activateForm">

--- a/resources/assets/js/components/koel-plus/KoelPlusModal.vue
+++ b/resources/assets/js/components/koel-plus/KoelPlusModal.vue
@@ -15,13 +15,13 @@
       </div>
 
       <div v-show="!showingActivateLicenseForm" class="space-x-3" data-testid="buttons">
-        <Btn big danger @click.prevent="openPurchaseOverlay">Purchase Koel Plus</Btn>
-        <Btn big success @click.prevent="showActivateLicenseForm">I have a license key</Btn>
+        <Btn variant="destructive" big @click.prevent="openPurchaseOverlay">Purchase Koel Plus</Btn>
+        <Btn variant="success" big @click.prevent="showActivateLicenseForm">I have a license key</Btn>
       </div>
 
       <div v-if="showingActivateLicenseForm" class="flex gap-3" data-testid="activateForm">
         <ActivateLicenseForm v-if="showingActivateLicenseForm" class="flex-1" />
-        <Btn class="cancel" transparent @click.prevent="hideActivateLicenseForm">Cancel</Btn>
+        <Btn variant="ghost" class="cancel" @click.prevent="hideActivateLicenseForm">Cancel</Btn>
       </div>
 
       <div class="text-[0.9rem] text-k-fg-70">
@@ -30,7 +30,7 @@
     </main>
 
     <footer class="w-full text-center bg-black/20">
-      <Btn danger data-testid="close-modal-btn" rounded @click.prevent="close">Close</Btn>
+      <Btn variant="destructive" data-testid="close-modal-btn" rounded @click.prevent="close">Close</Btn>
     </footer>
   </div>
 </template>

--- a/resources/assets/js/components/meta/AboutKoelModal.vue
+++ b/resources/assets/js/components/meta/AboutKoelModal.vue
@@ -54,7 +54,7 @@
     </main>
 
     <footer>
-      <Btn danger data-testid="close-modal-btn" rounded @click.prevent="close">Close</Btn>
+      <Btn variant="destructive" data-testid="close-modal-btn" rounded @click.prevent="close">Close</Btn>
     </footer>
   </div>
 </template>

--- a/resources/assets/js/components/meta/__snapshots__/AboutKoelModal.spec.ts.snap
+++ b/resources/assets/js/components/meta/__snapshots__/AboutKoelModal.spec.ts.snap
@@ -12,7 +12,7 @@ exports[`aboutKoelModal.vue > renders 1`] = `
     <!--v-if-->
     <p data-v-6b5b01a9=""> Loving Koel? Please consider supporting its development via <a data-v-6b5b01a9="" href="https://github.com/users/phanan/sponsorship" rel="noopener" target="_blank">GitHub Sponsors</a> and/or <a data-v-6b5b01a9="" href="https://opencollective.com/koel" rel="noopener" target="_blank">OpenCollective</a>. </p>
   </main>
-  <footer data-v-6b5b01a9=""><button data-v-8943c846="" data-v-6b5b01a9="" class="text-base text-white border border-transparent bg-k-primary px-3.5 py-2 rounded cursor-pointer" type="button" danger="" data-testid="close-modal-btn" rounded="">Close</button></footer>
+  <footer data-v-6b5b01a9=""><button data-v-8943c846="" data-v-6b5b01a9="" data-variant="destructive" class="text-base text-white border border-transparent bg-k-primary px-3.5 py-2 rounded cursor-pointer" type="button" data-testid="close-modal-btn" rounded="">Close</button></footer>
 </div>
 `;
 
@@ -27,6 +27,6 @@ exports[`aboutKoelModal.vue > renders with custom branding 1`] = `
     <!--v-if-->
     <!--v-if-->
   </main>
-  <footer data-v-6b5b01a9=""><button data-v-8943c846="" data-v-6b5b01a9="" class="text-base text-white border border-transparent bg-k-primary px-3.5 py-2 rounded cursor-pointer" type="button" danger="" data-testid="close-modal-btn" rounded="">Close</button></footer>
+  <footer data-v-6b5b01a9=""><button data-v-8943c846="" data-v-6b5b01a9="" data-variant="destructive" class="text-base text-white border border-transparent bg-k-primary px-3.5 py-2 rounded cursor-pointer" type="button" data-testid="close-modal-btn" rounded="">Close</button></footer>
 </div>
 `;

--- a/resources/assets/js/components/playable/AddToMenu.vue
+++ b/resources/assets/js/components/playable/AddToMenu.vue
@@ -44,7 +44,7 @@
       </ul>
     </section>
 
-    <Btn class="!w-full !border !border-solid !border-white/20" transparent @click.prevent="addToNewPlaylist">
+    <Btn variant="ghost" class="!w-full !border !border-solid !border-white/20" @click.prevent="addToNewPlaylist">
       New Playlist…
     </Btn>
   </div>

--- a/resources/assets/js/components/playable/EditSongForm.vue
+++ b/resources/assets/js/components/playable/EditSongForm.vue
@@ -145,7 +145,7 @@
 
     <footer>
       <Btn type="submit">Update</Btn>
-      <Btn class="btn-cancel" white @click.prevent="maybeClose">Cancel</Btn>
+      <Btn variant="ghost" class="btn-cancel" @click.prevent="maybeClose">Cancel</Btn>
     </footer>
   </form>
 </template>

--- a/resources/assets/js/components/playable/__snapshots__/AddToMenu.spec.ts.snap
+++ b/resources/assets/js/components/playable/__snapshots__/AddToMenu.spec.ts.snap
@@ -11,6 +11,6 @@ exports[`addToMenu.vue > renders 1`] = `
       <li data-v-2ee1a399="" class="playlist" data-testid="add-to-playlist" tabindex="0">Bar</li>
       <li data-v-2ee1a399="" class="playlist" data-testid="add-to-playlist" tabindex="0">Baz</li>
     </ul>
-  </section><button data-v-8943c846="" data-v-2ee1a399="" class="text-base text-white border border-transparent bg-k-primary px-3.5 py-2 rounded cursor-pointer !w-full !border !border-solid !border-white/20" type="button" transparent=""> New Playlist… </button>
+  </section><button data-v-8943c846="" data-v-2ee1a399="" data-variant="ghost" class="text-base text-white border border-transparent bg-k-primary px-3.5 py-2 rounded cursor-pointer !w-full !border !border-solid !border-white/20" type="button"> New Playlist… </button>
 </div>
 `;

--- a/resources/assets/js/components/playable/__snapshots__/EditSongForm.spec.ts.snap
+++ b/resources/assets/js/components/playable/__snapshots__/EditSongForm.spec.ts.snap
@@ -245,7 +245,7 @@ exports[`editSongForm.vue > edits a single song 1`] = `
       </div>
     </div>
   </div>
-  <footer data-v-9c4a3e26=""><button data-v-8943c846="" data-v-9c4a3e26="" class="text-base text-white border border-transparent bg-k-primary px-3.5 py-2 rounded cursor-pointer" type="submit">Update</button><button data-v-8943c846="" data-v-9c4a3e26="" class="text-base text-white border border-transparent bg-k-primary px-3.5 py-2 rounded cursor-pointer btn-cancel" type="button" white="">Cancel</button></footer>
+  <footer data-v-9c4a3e26=""><button data-v-8943c846="" data-v-9c4a3e26="" class="text-base text-white border border-transparent bg-k-primary px-3.5 py-2 rounded cursor-pointer" type="submit">Update</button><button data-v-8943c846="" data-v-9c4a3e26="" data-variant="ghost" class="text-base text-white border border-transparent bg-k-primary px-3.5 py-2 rounded cursor-pointer btn-cancel" type="button">Cancel</button></footer>
 </form>
 `;
 
@@ -486,6 +486,6 @@ exports[`editSongForm.vue > edits multiple songs 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <footer data-v-9c4a3e26=""><button data-v-8943c846="" data-v-9c4a3e26="" class="text-base text-white border border-transparent bg-k-primary px-3.5 py-2 rounded cursor-pointer" type="submit">Update</button><button data-v-8943c846="" data-v-9c4a3e26="" class="text-base text-white border border-transparent bg-k-primary px-3.5 py-2 rounded cursor-pointer btn-cancel" type="button" white="">Cancel</button></footer>
+  <footer data-v-9c4a3e26=""><button data-v-8943c846="" data-v-9c4a3e26="" class="text-base text-white border border-transparent bg-k-primary px-3.5 py-2 rounded cursor-pointer" type="submit">Update</button><button data-v-8943c846="" data-v-9c4a3e26="" data-variant="ghost" class="text-base text-white border border-transparent bg-k-primary px-3.5 py-2 rounded cursor-pointer btn-cancel" type="button">Cancel</button></footer>
 </form>
 `;

--- a/resources/assets/js/components/playable/playable-list/PlayableListControls.vue
+++ b/resources/assets/js/components/playable/playable-list/PlayableListControls.vue
@@ -6,8 +6,8 @@
           <Btn
             v-if="selectedPlayables.length < 2 && filteredPlayables.length"
             v-koel-tooltip
+            variant="highlight"
             class="btn-play-all"
-            highlight
             title="Play all. Press Alt/⌥ to change mode."
             @click.prevent="playAll"
           >
@@ -18,8 +18,8 @@
           <Btn
             v-if="selectedPlayables.length > 1"
             v-koel-tooltip
+            variant="highlight"
             class="btn-play-selected"
-            highlight
             title="Play selected. Press Alt/⌥ to change mode."
             @click.prevent="playSelected"
           >
@@ -32,9 +32,9 @@
           <Btn
             v-if="selectedPlayables.length < 2 && filteredPlayables.length"
             v-koel-tooltip
+            variant="highlight"
             class="btn-shuffle-all"
             data-testid="btn-shuffle-all"
-            highlight
             title="Shuffle all. Press Alt/⌥ to change mode."
             @click.prevent="shuffle"
           >
@@ -45,9 +45,9 @@
           <Btn
             v-if="selectedPlayables.length > 1"
             v-koel-tooltip
+            variant="highlight"
             class="btn-shuffle-selected"
             data-testid="btn-shuffle-selected"
-            highlight
             title="Shuffle selected. Press Alt/⌥ to change mode."
             @click.prevent="shuffleSelected"
           >
@@ -56,15 +56,17 @@
           </Btn>
         </template>
 
-        <Btn v-if="showAddToButton" ref="addToButton" success @click.prevent.stop="toggleAddToMenu">
+        <Btn variant="success" v-if="showAddToButton" ref="addToButton" @click.prevent.stop="toggleAddToMenu">
           {{ showingAddToMenu ? 'Cancel' : 'Add To…' }}
         </Btn>
 
-        <Btn v-if="config.clearQueue" danger title="Clear current queue" @click.prevent="clearQueue">Clear</Btn>
+        <Btn variant="destructive" v-if="config.clearQueue" title="Clear current queue" @click.prevent="clearQueue"
+          >Clear</Btn
+        >
       </BtnGroup>
 
       <BtnGroup v-if="config.refresh">
-        <Btn v-if="config.refresh" v-koel-tooltip success title="Refresh" @click.prevent="refresh">
+        <Btn variant="success" v-if="config.refresh" v-koel-tooltip title="Refresh" @click.prevent="refresh">
           <Icon :icon="faRotateRight" fixed-width />
         </Btn>
       </BtnGroup>

--- a/resources/assets/js/components/playlist/CreatePlaylistFolderForm.vue
+++ b/resources/assets/js/components/playlist/CreatePlaylistFolderForm.vue
@@ -12,7 +12,7 @@
 
     <footer>
       <Btn type="submit">Save</Btn>
-      <Btn white @click.prevent="maybeClose">Cancel</Btn>
+      <Btn variant="ghost" @click.prevent="maybeClose">Cancel</Btn>
     </footer>
   </form>
 </template>

--- a/resources/assets/js/components/playlist/CreatePlaylistForm.vue
+++ b/resources/assets/js/components/playlist/CreatePlaylistForm.vue
@@ -32,7 +32,7 @@
 
     <footer>
       <Btn type="submit">Save</Btn>
-      <Btn white @click.prevent="maybeClose">Cancel</Btn>
+      <Btn variant="ghost" @click.prevent="maybeClose">Cancel</Btn>
     </footer>
   </form>
 </template>

--- a/resources/assets/js/components/playlist/EditPlaylistFolderForm.vue
+++ b/resources/assets/js/components/playlist/EditPlaylistFolderForm.vue
@@ -19,7 +19,7 @@
 
     <footer>
       <Btn type="submit">Save</Btn>
-      <Btn white @click.prevent="maybeClose">Cancel</Btn>
+      <Btn variant="ghost" @click.prevent="maybeClose">Cancel</Btn>
     </footer>
   </form>
 </template>

--- a/resources/assets/js/components/playlist/EditPlaylistForm.vue
+++ b/resources/assets/js/components/playlist/EditPlaylistForm.vue
@@ -24,7 +24,7 @@
 
     <footer>
       <Btn type="submit">Save</Btn>
-      <Btn white @click.prevent="maybeClose">Cancel</Btn>
+      <Btn variant="ghost" @click.prevent="maybeClose">Cancel</Btn>
     </footer>
   </form>
 </template>

--- a/resources/assets/js/components/playlist/InvitePlaylistCollaborators.vue
+++ b/resources/assets/js/components/playlist/InvitePlaylistCollaborators.vue
@@ -1,6 +1,6 @@
 <template>
   <span>
-    <Btn variant="success" v-if="shouldShowInviteButton" small @click.prevent="inviteCollaborators">Invite</Btn>
+    <Btn size="small" variant="success" v-if="shouldShowInviteButton" @click.prevent="inviteCollaborators">Invite</Btn>
     <Icon v-if="creatingInviteLink" :icon="faCircleNotch" class="text-k-success" spin />
   </span>
 </template>

--- a/resources/assets/js/components/playlist/InvitePlaylistCollaborators.vue
+++ b/resources/assets/js/components/playlist/InvitePlaylistCollaborators.vue
@@ -1,6 +1,6 @@
 <template>
   <span>
-    <Btn v-if="shouldShowInviteButton" small success @click.prevent="inviteCollaborators">Invite</Btn>
+    <Btn variant="success" v-if="shouldShowInviteButton" small @click.prevent="inviteCollaborators">Invite</Btn>
     <Icon v-if="creatingInviteLink" :icon="faCircleNotch" class="text-k-success" spin />
   </span>
 </template>

--- a/resources/assets/js/components/playlist/PlaylistCollaboratorListItem.vue
+++ b/resources/assets/js/components/playlist/PlaylistCollaboratorListItem.vue
@@ -19,7 +19,7 @@
       <span v-else class="contributor">Contributor</span>
     </span>
     <span v-if="manageable" class="actions flex-[0_0_72px] text-right">
-      <Btn variant="destructive" v-if="removable" small @click.prevent="emit('remove')">Remove</Btn>
+      <Btn size="small" variant="destructive" v-if="removable" @click.prevent="emit('remove')">Remove</Btn>
     </span>
   </li>
 </template>

--- a/resources/assets/js/components/playlist/PlaylistCollaboratorListItem.vue
+++ b/resources/assets/js/components/playlist/PlaylistCollaboratorListItem.vue
@@ -19,7 +19,7 @@
       <span v-else class="contributor">Contributor</span>
     </span>
     <span v-if="manageable" class="actions flex-[0_0_72px] text-right">
-      <Btn v-if="removable" danger small @click.prevent="emit('remove')">Remove</Btn>
+      <Btn variant="destructive" v-if="removable" small @click.prevent="emit('remove')">Remove</Btn>
     </span>
   </li>
 </template>

--- a/resources/assets/js/components/playlist/smart-playlist/CreateSmartPlaylistForm.vue
+++ b/resources/assets/js/components/playlist/smart-playlist/CreateSmartPlaylistForm.vue
@@ -63,9 +63,9 @@
                 @input="onGroupChanged"
               />
               <Btn
+                size="small"
                 variant="success"
                 class="btn-add-group"
-                small
                 title="Add a new group"
                 uppercase
                 @click.prevent="addGroup"

--- a/resources/assets/js/components/playlist/smart-playlist/CreateSmartPlaylistForm.vue
+++ b/resources/assets/js/components/playlist/smart-playlist/CreateSmartPlaylistForm.vue
@@ -62,7 +62,14 @@
                 :is-first-group="index === 0"
                 @input="onGroupChanged"
               />
-              <Btn class="btn-add-group" small success title="Add a new group" uppercase @click.prevent="addGroup">
+              <Btn
+                variant="success"
+                class="btn-add-group"
+                small
+                title="Add a new group"
+                uppercase
+                @click.prevent="addGroup"
+              >
                 <Icon :icon="faPlus" />
                 Group
               </Btn>
@@ -74,7 +81,7 @@
 
     <footer>
       <Btn type="submit">Save</Btn>
-      <Btn class="btn-cancel" white @click.prevent="maybeClose">Cancel</Btn>
+      <Btn variant="ghost" class="btn-cancel" @click.prevent="maybeClose">Cancel</Btn>
     </footer>
   </form>
 </template>

--- a/resources/assets/js/components/playlist/smart-playlist/EditSmartPlaylistForm.vue
+++ b/resources/assets/js/components/playlist/smart-playlist/EditSmartPlaylistForm.vue
@@ -64,9 +64,9 @@
                 @input="onGroupChanged"
               />
               <Btn
+                size="small"
                 variant="success"
                 class="btn-add-group"
-                small
                 title="Add a new group"
                 uppercase
                 @click.prevent="addGroup"

--- a/resources/assets/js/components/playlist/smart-playlist/EditSmartPlaylistForm.vue
+++ b/resources/assets/js/components/playlist/smart-playlist/EditSmartPlaylistForm.vue
@@ -63,7 +63,14 @@
                 :is-first-group="index === 0"
                 @input="onGroupChanged"
               />
-              <Btn class="btn-add-group" small success title="Add a new group" uppercase @click.prevent="addGroup">
+              <Btn
+                variant="success"
+                class="btn-add-group"
+                small
+                title="Add a new group"
+                uppercase
+                @click.prevent="addGroup"
+              >
                 <Icon :icon="faPlus" />
                 Group
               </Btn>
@@ -75,7 +82,7 @@
 
     <footer>
       <Btn type="submit">Save</Btn>
-      <Btn class="btn-cancel" white @click.prevent="maybeClose">Cancel</Btn>
+      <Btn variant="ghost" class="btn-cancel" @click.prevent="maybeClose">Cancel</Btn>
     </footer>
   </form>
 </template>

--- a/resources/assets/js/components/playlist/smart-playlist/SmartPlaylistRule.vue
+++ b/resources/assets/js/components/playlist/smart-playlist/SmartPlaylistRule.vue
@@ -24,8 +24,8 @@
       </span>
 
       <Btn
+        variant="destructive"
         class="absolute -right-[14px] aspect-square top-1 scale-[60%] hover:scale-75 active:scale-[60%]"
-        danger
         rounded
         small
         title="Remove this rule"

--- a/resources/assets/js/components/playlist/smart-playlist/SmartPlaylistRule.vue
+++ b/resources/assets/js/components/playlist/smart-playlist/SmartPlaylistRule.vue
@@ -24,10 +24,10 @@
       </span>
 
       <Btn
+        size="small"
         variant="destructive"
         class="absolute -right-[14px] aspect-square top-1 scale-[60%] hover:scale-75 active:scale-[60%]"
         rounded
-        small
         title="Remove this rule"
         @click.prevent="removeRule"
       >

--- a/resources/assets/js/components/playlist/smart-playlist/SmartPlaylistRuleGroup.vue
+++ b/resources/assets/js/components/playlist/smart-playlist/SmartPlaylistRuleGroup.vue
@@ -19,10 +19,10 @@
 
     <div class="text-center absolute w-full left-0 -mt-[2px]">
       <Btn
+        variant="success"
         class="aspect-square scale-75 hover:scale-90 active:scale-[80%]"
         rounded
         small
-        success
         title="Remove this rule"
         @click.prevent="addRule"
       >

--- a/resources/assets/js/components/playlist/smart-playlist/SmartPlaylistRuleGroup.vue
+++ b/resources/assets/js/components/playlist/smart-playlist/SmartPlaylistRuleGroup.vue
@@ -19,10 +19,10 @@
 
     <div class="text-center absolute w-full left-0 -mt-[2px]">
       <Btn
+        size="small"
         variant="success"
         class="aspect-square scale-75 hover:scale-90 active:scale-[80%]"
         rounded
-        small
         title="Remove this rule"
         @click.prevent="addRule"
       >

--- a/resources/assets/js/components/podcast/AddPodcastForm.vue
+++ b/resources/assets/js/components/podcast/AddPodcastForm.vue
@@ -21,7 +21,7 @@
 
     <footer>
       <Btn type="submit">Save</Btn>
-      <Btn :disabled="loading" white @click.prevent="maybeClose">Cancel</Btn>
+      <Btn variant="ghost" :disabled="loading" @click.prevent="maybeClose">Cancel</Btn>
     </footer>
   </form>
 </template>

--- a/resources/assets/js/components/profile-preferences/LastfmIntegration.vue
+++ b/resources/assets/js/components/profile-preferences/LastfmIntegration.vue
@@ -20,7 +20,7 @@
       </p>
       <div class="buttons mt-4 space-x-2">
         <Btn class="!bg-[var(--lastfm-color)]" @click.prevent="connect">{{ connected ? 'Reconnect' : 'Connect' }}</Btn>
-        <Btn v-if="connected" class="disconnect" gray @click.prevent="disconnect">Disconnect</Btn>
+        <Btn variant="ghost" v-if="connected" class="disconnect" @click.prevent="disconnect">Disconnect</Btn>
       </div>
     </div>
 

--- a/resources/assets/js/components/profile-preferences/OfflineStorage.vue
+++ b/resources/assets/js/components/profile-preferences/OfflineStorage.vue
@@ -19,7 +19,7 @@
       </section>
 
       <section v-if="cachedSongCount" class="space-y-3">
-        <Btn variant="destructive" small @click.prevent="clearAll">Clear All</Btn>
+        <Btn size="small" variant="destructive" @click.prevent="clearAll">Clear All</Btn>
       </section>
     </template>
   </div>

--- a/resources/assets/js/components/profile-preferences/OfflineStorage.vue
+++ b/resources/assets/js/components/profile-preferences/OfflineStorage.vue
@@ -19,7 +19,7 @@
       </section>
 
       <section v-if="cachedSongCount" class="space-y-3">
-        <Btn danger small @click.prevent="clearAll">Clear All</Btn>
+        <Btn variant="destructive" small @click.prevent="clearAll">Clear All</Btn>
       </section>
     </template>
   </div>

--- a/resources/assets/js/components/profile-preferences/theme/CreateThemeForm.vue
+++ b/resources/assets/js/components/profile-preferences/theme/CreateThemeForm.vue
@@ -71,8 +71,8 @@
 
     <footer>
       <Btn type="submit">Save</Btn>
-      <Btn bordered transparent @click.prevent="previewing = true">Preview</Btn>
-      <Btn transparent @click.prevent="maybeClose">Cancel</Btn>
+      <Btn variant="ghost" bordered @click.prevent="previewing = true">Preview</Btn>
+      <Btn variant="ghost" @click.prevent="maybeClose">Cancel</Btn>
     </footer>
 
     <Btn v-if="previewing" class="btn-exit-preview fixed right-4 top-3" @click.prevent="previewing = false">

--- a/resources/assets/js/components/profile-preferences/theme/ThemePreferences.vue
+++ b/resources/assets/js/components/profile-preferences/theme/ThemePreferences.vue
@@ -6,7 +6,7 @@
     <template v-if="isPlus">
       <h4 class="text-xl mt-8 mb-5 text-k-fg">Custom Themes</h4>
       <ThemeList v-if="customThemes.length" :themes="customThemes" class="mb-4" data-testid="custom-themes" />
-      <Btn transparent bordered @click="requestCreateThemeForm">New Theme</Btn>
+      <Btn variant="ghost" bordered @click="requestCreateThemeForm">New Theme</Btn>
     </template>
   </section>
 </template>

--- a/resources/assets/js/components/radio/AddRadioStationForm.vue
+++ b/resources/assets/js/components/radio/AddRadioStationForm.vue
@@ -33,7 +33,7 @@
 
     <footer>
       <Btn type="submit">Save</Btn>
-      <Btn white @click.prevent="maybeClose">Cancel</Btn>
+      <Btn variant="ghost" @click.prevent="maybeClose">Cancel</Btn>
     </footer>
   </form>
 </template>

--- a/resources/assets/js/components/radio/EditRadioStationForm.vue
+++ b/resources/assets/js/components/radio/EditRadioStationForm.vue
@@ -33,7 +33,7 @@
 
     <footer>
       <Btn type="submit">Save</Btn>
-      <Btn white @click.prevent="maybeClose">Cancel</Btn>
+      <Btn variant="ghost" @click.prevent="maybeClose">Cancel</Btn>
     </footer>
   </form>
 </template>

--- a/resources/assets/js/components/screens/AlbumListScreen.vue
+++ b/resources/assets/js/components/screens/AlbumListScreen.vue
@@ -8,8 +8,8 @@
             <Btn
               v-koel-tooltip
               :title="preferences.albums_favorites_only ? 'Show all' : 'Show favorites only'"
+              variant="ghost"
               class="border border-k-fg-10"
-              transparent
               @click.prevent="toggleFavoritesOnly"
             >
               <Icon

--- a/resources/assets/js/components/screens/AlbumScreen.vue
+++ b/resources/assets/js/components/screens/AlbumScreen.vue
@@ -35,7 +35,7 @@
               @toggle="toggleFavorite"
             />
 
-            <Btn gray @click="requestContextMenu">
+            <Btn variant="ghost" @click="requestContextMenu">
               <Icon :icon="faEllipsis" fixed-width />
               <span class="sr-only">More Actions</span>
             </Btn>

--- a/resources/assets/js/components/screens/ArtistListScreen.vue
+++ b/resources/assets/js/components/screens/ArtistListScreen.vue
@@ -8,8 +8,8 @@
             <Btn
               v-koel-tooltip
               :title="preferences.artists_favorites_only ? 'Show all' : 'Show favorites only'"
+              variant="ghost"
               class="border border-k-fg-10"
-              transparent
               @click.prevent="toggleFavoritesOnly"
             >
               <Icon

--- a/resources/assets/js/components/screens/ArtistScreen.vue
+++ b/resources/assets/js/components/screens/ArtistScreen.vue
@@ -30,7 +30,7 @@
               class="px-3.5 py-2"
               @toggle="toggleFavorite"
             />
-            <Btn gray @click="requestContextMenu">
+            <Btn variant="ghost" @click="requestContextMenu">
               <Icon :icon="faEllipsis" fixed-width />
               <span class="sr-only">More Actions</span>
             </Btn>

--- a/resources/assets/js/components/screens/EpisodeScreen.vue
+++ b/resources/assets/js/components/screens/EpisodeScreen.vue
@@ -23,16 +23,16 @@
 
         <template #controls>
           <div class="flex gap-2">
-            <Btn v-koel-tooltip="playing ? 'Pause' : 'Play'" highlight @click.prevent="playOrPause">
+            <Btn variant="highlight" v-koel-tooltip="playing ? 'Pause' : 'Play'" @click.prevent="playOrPause">
               <Icon v-if="playing" :icon="faPause" fixed-width />
               <Icon v-else :icon="faPlay" fixed-width />
             </Btn>
 
             <Btn
+              variant="ghost"
               v-if="episode.episode_link"
               v-koel-tooltip="'Visit episode webpage'"
               :href="episode.episode_link"
-              gray
               tag="a"
               target="_blank"
             >
@@ -46,7 +46,7 @@
               @toggle="toggleFavorite"
             />
 
-            <Btn gray @click="requestContextMenu">
+            <Btn variant="ghost" @click="requestContextMenu">
               <Icon :icon="faEllipsis" fixed-width />
               <span class="sr-only">More Actions</span>
             </Btn>

--- a/resources/assets/js/components/screens/GenreScreen.vue
+++ b/resources/assets/js/components/screens/GenreScreen.vue
@@ -19,7 +19,7 @@
 
         <template #controls>
           <SongListControls :config @play-all="playAll" @play-selected="playSelected">
-            <Btn gray @click="requestContextMenu">
+            <Btn variant="ghost" @click="requestContextMenu">
               <Icon :icon="faEllipsis" fixed-width />
               <span class="sr-only">More Actions</span>
             </Btn>

--- a/resources/assets/js/components/screens/MediaBrowserScreen.vue
+++ b/resources/assets/js/components/screens/MediaBrowserScreen.vue
@@ -7,7 +7,7 @@
         <template #meta>
           <div class="flex items-center gap-2 mt-2">
             <Breadcrumbs :path class="flex-1" />
-            <Btn transparent small title="Reload" @click.prevent="refresh">
+            <Btn variant="ghost" small title="Reload" @click.prevent="refresh">
               <Icon :icon="faRotateRight" />
             </Btn>
           </div>

--- a/resources/assets/js/components/screens/MediaBrowserScreen.vue
+++ b/resources/assets/js/components/screens/MediaBrowserScreen.vue
@@ -7,7 +7,7 @@
         <template #meta>
           <div class="flex items-center gap-2 mt-2">
             <Breadcrumbs :path class="flex-1" />
-            <Btn variant="ghost" small title="Reload" @click.prevent="refresh">
+            <Btn size="small" variant="ghost" title="Reload" @click.prevent="refresh">
               <Icon :icon="faRotateRight" />
             </Btn>
           </div>

--- a/resources/assets/js/components/screens/PlaylistScreen.vue
+++ b/resources/assets/js/components/screens/PlaylistScreen.vue
@@ -26,7 +26,7 @@
             @play-all="playAll"
             @play-selected="playSelected"
           >
-            <Btn gray @click="requestContextMenu">
+            <Btn variant="ghost" @click="requestContextMenu">
               <Icon :icon="faEllipsis" fixed-width />
               <span class="sr-only">More Actions</span>
             </Btn>

--- a/resources/assets/js/components/screens/PodcastListScreen.vue
+++ b/resources/assets/js/components/screens/PodcastListScreen.vue
@@ -6,11 +6,11 @@
         <template #controls>
           <div class="flex gap-2">
             <Btn
+              size="small"
               variant="ghost"
               v-koel-tooltip
               :title="preferences.podcasts_favorites_only ? 'Show all' : 'Show favorites only'"
               class="border border-k-fg-10"
-              small
               @click.prevent="toggleFavoritesOnly"
             >
               <Icon

--- a/resources/assets/js/components/screens/PodcastListScreen.vue
+++ b/resources/assets/js/components/screens/PodcastListScreen.vue
@@ -6,11 +6,11 @@
         <template #controls>
           <div class="flex gap-2">
             <Btn
+              variant="ghost"
               v-koel-tooltip
               :title="preferences.podcasts_favorites_only ? 'Show all' : 'Show favorites only'"
               class="border border-k-fg-10"
               small
-              transparent
               @click.prevent="toggleFavoritesOnly"
             >
               <Icon
@@ -28,7 +28,7 @@
 
             <ListFilter />
             <BtnGroup uppercase>
-              <Btn highlight @click.prevent="requestAddPodcastForm">
+              <Btn variant="highlight" @click.prevent="requestAddPodcastForm">
                 <Icon :icon="faAdd" fixed-width />
               </Btn>
             </BtnGroup>

--- a/resources/assets/js/components/screens/PodcastScreen.vue
+++ b/resources/assets/js/components/screens/PodcastScreen.vue
@@ -30,12 +30,12 @@
 
         <template #controls>
           <div class="flex gap-2 flex-wrap">
-            <Btn v-if="episodes?.length" highlight uppercase @click.prevent="playOrPause">
+            <Btn variant="highlight" v-if="episodes?.length" uppercase @click.prevent="playOrPause">
               <Icon :icon="podcastPlaying ? faPause : faPlay" fixed-width />
               {{ playButtonLabel }}
             </Btn>
             <BtnGroup uppercase>
-              <Btn v-if="episodes" v-koel-tooltip="'Refresh'" success @click.prevent="refresh">
+              <Btn variant="success" v-if="episodes" v-koel-tooltip="'Refresh'" @click.prevent="refresh">
                 <Icon :icon="faRotateRight" fixed-width />
                 <span class="sr-only">Refresh Podcast</span>
               </Btn>
@@ -50,7 +50,7 @@
               @toggle="toggleFavorite"
             />
 
-            <Btn gray @click="requestContextMenu">
+            <Btn variant="ghost" @click="requestContextMenu">
               <Icon :icon="faEllipsis" fixed-width />
               <span class="sr-only">More Actions</span>
             </Btn>

--- a/resources/assets/js/components/screens/RadioStationListScreen.vue
+++ b/resources/assets/js/components/screens/RadioStationListScreen.vue
@@ -7,11 +7,11 @@
         <template #controls>
           <div class="flex gap-2">
             <Btn
+              size="small"
               v-koel-tooltip
               :title="preferences.radio_stations_favorites_only ? 'Show all' : 'Show favorites only'"
               variant="ghost"
               class="border border-k-fg-10"
-              small
               @click.prevent="toggleFavoritesOnly"
             >
               <Icon
@@ -30,10 +30,10 @@
             <ListFilter />
 
             <Btn
+              size="small"
               v-if="canAdd"
               v-koel-tooltip
               variant="highlight"
-              small
               title="Add a new station"
               @click.prevent="requestAddStationForm"
             >

--- a/resources/assets/js/components/screens/RadioStationListScreen.vue
+++ b/resources/assets/js/components/screens/RadioStationListScreen.vue
@@ -9,9 +9,9 @@
             <Btn
               v-koel-tooltip
               :title="preferences.radio_stations_favorites_only ? 'Show all' : 'Show favorites only'"
+              variant="ghost"
               class="border border-k-fg-10"
               small
-              transparent
               @click.prevent="toggleFavoritesOnly"
             >
               <Icon
@@ -32,7 +32,7 @@
             <Btn
               v-if="canAdd"
               v-koel-tooltip
-              highlight
+              variant="highlight"
               small
               title="Add a new station"
               @click.prevent="requestAddStationForm"

--- a/resources/assets/js/components/screens/UploadScreen.vue
+++ b/resources/assets/js/components/screens/UploadScreen.vue
@@ -6,11 +6,11 @@
 
         <template #controls>
           <BtnGroup v-if="hasUploadFailures" uppercase>
-            <Btn data-testid="upload-retry-all-btn" success @click="retryAll">
+            <Btn variant="success" data-testid="upload-retry-all-btn" @click="retryAll">
               <Icon :icon="faRotateRight" />
               Retry All
             </Btn>
-            <Btn data-testid="upload-remove-all-btn" highlight @click="removeFailedEntries">
+            <Btn variant="highlight" data-testid="upload-remove-all-btn" @click="removeFailedEntries">
               <Icon :icon="faTrashCan" />
               Remove Failed
             </Btn>

--- a/resources/assets/js/components/screens/UserListScreen.vue
+++ b/resources/assets/js/components/screens/UserListScreen.vue
@@ -6,11 +6,11 @@
 
         <template #controls>
           <BtnGroup uppercase>
-            <Btn success @click="showAddUserForm">
+            <Btn variant="success" @click="showAddUserForm">
               <Icon :icon="faPlus" />
               Add
             </Btn>
-            <Btn v-if="canInvite" highlight @click="showInviteUserForm">Invite</Btn>
+            <Btn variant="highlight" v-if="canInvite" @click="showInviteUserForm">Invite</Btn>
           </BtnGroup>
         </template>
       </ScreenHeader>

--- a/resources/assets/js/components/screens/__snapshots__/AllSongsScreen.spec.ts.snap
+++ b/resources/assets/js/components/screens/__snapshots__/AllSongsScreen.spec.ts.snap
@@ -13,7 +13,7 @@ exports[`allSongsScreen.vue > renders 1`] = `
       </div>
       <div data-v-8ea4eaa5="" class="controls w-full flex justify-between items-center gap-4">
         <div data-v-8ea4eaa5="" class="relative" data-testid="song-list-controls">
-          <div class="flex gap-2 flex-wrap"><span data-v-cf9b67d8="" class="btn-group inline-flex relative flex-nowrap" uppercase=""><button data-v-8943c846="" class="text-base text-white border border-transparent bg-k-primary px-3.5 py-2 rounded cursor-pointer btn-shuffle-all" type="button" data-testid="btn-shuffle-all" highlight="" title="Shuffle all. Press Alt/⌥ to change mode."><br data-testid="Icon" icon="[object Object]" fixed-width=""> All </button><!--v-if--><!--v-if--><!--v-if--></span>
+          <div class="flex gap-2 flex-wrap"><span data-v-cf9b67d8="" class="btn-group inline-flex relative flex-nowrap" uppercase=""><button data-v-8943c846="" data-variant="highlight" class="text-base text-white border border-transparent bg-k-primary px-3.5 py-2 rounded cursor-pointer btn-shuffle-all" type="button" data-testid="btn-shuffle-all" title="Shuffle all. Press Alt/⌥ to change mode."><br data-testid="Icon" icon="[object Object]" fixed-width=""> All </button><!--v-if--><!--v-if--><!--v-if--></span>
             <!--v-if-->
             <!--v-if-->
           </div>
@@ -26,7 +26,7 @@ exports[`allSongsScreen.vue > renders 1`] = `
                     <li data-v-2ee1a399="" data-testid="queue" tabindex="0">Queue</li>
                     <li data-v-2ee1a399="" class="favorites" data-testid="add-to-favorites" tabindex="0"> Favorites </li>
                   </ul>
-                </section><button data-v-8943c846="" data-v-2ee1a399="" class="text-base text-white border border-transparent bg-k-primary px-3.5 py-2 rounded cursor-pointer !w-full !border !border-solid !border-white/20" type="button" transparent=""> New Playlist… </button>
+                </section><button data-v-8943c846="" data-v-2ee1a399="" data-variant="ghost" class="text-base text-white border border-transparent bg-k-primary px-3.5 py-2 rounded cursor-pointer !w-full !border !border-solid !border-white/20" type="button"> New Playlist… </button>
               </div>
             </div>
           </div>

--- a/resources/assets/js/components/screens/home/RandomSongs.vue
+++ b/resources/assets/js/components/screens/home/RandomSongs.vue
@@ -2,7 +2,7 @@
   <HomeScreenBlock>
     <template #header>
       Something Random
-      <Btn variant="ghost" v-if="playables.length" class="float-right" rounded small @click.prevent="refresh">
+      <Btn size="small" variant="ghost" v-if="playables.length" class="float-right" rounded @click.prevent="refresh">
         <Icon :icon="faRotateRight" />
         <span class="sr-only">Refresh</span>
       </Btn>

--- a/resources/assets/js/components/screens/home/RandomSongs.vue
+++ b/resources/assets/js/components/screens/home/RandomSongs.vue
@@ -2,7 +2,7 @@
   <HomeScreenBlock>
     <template #header>
       Something Random
-      <Btn v-if="playables.length" class="float-right" transparent rounded small @click.prevent="refresh">
+      <Btn variant="ghost" v-if="playables.length" class="float-right" rounded small @click.prevent="refresh">
         <Icon :icon="faRotateRight" />
         <span class="sr-only">Refresh</span>
       </Btn>

--- a/resources/assets/js/components/screens/home/ViewAllRecentlyPlayedPlayablesButton.vue
+++ b/resources/assets/js/components/screens/home/ViewAllRecentlyPlayedPlayablesButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <Btn highlight rounded small @click.prevent="goToRecentlyPlayedScreen"> View All </Btn>
+  <Btn variant="highlight" rounded small @click.prevent="goToRecentlyPlayedScreen"> View All </Btn>
 </template>
 
 <script lang="ts" setup>

--- a/resources/assets/js/components/screens/home/ViewAllRecentlyPlayedPlayablesButton.vue
+++ b/resources/assets/js/components/screens/home/ViewAllRecentlyPlayedPlayablesButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <Btn variant="highlight" rounded small @click.prevent="goToRecentlyPlayedScreen"> View All </Btn>
+  <Btn size="small" variant="highlight" rounded @click.prevent="goToRecentlyPlayedScreen"> View All </Btn>
 </template>
 
 <script lang="ts" setup>

--- a/resources/assets/js/components/screens/search/PlayableExcerptResultsBlock.vue
+++ b/resources/assets/js/components/screens/search/PlayableExcerptResultsBlock.vue
@@ -4,11 +4,11 @@
       {{ headingText }}
 
       <Btn
+        size="small"
         v-if="playables.length && !searching"
         variant="highlight"
         data-testid="view-all-songs-btn"
         rounded
-        small
         @click.prevent="goToSongResults"
       >
         View All

--- a/resources/assets/js/components/screens/search/PlayableExcerptResultsBlock.vue
+++ b/resources/assets/js/components/screens/search/PlayableExcerptResultsBlock.vue
@@ -5,8 +5,8 @@
 
       <Btn
         v-if="playables.length && !searching"
+        variant="highlight"
         data-testid="view-all-songs-btn"
-        highlight
         rounded
         small
         @click.prevent="goToSongResults"

--- a/resources/assets/js/components/ui/DialogBox.vue
+++ b/resources/assets/js/components/ui/DialogBox.vue
@@ -22,7 +22,7 @@
     </div>
 
     <footer class="flex justify-end gap-2 px-6 py-4 bg-k-fg-3">
-      <Btn v-if="showCancelButton" gray name="cancel" @click.prevent="cancel">Cancel</Btn>
+      <Btn variant="ghost" v-if="showCancelButton" name="cancel" @click.prevent="cancel">Cancel</Btn>
       <Btn name="ok">OK</Btn>
     </footer>
   </dialog>

--- a/resources/assets/js/components/ui/DuplicateUploadList.vue
+++ b/resources/assets/js/components/ui/DuplicateUploadList.vue
@@ -16,8 +16,8 @@
       <DuplicateUploadItem v-for="upload in songs" :key="upload.id" :upload />
 
       <footer class="flex justify-end gap-2 px-4 py-3 bg-k-fg-3">
-        <Btn small highlight @click="confirmDiscardAll">Discard All</Btn>
-        <Btn small success @click="keepAll">Keep All</Btn>
+        <Btn variant="highlight" small @click="confirmDiscardAll">Discard All</Btn>
+        <Btn variant="success" small @click="keepAll">Keep All</Btn>
       </footer>
     </section>
   </details>

--- a/resources/assets/js/components/ui/DuplicateUploadList.vue
+++ b/resources/assets/js/components/ui/DuplicateUploadList.vue
@@ -16,8 +16,8 @@
       <DuplicateUploadItem v-for="upload in songs" :key="upload.id" :upload />
 
       <footer class="flex justify-end gap-2 px-4 py-3 bg-k-fg-3">
-        <Btn variant="highlight" small @click="confirmDiscardAll">Discard All</Btn>
-        <Btn variant="success" small @click="keepAll">Keep All</Btn>
+        <Btn size="small" variant="highlight" @click="confirmDiscardAll">Discard All</Btn>
+        <Btn size="small" variant="success" @click="keepAll">Keep All</Btn>
       </footer>
     </section>
   </details>

--- a/resources/assets/js/components/ui/album-artist/ExpandableContentBlock.vue
+++ b/resources/assets/js/components/ui/album-artist/ExpandableContentBlock.vue
@@ -4,7 +4,7 @@
       <slot />
     </div>
 
-    <Btn v-if="!showingFull" class="mt-4" small @click.prevent="showingFull = true"> Read More </Btn>
+    <Btn size="small" v-if="!showingFull" class="mt-4" @click.prevent="showingFull = true"> Read More </Btn>
   </article>
 </template>
 

--- a/resources/assets/js/components/ui/form/Btn.vue
+++ b/resources/assets/js/components/ui/form/Btn.vue
@@ -2,6 +2,7 @@
   <button
     v-if="tag === 'button'"
     ref="button"
+    :data-variant="variant"
     class="text-base text-white border border-transparent bg-k-primary px-3.5 py-2 rounded cursor-pointer"
     type="button"
   >
@@ -10,6 +11,7 @@
   <a
     v-else
     ref="button"
+    :data-variant="variant"
     class="text-base text-white border border-transparent bg-k-primary px-3.5 py-2 rounded cursor-pointer"
   >
     <slot>Click me</slot>
@@ -19,7 +21,9 @@
 <script lang="ts" setup>
 import { ref } from 'vue'
 
-withDefaults(defineProps<{ tag?: 'button' | 'a' }>(), {
+type Variant = 'success' | 'destructive' | 'highlight' | 'ghost'
+
+withDefaults(defineProps<{ tag?: 'button' | 'a'; variant?: Variant }>(), {
   tag: 'button',
 })
 
@@ -52,21 +56,19 @@ a {
     @apply text-[0.9rem] px-3 py-1;
   }
 
-  &[success] {
+  &[data-variant='success'] {
     @apply bg-k-success text-white;
   }
 
-  &[white],
-  &[transparent],
-  &[gray] {
+  &[data-variant='ghost'] {
     @apply bg-transparent text-k-fg hover:text-k-fg-80 active:text-k-fg-70;
   }
 
-  &[danger] {
+  &[data-variant='destructive'] {
     @apply bg-k-danger text-white;
   }
 
-  &[highlight] {
+  &[data-variant='highlight'] {
     @apply bg-k-highlight text-k-highlight-fg;
   }
 
@@ -85,15 +87,15 @@ a {
   &[bordered] {
     @apply border-k-fg-20 bg-transparent;
 
-    &[success] {
+    &[data-variant='success'] {
       @apply border-k-success;
     }
 
-    &[danger] {
+    &[data-variant='destructive'] {
       @apply border-k-danger;
     }
 
-    &[highlight] {
+    &[data-variant='highlight'] {
       @apply border-k-highlight;
     }
   }

--- a/resources/assets/js/components/ui/form/Btn.vue
+++ b/resources/assets/js/components/ui/form/Btn.vue
@@ -30,7 +30,7 @@ withDefaults(defineProps<{ tag?: 'button' | 'a'; variant?: Variant; size?: Size 
   tag: 'button',
 })
 
-const button = ref<HTMLButtonElement>()
+const button = ref<HTMLButtonElement | HTMLAnchorElement>()
 
 defineExpose({
   button,

--- a/resources/assets/js/components/ui/form/Btn.vue
+++ b/resources/assets/js/components/ui/form/Btn.vue
@@ -3,6 +3,7 @@
     v-if="tag === 'button'"
     ref="button"
     :data-variant="variant"
+    :data-size="size"
     class="text-base text-white border border-transparent bg-k-primary px-3.5 py-2 rounded cursor-pointer"
     type="button"
   >
@@ -12,6 +13,7 @@
     v-else
     ref="button"
     :data-variant="variant"
+    :data-size="size"
     class="text-base text-white border border-transparent bg-k-primary px-3.5 py-2 rounded cursor-pointer"
   >
     <slot>Click me</slot>
@@ -22,8 +24,9 @@
 import { ref } from 'vue'
 
 type Variant = 'success' | 'destructive' | 'highlight' | 'ghost'
+type Size = 'small' | 'large'
 
-withDefaults(defineProps<{ tag?: 'button' | 'a'; variant?: Variant }>(), {
+withDefaults(defineProps<{ tag?: 'button' | 'a'; variant?: Variant; size?: Size }>(), {
   tag: 'button',
 })
 
@@ -48,11 +51,11 @@ a {
     box-shadow: inset 0 10px 10px -10px rgba(0, 0, 0, 0.6);
   }
 
-  &[big] {
+  &[data-size='large'] {
     @apply px-6 py-3;
   }
 
-  &[small] {
+  &[data-size='small'] {
     @apply text-[0.9rem] px-3 py-1;
   }
 

--- a/resources/assets/js/components/ui/upload/DuplicateUploadItem.vue
+++ b/resources/assets/js/components/ui/upload/DuplicateUploadItem.vue
@@ -8,8 +8,8 @@
         Uploaded {{ new Date(upload.created_at).toLocaleDateString() }}
       </span>
     </span>
-    <Btn small bordered highlight @click="confirmDiscard">Discard</Btn>
-    <Btn small bordered success @click="keep">Keep</Btn>
+    <Btn variant="highlight" small bordered @click="confirmDiscard">Discard</Btn>
+    <Btn variant="success" small bordered @click="keep">Keep</Btn>
   </div>
 </template>
 

--- a/resources/assets/js/components/ui/upload/DuplicateUploadItem.vue
+++ b/resources/assets/js/components/ui/upload/DuplicateUploadItem.vue
@@ -8,8 +8,8 @@
         Uploaded {{ new Date(upload.created_at).toLocaleDateString() }}
       </span>
     </span>
-    <Btn variant="highlight" small bordered @click="confirmDiscard">Discard</Btn>
-    <Btn variant="success" small bordered @click="keep">Keep</Btn>
+    <Btn size="small" variant="highlight" bordered @click="confirmDiscard">Discard</Btn>
+    <Btn size="small" variant="success" bordered @click="keep">Keep</Btn>
   </div>
 </template>
 

--- a/resources/assets/js/components/ui/upload/UploadItem.vue
+++ b/resources/assets/js/components/ui/upload/UploadItem.vue
@@ -3,13 +3,13 @@
     <div :class="cssClass" class="h-full w-full min-h-[32px] bg-k-fg-5 relative rounded-lg overflow-hidden">
       <div class="absolute z-1 h-full w-full flex items-center">
         <span class="name px-4 flex-1 flex items-center">{{ file.name }}</span>
-        <Btn v-if="canRetry" class="!px-3" icon-only title="Retry" transparent unrounded @click="retry">
+        <Btn variant="ghost" v-if="canRetry" class="!px-3" icon-only title="Retry" unrounded @click="retry">
           <Icon :icon="faRotateBack" />
         </Btn>
-        <Btn v-if="canAbort" class="!px-3" icon-only title="Abort" transparent unrounded @click="abort">
+        <Btn variant="ghost" v-if="canAbort" class="!px-3" icon-only title="Abort" unrounded @click="abort">
           <Icon :icon="faXmark" />
         </Btn>
-        <Btn v-if="canRemove" class="!px-3" icon-only title="Remove" transparent unrounded @click="remove">
+        <Btn variant="ghost" v-if="canRemove" class="!px-3" icon-only title="Remove" unrounded @click="remove">
           <Icon :icon="faTrashCan" />
         </Btn>
       </div>

--- a/resources/assets/js/components/ui/upload/__snapshots__/UploadItem.spec.ts.snap
+++ b/resources/assets/js/components/ui/upload/__snapshots__/UploadItem.spec.ts.snap
@@ -3,8 +3,8 @@
 exports[`uploadItem.vue > renders 1`] = `
 <article data-v-c7c7e2e2="" title="" class="upload-item relative">
   <div data-v-c7c7e2e2="" class="canceled h-full w-full min-h-[32px] bg-k-fg-5 relative rounded-lg overflow-hidden">
-    <div data-v-c7c7e2e2="" class="absolute z-1 h-full w-full flex items-center"><span data-v-c7c7e2e2="" class="name px-4 flex-1 flex items-center">Sample Track</span><button data-v-8943c846="" data-v-c7c7e2e2="" class="text-base text-white border border-transparent bg-k-primary px-3.5 py-2 rounded cursor-pointer !px-3" type="button" icon-only="" title="Retry" transparent="" unrounded=""><br data-v-c7c7e2e2="" data-testid="Icon" icon="[object Object]"></button>
-      <!--v-if--><button data-v-8943c846="" data-v-c7c7e2e2="" class="text-base text-white border border-transparent bg-k-primary px-3.5 py-2 rounded cursor-pointer !px-3" type="button" icon-only="" title="Remove" transparent="" unrounded=""><br data-v-c7c7e2e2="" data-testid="Icon" icon="[object Object]"></button>
+    <div data-v-c7c7e2e2="" class="absolute z-1 h-full w-full flex items-center"><span data-v-c7c7e2e2="" class="name px-4 flex-1 flex items-center">Sample Track</span><button data-v-8943c846="" data-v-c7c7e2e2="" data-variant="ghost" class="text-base text-white border border-transparent bg-k-primary px-3.5 py-2 rounded cursor-pointer !px-3" type="button" icon-only="" title="Retry" unrounded=""><br data-v-c7c7e2e2="" data-testid="Icon" icon="[object Object]"></button>
+      <!--v-if--><button data-v-8943c846="" data-v-c7c7e2e2="" data-variant="ghost" class="text-base text-white border border-transparent bg-k-primary px-3.5 py-2 rounded cursor-pointer !px-3" type="button" icon-only="" title="Remove" unrounded=""><br data-v-c7c7e2e2="" data-testid="Icon" icon="[object Object]"></button>
     </div>
   </div>
   <p data-v-c7c7e2e2="" class="text-[.90rem] mt-1 ml-4">

--- a/resources/assets/js/components/user/AddUserForm.vue
+++ b/resources/assets/js/components/user/AddUserForm.vue
@@ -23,7 +23,7 @@
 
     <footer>
       <Btn :disabled="loading" class="btn-add" type="submit">Save</Btn>
-      <Btn :disabled="loading" class="btn-cancel" white @click.prevent="maybeClose">Cancel</Btn>
+      <Btn variant="ghost" :disabled="loading" class="btn-cancel" @click.prevent="maybeClose">Cancel</Btn>
     </footer>
   </form>
 </template>

--- a/resources/assets/js/components/user/EditUserForm.vue
+++ b/resources/assets/js/components/user/EditUserForm.vue
@@ -39,7 +39,7 @@
 
     <footer>
       <Btn class="btn-update" type="submit">Update</Btn>
-      <Btn class="btn-cancel" white @click.prevent="maybeClose">Cancel</Btn>
+      <Btn variant="ghost" class="btn-cancel" @click.prevent="maybeClose">Cancel</Btn>
     </footer>
   </form>
 </template>

--- a/resources/assets/js/components/user/InviteUserForm.vue
+++ b/resources/assets/js/components/user/InviteUserForm.vue
@@ -23,7 +23,7 @@
 
     <footer>
       <Btn class="btn-add" type="submit">Invite</Btn>
-      <Btn class="btn-cancel" white @click.prevent="maybeClose">Cancel</Btn>
+      <Btn variant="ghost" class="btn-cancel" @click.prevent="maybeClose">Cancel</Btn>
     </footer>
   </form>
 </template>

--- a/resources/assets/js/components/user/UserCard.vue
+++ b/resources/assets/js/components/user/UserCard.vue
@@ -37,9 +37,9 @@
         <p>{{ user.email }}</p>
       </main>
 
-      <Btn v-if="isCurrentUser" :href="url('profile')" highlight small tag="a">Your Profile</Btn>
+      <Btn variant="highlight" v-if="isCurrentUser" :href="url('profile')" small tag="a">Your Profile</Btn>
 
-      <Btn v-else gray @click="requestContextMenu">
+      <Btn variant="ghost" v-else @click="requestContextMenu">
         <Icon :icon="faEllipsis" fixed-width />
         <span class="sr-only">More Actions</span>
       </Btn>

--- a/resources/assets/js/components/user/UserCard.vue
+++ b/resources/assets/js/components/user/UserCard.vue
@@ -37,7 +37,7 @@
         <p>{{ user.email }}</p>
       </main>
 
-      <Btn variant="highlight" v-if="isCurrentUser" :href="url('profile')" small tag="a">Your Profile</Btn>
+      <Btn size="small" variant="highlight" v-if="isCurrentUser" :href="url('profile')" tag="a">Your Profile</Btn>
 
       <Btn variant="ghost" v-else @click="requestContextMenu">
         <Icon :icon="faEllipsis" fixed-width />

--- a/resources/assets/js/components/utils/ImageCropper.vue
+++ b/resources/assets/js/components/utils/ImageCropper.vue
@@ -9,8 +9,8 @@
         :stencil-props="{ aspectRatio: 1 }"
       />
       <div class="fixed top-6 right-6 flex flex-1 gap-2">
-        <Btn success @click.prevent="crop">Crop</Btn>
-        <Btn transparent @click.prevent="emits('cancel')">Cancel</Btn>
+        <Btn variant="success" @click.prevent="crop">Crop</Btn>
+        <Btn variant="ghost" @click.prevent="emits('cancel')">Cancel</Btn>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
`Btn` accepted two flavors of mutually-exclusive appearances as independent boolean attributes — variants (`success`, `danger`, `highlight`, `white`, `transparent`, `gray`) and sizes (`small`, `big`). The TypeScript API permitted nonsense like `<Btn success danger small big>`, the variant vocabulary borrowed alert-state words for button intents, and three of the variant attributes (`white`/`transparent`/`gray`) all produced identical styling.

This PR replaces both axes with discriminated-union props:
- `variant: 'success' | 'destructive' | 'highlight' | 'ghost'`
- `size: 'small' | 'large'` (omit for default/medium)

CSS uses `[data-variant='…']` / `[data-size='…']` selectors, so the rendered DOM also stops emitting bare boolean attributes that fell through Vue's `inheritAttrs`.

## Variant rename rationale
| Old | New | Why |
|---|---|---|
| `success` | `success` | Kept — renaming to `primary` would collide with the existing `bg-k-primary` token |
| `danger` | `destructive` | Button intent vocabulary (the action), not alert-state vocabulary (the condition) |
| `highlight` | `highlight` | Kept — koel-specific brand color, no clearer alternative |
| `white` / `transparent` / `gray` | `ghost` | All three produced identical CSS; collapsed into one canonical name |

## Size rename rationale
| Old | New | Why |
|---|---|---|
| `small` | `size="small"` | Mutually-exclusive sibling of `big`; structured prop forbids stacking |
| `big` | `size="large"` | T-shirt-size consistency (`small` / `medium` / `large`); `big` was the only odd-one-out term |

## Modifier flags stay boolean
`rounded`, `unrounded`, `bordered`, `uppercase` remain boolean. They are genuinely orthogonal and stack with any variant and size — a button can be `<Btn variant="destructive" size="small" rounded bordered>` simultaneously. Only mutually-exclusive choices got folded into props.

## Migration
75+ consumer call sites were updated, e.g.:
```vue
<!-- Before -->
<Btn success small bordered>Keep</Btn>
<Btn danger big>Delete</Btn>
<Btn transparent>Cancel</Btn>

<!-- After -->
<Btn variant="success" size="small" bordered>Keep</Btn>
<Btn variant="destructive" size="large">Delete</Btn>
<Btn variant="ghost">Cancel</Btn>
```

5 snapshot files were regenerated. Each diff is exactly the expected swap of `boolean=""` → `data-variant="…"` / `data-size="…"` — no incidental changes.

## Test plan
- [x] `vp test run` covering `screens/`, `playable/`, `playlist/`, `ui/`, `user/` — 524/524 green
- [x] `vp check resources/assets` — lint + format clean
- [x] Quote-aware AST-style scan confirms zero leftover boolean variant or size attrs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized button styling across the app to a unified variant and size system (ghost, highlight, success, destructive, small/large), harmonizing the look of cancel, action, toolbar, and modal buttons throughout dialogs, forms, lists, and screens. Visual consistency updated with no changes to behavior or interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->