### PR TITLE
fix: add hover state to BasicListSorter menu items

### DIFF
--- a/resources/assets/js/components/ui/BasicListSorter.spec.ts
+++ b/resources/assets/js/components/ui/BasicListSorter.spec.ts
@@ -58,13 +58,6 @@ describe('basicListSorter', () => {
     expect(dateItem.classList.contains('active')).toBe(true)
   })
 
-  it('applies hover styling to menu items', () => {
-    renderComponent()
-    const item = screen.getByTitle('Sort by Name')
-    expect(item.classList.contains('hover:bg-k-highlight')).toBe(true)
-    expect(item.classList.contains('hover:text-k-highlight-fg')).toBe(true)
-  })
-
   it('emits sort with toggled order when clicking current field', async () => {
     const { emitted } = renderComponent('name', 'asc')
 

--- a/resources/assets/js/components/ui/BasicListSorter.spec.ts
+++ b/resources/assets/js/components/ui/BasicListSorter.spec.ts
@@ -58,6 +58,13 @@ describe('basicListSorter', () => {
     expect(dateItem.classList.contains('active')).toBe(true)
   })
 
+  it('applies hover styling to menu items', () => {
+    renderComponent()
+    const item = screen.getByTitle('Sort by Name')
+    expect(item.classList.contains('hover:bg-k-highlight')).toBe(true)
+    expect(item.classList.contains('hover:text-k-highlight-fg')).toBe(true)
+  })
+
   it('emits sort with toggled order when clicking current field', async () => {
     const { emitted } = renderComponent('name', 'asc')
 

--- a/resources/assets/js/components/ui/BasicListSorter.vue
+++ b/resources/assets/js/components/ui/BasicListSorter.vue
@@ -16,7 +16,7 @@
           :key="item.label"
           :class="isCurrentField(item.field) && 'active'"
           :title="`Sort by ${item.label}`"
-          class="cursor-pointer group flex justify-between"
+          class="cursor-pointer group flex justify-between hover:bg-k-highlight hover:text-k-highlight-fg"
           @click="sort(item.field)"
         >
           <span>{{ item.label }}</span>


### PR DESCRIPTION
## Summary
The sort dropdown's menu items had no visible hover response, making it unclear which option would be selected on click. Notably, the icon shown next to the active sort field already used \`group-hover:text-k-highlight-fg\` — anticipating a parent hover state that was never wired up.

This adds \`hover:bg-k-highlight hover:text-k-highlight-fg\` to the \`<li>\`, matching how \`ContextMenuItem\` styles hover and focus elsewhere in koel.

## Test plan
- [x] \`vp test run\` for \`BasicListSorter.spec.ts\` — all 8 existing tests pass
- [x] \`vp check resources/assets\` — lint + format clean
- [ ] Hover state visual verification in a running browser (not done — please confirm visually before merge)

## Follow-up note
The \`active\` class applied to the current sort field (line 17) has no global CSS rule — it's a dead class. Out of scope for this hover fix, but worth a future pass to either give it a visible style or remove it.