### PR TITLE
refactor: route paginated store URLs through flattenParams

### DIFF
--- a/resources/assets/js/stores/albumStore.ts
+++ b/resources/assets/js/stores/albumStore.ts
@@ -3,6 +3,7 @@ import { reactive } from 'vue'
 import { differenceBy, unionBy } from 'lodash'
 import { cache } from '@/services/cache'
 import { http } from '@/services/http'
+import { flattenParams } from '@/utils/helpers'
 import { logger } from '@/utils/logger'
 import { useVault } from '@/composables/useVault'
 import { playableStore as songStore } from '@/stores/playableStore'
@@ -77,7 +78,7 @@ export const albumStore = {
   },
 
   async paginate(params: AlbumListPaginateParams) {
-    const resource = await http.get<PaginatorResource<Album>>(`albums?${new URLSearchParams(params).toString()}`)
+    const resource = await http.get<PaginatorResource<Album>>(`albums?${new URLSearchParams(flattenParams(params))}`)
     this.state.albums = unionBy(this.state.albums, this.syncWithVault(resource.data), 'id')
 
     return resource.links.next ? ++resource.meta.current_page : null

--- a/resources/assets/js/stores/artistStore.ts
+++ b/resources/assets/js/stores/artistStore.ts
@@ -3,6 +3,7 @@ import { reactive } from 'vue'
 import { differenceBy, unionBy } from 'lodash'
 import { cache } from '@/services/cache'
 import { http } from '@/services/http'
+import { flattenParams } from '@/utils/helpers'
 import { logger } from '@/utils/logger'
 import { useVault } from '@/composables/useVault'
 import { playableStore as songStore } from '@/stores/playableStore'
@@ -68,7 +69,7 @@ export const artistStore = {
   },
 
   async paginate(params: ArtistListPaginateParams) {
-    const resource = await http.get<PaginatorResource<Artist>>(`artists?${new URLSearchParams(params).toString()}`)
+    const resource = await http.get<PaginatorResource<Artist>>(`artists?${new URLSearchParams(flattenParams(params))}`)
     this.state.artists = unionBy(this.state.artists, this.syncWithVault(resource.data), 'id')
 
     return resource.links.next ? ++resource.meta.current_page : null

--- a/resources/assets/js/stores/playableStore.ts
+++ b/resources/assets/js/stores/playableStore.ts
@@ -1,7 +1,7 @@
 import isMobile from 'ismobilejs'
 import { differenceBy, orderBy, sumBy, take, unionBy, uniqBy } from 'lodash'
 import { Reactive, reactive, watch } from 'vue'
-import { arrayify, moveItemsInList, use } from '@/utils/helpers'
+import { arrayify, flattenParams, moveItemsInList, use } from '@/utils/helpers'
 import { isSong } from '@/utils/typeGuards'
 import { logger } from '@/utils/logger'
 import { md5 } from '@/utils/crypto'
@@ -267,7 +267,7 @@ export const playableStore = {
     const id = typeof genre === 'string' ? genre : genre.id
 
     const resource = await http.get<PaginatorResource<Song>>(
-      `genres/${id}/songs?${new URLSearchParams(params).toString()}`,
+      `genres/${id}/songs?${new URLSearchParams(flattenParams(params))}`,
     )
 
     const songs = this.syncWithVault(resource.data) as Song[]
@@ -290,7 +290,7 @@ export const playableStore = {
   },
 
   async paginateSongs(params: SongListPaginateParams) {
-    const resource = await http.get<PaginatorResource<Playable>>(`songs?${new URLSearchParams(params).toString()}`)
+    const resource = await http.get<PaginatorResource<Playable>>(`songs?${new URLSearchParams(flattenParams(params))}`)
     this.state.playables = unionBy(this.state.playables, this.syncWithVault(resource.data), 'id')
 
     return resource.links.next ? ++resource.meta.current_page : null

--- a/resources/assets/js/utils/helpers.ts
+++ b/resources/assets/js/utils/helpers.ts
@@ -147,7 +147,7 @@ export const defineAsyncComponent = (
   })
 }
 
-export const flattenParams = (params: Record<string, unknown>): Record<string, string> => {
+export const flattenParams = <T extends object>(params: T): Record<string, string> => {
   const result: Record<string, string> = {}
 
   for (const [key, value] of Object.entries(params)) {


### PR DESCRIPTION
## Summary

- The four paginate helpers (`albumStore.paginate`, `artistStore.paginate`, `playableStore.paginateSongs`, `playableStore.paginateSongsByGenre`) were passing typed `Paginate` params directly into `new URLSearchParams(...)`. PHPStorm/TS rightly flagged the assignment because `PaginateParams` has `page: number` (and `sort: MaybeArray<S>` which permits arrays). It worked at runtime via `String()` coercion, but the type-level lie masked a latent bug: array `sort` values were being joined with commas instead of producing repeated query keys.
- Switched all four call sites to `new URLSearchParams(flattenParams(params))`. The existing `flattenParams` helper coerces with `String()`, filters `null`/`undefined`, and uses `key[i]=v` indexed brackets for array values (matching Laravel's array decoding on the backend).
- Relaxed `flattenParams`'s parameter to `<T extends object>` so typed interfaces (which don't carry an index signature) are accepted without a cast. The function body is unchanged.

## Test plan

- [x] Existing `helpers.spec.ts` `flattenParams` tests pass unchanged (181 tests across helpers + stores)
- [x] Existing store specs that assert URL strings (`'genres/foo/songs?page=2&sort=title&order=desc'`, etc.) still pass — `flattenParams` preserves entry order via `Object.entries`, so URL output matches today's runtime
- [x] `vp check` clean across all 824 frontend files (lint + types + format)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced parameter handling for pagination, filtering, and sorting across album, artist, and song lists to ensure proper URL query string encoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->