### PR TITLE
refactor: consolidate DownloadService storage dispatch via factory

### DIFF
--- a/app/Services/DownloadService.php
+++ b/app/Services/DownloadService.php
@@ -3,13 +3,12 @@
 namespace App\Services;
 
 use App\Enums\DownloadableType;
-use App\Enums\SongStorageType;
 use App\Exceptions\DownloadLimitExceededException;
 use App\Models\Song;
 use App\Models\User;
 use App\Repositories\SongRepository;
-use App\Services\SongStorages\CloudStorageFactory;
-use App\Services\SongStorages\SftpStorage;
+use App\Services\SongStorages\CloudStorage;
+use App\Services\SongStorages\SongStorageFactory;
 use App\Values\Downloadable;
 use App\Values\Podcast\EpisodePlayable;
 use App\Values\SongZipArchive;
@@ -78,7 +77,6 @@ class DownloadService
         );
     }
 
-    // @mago-ignore lint:halstead
     public function getLocalPathOrDownloadableUrl(Song $song): ?string
     {
         if (!$song->storage->supported()) {
@@ -90,15 +88,11 @@ class DownloadService
             return $song->path;
         }
 
-        if ($song->storage === SongStorageType::LOCAL) {
-            return $song->path;
-        }
+        $storage = SongStorageFactory::make($song->storage);
 
-        if ($song->storage === SongStorageType::SFTP) {
-            return app(SftpStorage::class)->copyToLocal($song);
-        }
-
-        return CloudStorageFactory::make($song->storage)->getPresignedUrl($song->storage_metadata->getPath());
+        return $storage instanceof CloudStorage
+            ? $storage->getPresignedUrl($song->storage_metadata->getPath())
+            : $storage->getLocalPath($song->path);
     }
 
     public function getLocalPath(Song $song): ?string
@@ -111,19 +105,8 @@ class DownloadService
             return EpisodePlayable::getForEpisode($song)->path;
         }
 
-        $location = $song->storage_metadata->getPath();
+        $localPath = SongStorageFactory::make($song->storage)->getLocalPath($song->path);
 
-        if ($song->storage === SongStorageType::LOCAL) {
-            return File::exists($location) ? $location : null;
-        }
-
-        if ($song->storage === SongStorageType::SFTP) {
-            /** @var SftpStorage $storage */
-            $storage = app(SftpStorage::class);
-
-            return $storage->copyToLocal($location);
-        }
-
-        return CloudStorageFactory::make($song->storage)->copyToLocal($location);
+        return File::exists($localPath) ? $localPath : null;
     }
 }

--- a/app/Services/SongStorages/SongStorageFactory.php
+++ b/app/Services/SongStorages/SongStorageFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Services\SongStorages;
+
+use App\Enums\SongStorageType;
+
+class SongStorageFactory
+{
+    public static function make(SongStorageType $storageType): SongStorage
+    {
+        return match ($storageType) {
+            SongStorageType::LOCAL => app(LocalStorage::class),
+            SongStorageType::SFTP => app(SftpStorage::class),
+            SongStorageType::S3 => app(S3CompatibleStorage::class),
+            SongStorageType::S3_LAMBDA => app(S3LambdaStorage::class),
+            SongStorageType::DROPBOX => app(DropboxStorage::class),
+        };
+    }
+}

--- a/tests/Unit/Services/SongStorages/SongStorageFactoryTest.php
+++ b/tests/Unit/Services/SongStorages/SongStorageFactoryTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Unit\Services\SongStorages;
+
+use App\Enums\SongStorageType;
+use App\Services\SongStorages\DropboxStorage;
+use App\Services\SongStorages\LocalStorage;
+use App\Services\SongStorages\S3CompatibleStorage;
+use App\Services\SongStorages\S3LambdaStorage;
+use App\Services\SongStorages\SftpStorage;
+use App\Services\SongStorages\SongStorage;
+use App\Services\SongStorages\SongStorageFactory;
+use Illuminate\Support\Facades\Cache;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SongStorageFactoryTest extends TestCase
+{
+    /** @return array<mixed> */
+    public static function provideStorageData(): array
+    {
+        return [
+            'Local' => [SongStorageType::LOCAL, LocalStorage::class],
+            'SFTP' => [SongStorageType::SFTP, SftpStorage::class],
+            'S3 Compatible' => [SongStorageType::S3, S3CompatibleStorage::class],
+            'S3 Lambda' => [SongStorageType::S3_LAMBDA, S3LambdaStorage::class],
+            'Dropbox' => [SongStorageType::DROPBOX, DropboxStorage::class],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('provideStorageData')]
+    public function resolve(SongStorageType $storageType, string $concreteClassName): void
+    {
+        Cache::set('dropbox_access_token', 'foo');
+        $instance = SongStorageFactory::make($storageType);
+
+        self::assertInstanceOf($concreteClassName, $instance);
+        self::assertInstanceOf(SongStorage::class, $instance);
+
+        Cache::delete('dropbox_access_token');
+    }
+}


### PR DESCRIPTION
## Summary

- `SongStorageFactory` generalizes the existing `CloudStorageFactory` across all five `SongStorageType` cases (Local, SFTP, S3, S3 Lambda, Dropbox), returning a `SongStorage`.
- `DownloadService::getLocalPathOrDownloadableUrl` and `getLocalPath` now route through the factory and use polymorphism, replacing the per-storage-type if-chains.
- Two latent issues fixed incidentally: the SFTP branch was passing a `Song` where `SftpStorage::copyToLocal(string)` expected a string, and `getLocalPath` previously returned a path to a non-existent tmp file when a cloud copy failed silently. The unified `File::exists` check at the end of `getLocalPath` now applies the existence invariant uniformly across all storage types.
- `CloudStorageFactory` is left in place — it has the stricter `NonCloudStorageException` contract that callers like `CloudTranscodingStrategy` rely on.

## Test plan

- [x] `php artisan test --compact --filter='Storage|Download'` (60 passed, 158 assertions)
- [x] `vendor/bin/phpstan analyse app/Services/SongStorages app/Services/DownloadService.php` (clean)
- [x] New `SongStorageFactoryTest` covers the dispatch table for all five storage types (mirrors the existing `CloudStorageFactoryTest`)
- [ ] Manually verify a one-song download (local + cloud, if available) once CI is green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized internal download and storage service implementations with improved architecture and reduced code complexity. Storage handling now uses an enhanced factory pattern to streamline operations across all supported storage providers.

* **Tests**
  * Added comprehensive unit test coverage for storage factory resolution to validate consistency and reliability across all supported storage types and configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->