### PR TITLE
chore: align tsconfig with the typecheck override

### DIFF
--- a/resources/assets/tsconfig.json
+++ b/resources/assets/tsconfig.json
@@ -6,7 +6,7 @@
     "strict": true,
     "noImplicitAny": false,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "experimentalDecorators": true,
     "esModuleInterop": true,
     "allowJs": true,

--- a/resources/assets/tsconfig.json
+++ b/resources/assets/tsconfig.json
@@ -15,5 +15,5 @@
     }
   },
   "include": ["js/**/*", "../../node_modules/vitest/globals.d.ts"],
-  "exclude": ["js/__tests__/**/*"]
+  "exclude": []
 }


### PR DESCRIPTION
## Summary

Two divergences between `tsconfig.json` (read by IDEs / Volar) and `tsconfig.typecheck.json` (used by the CLI typecheck) were producing IDE-only "Cannot find module" / "Cannot find name" errors for code the CLI handled fine. Both fixed in this PR by aligning the IDE-facing config with what the typecheck already does.

### moduleResolution: "node" → "bundler"

The base config used `"node"`, the typecheck override used `"bundler"`. So the CLI saw subpath exports like `vite-plus/test` correctly, but editors saw *"Cannot find module 'vite-plus/test'… Consider updating to node16, nodenext, or bundler"*. `"bundler"` is the right default for any Vite-bundled project — it honours the package's `exports` field without forcing explicit file extensions on relative imports the way `node16`/`nodenext` would.

### Stopped excluding `__tests__`

The base config excluded `js/__tests__/**/*`. Test files (including factories) weren't part of the TS project from the IDE's perspective, so ambient types declared in `types.d.ts` (e.g. `ArtistInfo`, `MaybeArray`) weren't in scope inside tests — surfacing as "Cannot find name 'ArtistInfo'" in PHPStorm. The base config doesn't emit anything (no `outDir`, no `tsc` build), so the exclusion had no payoff and a real cost.

After this change `tsconfig.typecheck.json` overrides become mostly redundant; that's a separate cleanup.

## Test plan

- [x] `vp check` clean (lint + types + format) across all 824 files
- [x] `vp test` — all 1474 tests pass
- [x] `vp build` succeeds
- [ ] User verifies the IDE errors are gone after pulling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript module resolution configuration to improve build compatibility and consistency with modern tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->