### PR TITLE
feat: keyboard navigation in BasicListSorter menu

### DIFF
--- a/resources/assets/js/components/ui/BasicListSorter.spec.ts
+++ b/resources/assets/js/components/ui/BasicListSorter.spec.ts
@@ -72,4 +72,113 @@ describe('basicListSorter', () => {
     const button = screen.getByRole('button')
     expect(button.getAttribute('title')).toBe('Sorting by Size, descending')
   })
+
+  describe('keyboard navigation', () => {
+    const openMenu = async (field: string = 'name', order: SortOrder = 'asc') => {
+      const rendered = renderComponent(field, order)
+      const panel = rendered.container.querySelector<HTMLElement>('[popover]')!
+
+      panel.showPopover()
+      await h.tick(2)
+
+      return rendered
+    }
+
+    it('focuses the active sort field when the menu opens', async () => {
+      await openMenu('date', 'asc')
+
+      expect(document.activeElement).toBe(screen.getByTitle('Sort by Date'))
+    })
+
+    it('falls back to the first item when no field matches', async () => {
+      await openMenu('unknown' as any, 'asc')
+
+      expect(document.activeElement).toBe(screen.getByTitle('Sort by Name'))
+    })
+
+    it('moves focus to the next item on ArrowDown', async () => {
+      await openMenu('name', 'asc')
+
+      await h.user.keyboard('{ArrowDown}')
+
+      expect(document.activeElement).toBe(screen.getByTitle('Sort by Date'))
+    })
+
+    it('wraps focus to the first item past the end', async () => {
+      await openMenu('size', 'asc')
+
+      await h.user.keyboard('{ArrowDown}')
+
+      expect(document.activeElement).toBe(screen.getByTitle('Sort by Name'))
+    })
+
+    it('moves focus to the previous item on ArrowUp', async () => {
+      await openMenu('date', 'asc')
+
+      await h.user.keyboard('{ArrowUp}')
+
+      expect(document.activeElement).toBe(screen.getByTitle('Sort by Name'))
+    })
+
+    it('wraps focus to the last item past the start', async () => {
+      await openMenu('name', 'asc')
+
+      await h.user.keyboard('{ArrowUp}')
+
+      expect(document.activeElement).toBe(screen.getByTitle('Sort by Size'))
+    })
+
+    it('jumps to the first item on Home', async () => {
+      await openMenu('size', 'asc')
+
+      await h.user.keyboard('{Home}')
+
+      expect(document.activeElement).toBe(screen.getByTitle('Sort by Name'))
+    })
+
+    it('jumps to the last item on End', async () => {
+      await openMenu('name', 'asc')
+
+      await h.user.keyboard('{End}')
+
+      expect(document.activeElement).toBe(screen.getByTitle('Sort by Size'))
+    })
+
+    it('activates the focused item on Enter', async () => {
+      const { emitted } = await openMenu('name', 'asc')
+
+      await h.user.keyboard('{ArrowDown}')
+      await h.user.keyboard('{Enter}')
+
+      expect(emitted().sort).toBeTruthy()
+      expect(emitted().sort[0]).toEqual(['date', 'asc'])
+    })
+
+    it('activates the focused item on Space', async () => {
+      const { emitted } = await openMenu('name', 'asc')
+
+      await h.user.keyboard('{ArrowDown}{ArrowDown}')
+      await h.user.keyboard(' ')
+
+      expect(emitted().sort).toBeTruthy()
+      expect(emitted().sort[0]).toEqual(['size', 'asc'])
+    })
+
+    it('uses roving tabindex on menu items', async () => {
+      await openMenu('date', 'asc')
+
+      const dateItem = screen.getByTitle('Sort by Date')
+      const nameItem = screen.getByTitle('Sort by Name')
+      const sizeItem = screen.getByTitle('Sort by Size')
+
+      expect(dateItem.getAttribute('tabindex')).toBe('0')
+      expect(nameItem.getAttribute('tabindex')).toBe('-1')
+      expect(sizeItem.getAttribute('tabindex')).toBe('-1')
+
+      await h.user.keyboard('{ArrowDown}')
+
+      expect(dateItem.getAttribute('tabindex')).toBe('-1')
+      expect(sizeItem.getAttribute('tabindex')).toBe('0')
+    })
+  })
 })

--- a/resources/assets/js/components/ui/BasicListSorter.vue
+++ b/resources/assets/js/components/ui/BasicListSorter.vue
@@ -8,18 +8,30 @@
       <span class="mr-2">{{ currentLabel }}</span>
       <Icon :icon="order === 'asc' ? faArrowUp : faArrowDown" />
     </button>
-    <Popover ref="popover" :anchor="button" placement="bottom-end" class="context-menu normal-case tracking-normal">
-      <menu>
+    <Popover
+      ref="popover"
+      :anchor="button"
+      placement="bottom-end"
+      class="context-menu normal-case tracking-normal"
+      @toggle="onPopoverToggle"
+    >
+      <menu role="menu" aria-orientation="vertical" @keydown="onKeydown">
         <li
-          v-for="item in items"
+          v-for="(item, index) in items"
           :key="item.label"
+          :ref="el => setItemRef(el, index)"
           :class="isCurrentField(item.field) && 'active'"
           :title="`Sort by ${item.label}`"
-          class="cursor-pointer group flex justify-between hover:bg-k-highlight hover:text-k-highlight-fg"
+          :tabindex="focusedIndex === index ? 0 : -1"
+          role="menuitem"
+          class="cursor-pointer group flex justify-between outline-none hover:bg-k-highlight hover:text-k-highlight-fg focus:bg-k-highlight focus:text-k-highlight-fg"
           @click="sort(item.field)"
         >
           <span>{{ item.label }}</span>
-          <span v-if="isCurrentField(item.field)" class="text-k-fg group-hover:text-k-highlight-fg">
+          <span
+            v-if="isCurrentField(item.field)"
+            class="text-k-fg group-hover:text-k-highlight-fg group-focus:text-k-highlight-fg"
+          >
             <Icon v-if="order === 'asc'" :icon="faArrowUp" />
             <Icon v-else :icon="faArrowDown" />
           </span>
@@ -31,7 +43,7 @@
 
 <script generic="T extends SortField" lang="ts" setup>
 import { faArrowDown, faArrowUp } from '@fortawesome/free-solid-svg-icons'
-import { computed, ref, toRefs } from 'vue'
+import { computed, nextTick, ref, toRefs } from 'vue'
 
 import Popover from '@/components/ui/Popover.vue'
 
@@ -47,6 +59,14 @@ const { field: currentField, order: currentOrder, items } = toRefs(props)
 
 const button = ref<HTMLButtonElement>()
 const popover = ref<InstanceType<typeof Popover>>()
+const itemRefs = ref<HTMLLIElement[]>([])
+const focusedIndex = ref(0)
+
+const setItemRef = (el: unknown, index: number) => {
+  if (el instanceof HTMLLIElement) {
+    itemRefs.value[index] = el
+  }
+}
 
 const currentLabel = computed(() => {
   return items.value.find((item: BasicListSorterDropDownItem<T>) => item.field === currentField.value)?.label
@@ -69,4 +89,60 @@ const isCurrentField = (field: T) => field === currentField.value
 const title = computed(
   () => `Sorting by ${currentLabel.value}, ${currentOrder.value === 'asc' ? 'ascending' : 'descending'}`,
 )
+
+const focusItem = async (index: number) => {
+  focusedIndex.value = index
+  // Wait for the tabindex update to apply before moving focus.
+  await nextTick()
+  itemRefs.value[index]?.focus()
+}
+
+const onPopoverToggle = (open: boolean) => {
+  if (!open) {
+    return
+  }
+  // On open, focus the currently-active sort option, falling back to the first item.
+  const activeIndex = items.value.findIndex(item => item.field === currentField.value)
+  focusItem(activeIndex >= 0 ? activeIndex : 0)
+}
+
+const onKeydown = (event: KeyboardEvent) => {
+  const len = items.value.length
+
+  if (!len) {
+    return
+  }
+
+  switch (event.key) {
+    case 'ArrowDown':
+      event.preventDefault()
+      focusItem((focusedIndex.value + 1) % len)
+      break
+
+    case 'ArrowUp':
+      event.preventDefault()
+      focusItem((focusedIndex.value - 1 + len) % len)
+      break
+
+    case 'Home':
+      event.preventDefault()
+      focusItem(0)
+      break
+
+    case 'End':
+      event.preventDefault()
+      focusItem(len - 1)
+      break
+
+    case 'Enter':
+    case ' ': {
+      event.preventDefault()
+      const item = items.value[focusedIndex.value]
+      if (item) {
+        sort(item.field)
+      }
+      break
+    }
+  }
+}
 </script>


### PR DESCRIPTION
## Summary
Implements the WAI-ARIA APG menu pattern with roving tabindex on \`BasicListSorter\`. Closes the a11y gap left in PR #2421, which removed \`role=\"menu\"\` / \`menuitem\` from this component because the keyboard contract wasn't yet implemented.

## Behavior

| Key | Action |
|---|---|
| ArrowDown | Focus next item (wraps to first at end) |
| ArrowUp | Focus previous item (wraps to last at start) |
| Home | Focus first item |
| End | Focus last item |
| Enter | Activate focused item |
| Space | Activate focused item |
| Esc | Close menu (native via \`popover=\"auto\"\`) |
| click-outside | Close menu (native via \`popover=\"auto\"\`) |

On open, focus moves to the currently-active sort field (e.g. if sorting by Date, the Date item gets focus), or the first item if no field matches.

## A11y attributes
- \`role=\"menu\"\` on the panel, \`aria-orientation=\"vertical\"\`
- \`role=\"menuitem\"\` on each item
- Roving tabindex: focused item has \`tabindex=\"0\"\`, all others have \`tabindex=\"-1\"\`. Tab from outside enters the active item; Tab from there exits the menu (matches native menu behavior).

## Test plan
- [x] 11 new behavioral tests covering arrow keys, Home/End, Enter/Space, focus-on-open, fallback when no active field, and roving tabindex transitions
- [x] All 19 BasicListSorter tests pass
- [x] \`vp test run resources/assets/js\` — full suite, 1478/1478 green
- [x] \`vp check resources/assets\` — lint + format clean
- [ ] Manual browser verification: arrow-key cycling, screen-reader announcement of "menu" + item position

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard navigation to the sort dropdown menu
  * Users can now navigate options using arrow keys with wraparound support
  * Home and End keys jump to the first and last options
  * Enter and Space keys select the focused option
  * Improved visual focus indicators for keyboard navigation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->