### PR TITLE
refactor: extract shared store vault into useVault composable

### DIFF
--- a/resources/assets/js/composables/useVault.spec.ts
+++ b/resources/assets/js/composables/useVault.spec.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vite-plus/test'
+import { createHarness } from '@/__tests__/TestHarness'
+import { useVault } from './useVault'
+
+interface Item {
+  id: string
+  name: string
+  meta?: { genre?: string; year?: number }
+}
+
+describe('useVault', () => {
+  createHarness()
+
+  it('returns undefined when looking up a missing id', () => {
+    const vault = useVault<Item>()
+    expect(vault.byId('nope')).toBeUndefined()
+  })
+
+  it('inserts new items via syncWithVault and looks them up by id', () => {
+    const vault = useVault<Item>()
+
+    const [synced] = vault.syncWithVault({ id: 'a', name: 'Alpha' })
+
+    expect(vault.byId('a')).toBe(synced)
+    expect(vault.byId('a')?.name).toBe('Alpha')
+  })
+
+  it('deep-merges updates into existing items, preserving identity', () => {
+    const vault = useVault<Item>()
+
+    const [first] = vault.syncWithVault({ id: 'a', name: 'Alpha', meta: { genre: 'rock' } })
+    const [second] = vault.syncWithVault({ id: 'a', name: 'Alpha v2', meta: { year: 1969 } })
+
+    expect(second).toBe(first)
+    expect(second.name).toBe('Alpha v2')
+    expect(second.meta).toEqual({ genre: 'rock', year: 1969 })
+  })
+
+  it('accepts a single item or an array', () => {
+    const vault = useVault<Item>()
+
+    const single = vault.syncWithVault({ id: 'a', name: 'Alpha' })
+    const many = vault.syncWithVault([
+      { id: 'b', name: 'Bravo' },
+      { id: 'c', name: 'Charlie' },
+    ])
+
+    expect(single).toHaveLength(1)
+    expect(many).toHaveLength(2)
+    expect(vault.byId('b')?.name).toBe('Bravo')
+    expect(vault.byId('c')?.name).toBe('Charlie')
+  })
+
+  it('exposes the underlying Map for direct operations', () => {
+    const vault = useVault<Item>()
+
+    vault.syncWithVault([
+      { id: 'a', name: 'Alpha' },
+      { id: 'b', name: 'Bravo' },
+    ])
+
+    expect(vault.vault.size).toBe(2)
+    vault.vault.delete('a')
+    expect(vault.byId('a')).toBeUndefined()
+    expect(vault.byId('b')?.name).toBe('Bravo')
+  })
+
+  it('isolates instances from one another', () => {
+    const a = useVault<Item>()
+    const b = useVault<Item>()
+
+    a.syncWithVault({ id: 'x', name: 'in A' })
+
+    expect(a.byId('x')?.name).toBe('in A')
+    expect(b.byId('x')).toBeUndefined()
+  })
+})

--- a/resources/assets/js/composables/useVault.spec.ts
+++ b/resources/assets/js/composables/useVault.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vite-plus/test'
+import { describe, expect, it, vi } from 'vite-plus/test'
 import { createHarness } from '@/__tests__/TestHarness'
 import { useVault } from './useVault'
 
@@ -73,5 +73,18 @@ describe('useVault', () => {
 
     expect(a.byId('x')?.name).toBe('in A')
     expect(b.byId('x')).toBeUndefined()
+  })
+
+  it('runs onItemAdded exactly once for newly added entries and not for updates', () => {
+    const onItemAdded = vi.fn()
+    const vault = useVault<Item>({ onItemAdded })
+
+    vault.syncWithVault({ id: 'a', name: 'Alpha' })
+    vault.syncWithVault({ id: 'a', name: 'Alpha v2' })
+    vault.syncWithVault({ id: 'b', name: 'Bravo' })
+
+    expect(onItemAdded).toHaveBeenCalledTimes(2)
+    expect(onItemAdded.mock.calls[0][0].id).toBe('a')
+    expect(onItemAdded.mock.calls[1][0].id).toBe('b')
   })
 })

--- a/resources/assets/js/composables/useVault.ts
+++ b/resources/assets/js/composables/useVault.ts
@@ -1,0 +1,22 @@
+import { merge } from 'lodash'
+import { reactive } from 'vue'
+import { arrayify } from '@/utils/helpers'
+
+export const useVault = <T extends { id: PropertyKey }>() => {
+  const vault = new Map<T['id'], T>()
+
+  return {
+    vault,
+
+    byId: (id: T['id']) => vault.get(id),
+
+    syncWithVault: (items: MaybeArray<T>): T[] =>
+      arrayify(items).map(item => {
+        const existing = vault.get(item.id)
+        const local = reactive(existing ? merge(existing, item) : item) as T
+        vault.set(item.id, local)
+
+        return local
+      }),
+  }
+}

--- a/resources/assets/js/composables/useVault.ts
+++ b/resources/assets/js/composables/useVault.ts
@@ -26,8 +26,8 @@ export const useVault = <T extends object & { id: PropertyKey }>(options: UseVau
         }
 
         const local = reactive(item)
-        options.onItemAdded?.(local)
         vault.set(item.id, local)
+        options.onItemAdded?.(local)
 
         return local
       }),

--- a/resources/assets/js/composables/useVault.ts
+++ b/resources/assets/js/composables/useVault.ts
@@ -1,21 +1,22 @@
 import { merge } from 'lodash'
+import type { Reactive } from 'vue'
 import { reactive } from 'vue'
 import { arrayify } from '@/utils/helpers'
 
 interface UseVaultOptions<T> {
   /** Invoked once for every item newly added to the vault, after it's wrapped reactive. */
-  onItemAdded?: (item: T) => void
+  onItemAdded?: (item: Reactive<T>) => void
 }
 
-export const useVault = <T extends { id: PropertyKey }>(options: UseVaultOptions<T> = {}) => {
-  const vault = new Map<T['id'], T>()
+export const useVault = <T extends object & { id: PropertyKey }>(options: UseVaultOptions<T> = {}) => {
+  const vault = new Map<T['id'], Reactive<T>>()
 
   return {
     vault,
 
-    byId: (id: T['id']) => vault.get(id),
+    byId: (id: T['id']): Reactive<T> | undefined => vault.get(id),
 
-    syncWithVault: (items: MaybeArray<T>): T[] =>
+    syncWithVault: (items: MaybeArray<T>): Reactive<T>[] =>
       arrayify(items).map(item => {
         const existing = vault.get(item.id)
 
@@ -24,7 +25,7 @@ export const useVault = <T extends { id: PropertyKey }>(options: UseVaultOptions
           return existing
         }
 
-        const local = reactive(item) as T
+        const local = reactive(item)
         options.onItemAdded?.(local)
         vault.set(item.id, local)
 

--- a/resources/assets/js/composables/useVault.ts
+++ b/resources/assets/js/composables/useVault.ts
@@ -2,7 +2,12 @@ import { merge } from 'lodash'
 import { reactive } from 'vue'
 import { arrayify } from '@/utils/helpers'
 
-export const useVault = <T extends { id: PropertyKey }>() => {
+interface UseVaultOptions<T> {
+  /** Invoked once for every item newly added to the vault, after it's wrapped reactive. */
+  onItemAdded?: (item: T) => void
+}
+
+export const useVault = <T extends { id: PropertyKey }>(options: UseVaultOptions<T> = {}) => {
   const vault = new Map<T['id'], T>()
 
   return {
@@ -13,7 +18,14 @@ export const useVault = <T extends { id: PropertyKey }>() => {
     syncWithVault: (items: MaybeArray<T>): T[] =>
       arrayify(items).map(item => {
         const existing = vault.get(item.id)
-        const local = reactive(existing ? merge(existing, item) : item) as T
+
+        if (existing) {
+          merge(existing, item)
+          return existing
+        }
+
+        const local = reactive(item) as T
+        options.onItemAdded?.(local)
         vault.set(item.id, local)
 
         return local

--- a/resources/assets/js/stores/albumStore.ts
+++ b/resources/assets/js/stores/albumStore.ts
@@ -1,10 +1,10 @@
 import type { Reactive } from 'vue'
 import { reactive } from 'vue'
-import { differenceBy, merge, unionBy } from 'lodash'
+import { differenceBy, unionBy } from 'lodash'
 import { cache } from '@/services/cache'
 import { http } from '@/services/http'
-import { arrayify } from '@/utils/helpers'
 import { logger } from '@/utils/logger'
+import { useVault } from '@/composables/useVault'
 import { playableStore as songStore } from '@/stores/playableStore'
 
 const UNKNOWN_ALBUM_NAME = 'Unknown Album'
@@ -20,15 +20,11 @@ interface AlbumListPaginateParams extends PaginateParams<AlbumListSortField> {
 }
 
 export const albumStore = {
-  vault: new Map<Album['id'], Album>(),
+  ...useVault<Album>(),
 
   state: reactive({
     albums: [] as Album[],
   }),
-
-  byId(id: Album['id']) {
-    return this.vault.get(id)
-  },
 
   removeByIds(ids: Album['id'][]) {
     this.state.albums = differenceBy(
@@ -48,16 +44,6 @@ export const albumStore = {
     }
 
     return album.name === UNKNOWN_ALBUM_NAME
-  },
-
-  syncWithVault(albums: MaybeArray<Album>) {
-    return arrayify(albums).map(album => {
-      let local = this.vault.get(album.id)
-      local = reactive(local ? merge(local, album) : album)
-      this.vault.set(album.id, local)
-
-      return local
-    })
   },
 
   async update(album: Album, data: AlbumUpdateData) {

--- a/resources/assets/js/stores/artistStore.ts
+++ b/resources/assets/js/stores/artistStore.ts
@@ -3,8 +3,8 @@ import { reactive } from 'vue'
 import { differenceBy, unionBy } from 'lodash'
 import { cache } from '@/services/cache'
 import { http } from '@/services/http'
-import { arrayify } from '@/utils/helpers'
 import { logger } from '@/utils/logger'
+import { useVault } from '@/composables/useVault'
 import { playableStore as songStore } from '@/stores/playableStore'
 
 const UNKNOWN_ARTIST_NAME = 'Unknown Artist'
@@ -20,15 +20,11 @@ interface ArtistListPaginateParams extends PaginateParams<ArtistListSortField> {
 }
 
 export const artistStore = {
-  vault: new Map<Artist['id'], Artist>(),
+  ...useVault<Artist>(),
 
   state: reactive({
     artists: [] as Artist[],
   }),
-
-  byId(id: Artist['id']) {
-    return this.vault.get(id)
-  },
 
   removeByIds(ids: Artist['id'][]) {
     this.state.artists = differenceBy(
@@ -47,16 +43,6 @@ export const artistStore = {
 
   isStandard(artist: Artist | Artist['name']) {
     return !this.isVarious(artist) && !this.isUnknown(artist)
-  },
-
-  syncWithVault(artists: MaybeArray<Artist>) {
-    return arrayify(artists).map(artist => {
-      let local = this.vault.get(artist.id)
-      local = local ? Object.assign(local, artist) : reactive(artist)
-      this.vault.set(artist.id, local)
-
-      return local
-    })
   },
 
   async update(artist: Artist, data: ArtistUpdateData) {

--- a/resources/assets/js/stores/playableStore.spec.ts
+++ b/resources/assets/js/stores/playableStore.spec.ts
@@ -159,38 +159,36 @@ describe('playableStore', () => {
     expect(playableStore.getShareableUrl(song)).toBe(`http://test/#/songs/${song.id}`)
   })
 
-  it('syncs with the vault', () => {
+  it('syncs new songs into the vault and applies playback state defaults', () => {
     const song = h.factory('song', {
       playback_state: null,
     })
 
-    const watchPlayCountMock = h.mock(playableStore, 'watchPlayCount')
+    const [synced] = playableStore.syncWithVault(song)
 
-    expect(playableStore.syncWithVault(song)).toEqual([reactive(song)])
     expect(playableStore.vault.has(song.id)).toBe(true)
-    expect(watchPlayCountMock).toHaveBeenCalledOnce()
+    expect(synced.playback_state).toBe('Stopped')
 
-    expect(playableStore.syncWithVault(song)).toEqual([reactive(song)])
-    expect(playableStore.vault.has(song.id)).toBe(true)
-    // second call shouldn't set up play count tracking again
-    expect(watchPlayCountMock).toHaveBeenCalledOnce()
+    // re-syncing the same song reuses the existing reactive entry
+    const [resynced] = playableStore.syncWithVault(song)
+    expect(resynced).toBe(synced)
   })
 
-  it('watches play count tracking', async () => {
+  it('refreshes play stats when a vaulted song play count changes', async () => {
     const refreshMock = h.mock(overviewStore, 'refreshPlayStats')
 
-    const song = reactive(
-      h.factory('song', {
-        play_count: 98,
-      }),
-    )
-
-    playableStore.watchPlayCount(song)
-    song.play_count = 100
+    const [synced] = playableStore.syncWithVault(h.factory('song', { play_count: 98 }))
+    synced.play_count = 100
 
     await h.tick()
+    expect(refreshMock).toHaveBeenCalledTimes(1)
 
-    expect(refreshMock).toHaveBeenCalled()
+    // re-syncing the same song does not double up the watcher
+    playableStore.syncWithVault({ ...synced, play_count: 101 } as Song)
+    synced.play_count = 102
+
+    await h.tick()
+    expect(refreshMock).toHaveBeenCalledTimes(2)
   })
 
   it('fetches for album', async () => {

--- a/resources/assets/js/stores/playableStore.ts
+++ b/resources/assets/js/stores/playableStore.ts
@@ -1,6 +1,5 @@
 import isMobile from 'ismobilejs'
-import { differenceBy, merge, orderBy, sumBy, take, unionBy, uniqBy } from 'lodash'
-import type { Reactive } from 'vue'
+import { differenceBy, orderBy, sumBy, take, unionBy, uniqBy } from 'lodash'
 import { reactive, watch } from 'vue'
 import { arrayify, moveItemsInList, use } from '@/utils/helpers'
 import { isSong } from '@/utils/typeGuards'
@@ -10,6 +9,7 @@ import { normalizeForComparison, secondsToHumanReadable } from '@/utils/formatte
 import { authService } from '@/services/authService'
 import { cache } from '@/services/cache'
 import { http } from '@/services/http'
+import { useVault } from '@/composables/useVault'
 import { preferenceStore } from '@/stores/preferenceStore'
 import { commonStore } from '@/stores/commonStore'
 import { albumStore } from '@/stores/albumStore'
@@ -42,8 +42,20 @@ export interface SongUpdateResult {
 
 export type SongListPaginateParams = PaginateParams<PlayableListSortField>
 
+const watchPlayCount = (playable: Playable) => {
+  watch(
+    () => playable.play_count,
+    () => overviewStore.refreshPlayStats(),
+  )
+}
+
 export const playableStore = {
-  vault: new Map<Playable['id'], Reactive<Playable>>(),
+  ...useVault<Playable>({
+    onItemAdded: playable => {
+      playable.playback_state = 'Stopped'
+      watchPlayCount(playable)
+    },
+  }),
 
   state: reactive<{ playables: Playable[]; favorites: Playable[] }>({
     playables: [],
@@ -184,30 +196,6 @@ export const playableStore = {
   },
 
   getShareableUrl: (song: Playable) => `${window.BASE_URL}#/songs/${song.id}`,
-
-  syncWithVault(playables: MaybeArray<Playable>) {
-    return arrayify(playables).map(playable => {
-      let local = this.byId(playable.id)
-
-      if (local) {
-        merge(local, playable)
-      } else {
-        local = reactive(playable)
-        local.playback_state = 'Stopped'
-        this.watchPlayCount(local)
-        this.vault.set(local.id, local)
-      }
-
-      return local
-    })
-  },
-
-  watchPlayCount: (playable: Playable) => {
-    watch(
-      () => playable.play_count,
-      () => overviewStore.refreshPlayStats(),
-    )
-  },
 
   ensureNotDeleted: (songs: MaybeArray<Song>) => arrayify(songs).filter(({ deleted }) => !deleted),
 

--- a/resources/assets/js/stores/playableStore.ts
+++ b/resources/assets/js/stores/playableStore.ts
@@ -1,6 +1,6 @@
 import isMobile from 'ismobilejs'
 import { differenceBy, orderBy, sumBy, take, unionBy, uniqBy } from 'lodash'
-import { reactive, watch } from 'vue'
+import { Reactive, reactive, watch } from 'vue'
 import { arrayify, moveItemsInList, use } from '@/utils/helpers'
 import { isSong } from '@/utils/typeGuards'
 import { logger } from '@/utils/logger'

--- a/resources/assets/js/stores/userStore.ts
+++ b/resources/assets/js/stores/userStore.ts
@@ -1,7 +1,7 @@
 import { reactive } from 'vue'
-import { differenceBy, merge } from 'lodash'
+import { differenceBy } from 'lodash'
 import { http } from '@/services/http'
-import { arrayify } from '@/utils/helpers'
+import { useVault } from '@/composables/useVault'
 
 type UserFormData = Pick<User, 'name' | 'email' | 'role'>
 
@@ -14,22 +14,12 @@ export interface UpdateUserData extends UserFormData {
 }
 
 export const userStore = {
-  vault: new Map<User['id'], User>(),
+  ...useVault<User>(),
 
   state: reactive({
     users: [] as User[],
     current: null! as CurrentUser,
   }),
-
-  syncWithVault(users: MaybeArray<User>) {
-    return arrayify(users).map(user => {
-      let local = this.byId(user.id)
-      local = reactive(local ? merge(local, user) : user)
-      this.vault.set(user.id, local)
-
-      return local
-    })
-  },
 
   init(currentUser: CurrentUser) {
     this.state.users = this.syncWithVault(currentUser)
@@ -38,10 +28,6 @@ export const userStore = {
 
   async fetch() {
     this.state.users = this.syncWithVault(await http.get<User[]>('users'))
-  },
-
-  byId(id: User['id']) {
-    return this.vault.get(id)
   },
 
   get current() {


### PR DESCRIPTION
## Summary

- The album, artist, user, and playable stores each hand-rolled an identical `vault`/`byId`/`syncWithVault` trio with subtly **different merge strategies** (`albumStore`, `userStore`, and `playableStore` used lodash `merge`; `artistStore` used `Object.assign`). For flat data shapes this drift is invisible today, but it's exactly the kind of inconsistency that surfaces as a bug the moment a nested field is added.
- Extracted the cache primitives into a single `useVault<T>()` composable so all four stores now share one merge strategy (deep merge — the safer default for entities with nested objects).
- `useVault` accepts an `onItemAdded` hook for stores that need to initialize newly-added entries. `playableStore` uses it for two side effects: defaulting `playback_state` to `'Stopped'` and registering a play-count watcher.
- Stores keep their list state (`state.albums`, `state.users`, etc.) and domain methods; only the cache layer is shared.

## Behavioural diff worth knowing about

`playableStore` previously routed its own `syncWithVault` lookup through `byId`, which filters out songs marked `deleted`. So re-syncing a deleted song *orphaned* the existing reactive entry and inserted a fresh one. With `useVault`, lookup is via the raw vault Map, so the same call merges into the existing entry — preserving identity for any references. In practice this code path is unlikely to fire (the server doesn't return deleted songs), and the new behaviour is arguably correct.

## Test plan

- [x] New `useVault.spec.ts` covers byId, deep-merge of updates with identity preservation, single-vs-array input, isolation between instances, and `onItemAdded` semantics
- [x] Two implementation-coupled `playableStore` tests (which mocked `watchPlayCount` to verify it was called) rewritten to assert observable behaviour through `syncWithVault`
- [x] All 174 tests across `composables/useVault` + `stores/` pass
- [x] `vp check` is clean (lint + types + format) on all modified files
- [ ] Manual smoke test: navigate to album/artist/song screens once CI is green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Central vault composable for managed entities with ID-based retrieval, synchronization, and stable reactive references.

* **Refactor**
  * Album, artist, user, and playable stores now delegate state handling to the vault composable for consistency and less duplication.

* **Bug Fixes**
  * Playable items initialize with a stopped playback state and avoid double-registering play-count watchers.

* **Tests**
  * New and updated tests cover vault behavior, synchronization, identity preservation, and watcher firing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->