### PR TITLE
chore: thread Eloquent generics through custom builders + repo docblock cleanup

### DIFF
--- a/app/Builders/AlbumBuilder.php
+++ b/app/Builders/AlbumBuilder.php
@@ -13,6 +13,9 @@ use Illuminate\Support\Facades\DB;
 use LogicException;
 use Webmozart\Assert\Assert;
 
+/**
+ * @extends FavoriteableBuilder<Album>
+ */
 class AlbumBuilder extends FavoriteableBuilder
 {
     use CanScopeByUser;

--- a/app/Builders/ArtistBuilder.php
+++ b/app/Builders/ArtistBuilder.php
@@ -13,6 +13,9 @@ use Illuminate\Support\Facades\DB;
 use LogicException;
 use Webmozart\Assert\Assert;
 
+/**
+ * @extends FavoriteableBuilder<Artist>
+ */
 class ArtistBuilder extends FavoriteableBuilder
 {
     use CanScopeByUser;

--- a/app/Builders/FavoriteableBuilder.php
+++ b/app/Builders/FavoriteableBuilder.php
@@ -4,10 +4,15 @@ namespace App\Builders;
 
 use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Query\JoinClause;
 use Illuminate\Support\Facades\DB;
 
 /**
+ * @template TModel of Model
+ *
+ * @extends Builder<TModel>
+ *
  * @property ?User $user
  */
 abstract class FavoriteableBuilder extends Builder

--- a/app/Builders/SongBuilder.php
+++ b/app/Builders/SongBuilder.php
@@ -4,6 +4,7 @@ namespace App\Builders;
 
 use App\Builders\Concerns\CanScopeByUser;
 use App\Facades\License;
+use App\Models\Song;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\JoinClause;
 use Illuminate\Support\Facades\DB;
@@ -11,6 +12,9 @@ use Illuminate\Support\Str;
 use LogicException;
 use Webmozart\Assert\Assert;
 
+/**
+ * @extends FavoriteableBuilder<Song>
+ */
 class SongBuilder extends FavoriteableBuilder
 {
     use CanScopeByUser;

--- a/app/Models/Concerns/Users/HasUserRelationships.php
+++ b/app/Models/Concerns/Users/HasUserRelationships.php
@@ -27,19 +27,16 @@ trait HasUserRelationships
         return $this->belongsTo(User::class, 'invited_by_id');
     }
 
-    /** @return BelongsToMany<Playlist, $this> */
     public function playlists(): BelongsToMany
     {
         return $this->belongsToMany(Playlist::class)->withPivot('role', 'position')->withTimestamps();
     }
 
-    /** @return BelongsToMany<Playlist, $this> */
     public function ownedPlaylists(): BelongsToMany
     {
         return $this->playlists()->wherePivot('role', 'owner');
     }
 
-    /** @return BelongsToMany<Playlist, $this> */
     public function collaboratedPlaylists(): BelongsToMany
     {
         return $this->playlists()->wherePivot('role', 'collaborator');

--- a/app/Models/Concerns/Users/HasUserRelationships.php
+++ b/app/Models/Concerns/Users/HasUserRelationships.php
@@ -27,16 +27,19 @@ trait HasUserRelationships
         return $this->belongsTo(User::class, 'invited_by_id');
     }
 
+    /** @return BelongsToMany<Playlist, $this> */
     public function playlists(): BelongsToMany
     {
         return $this->belongsToMany(Playlist::class)->withPivot('role', 'position')->withTimestamps();
     }
 
+    /** @return BelongsToMany<Playlist, $this> */
     public function ownedPlaylists(): BelongsToMany
     {
         return $this->playlists()->wherePivot('role', 'owner');
     }
 
+    /** @return BelongsToMany<Playlist, $this> */
     public function collaboratedPlaylists(): BelongsToMany
     {
         return $this->playlists()->wherePivot('role', 'collaborator');

--- a/app/Repositories/AlbumRepository.php
+++ b/app/Repositories/AlbumRepository.php
@@ -24,7 +24,6 @@ class AlbumRepository extends Repository implements ScoutableRepository
         return Album::query()->withUserContext(user: $user ?? $this->auth->user())->findOrFail($id);
     }
 
-    /** @return Collection<int, Album> */
     public function getRecentlyAdded(int $count = 6, ?User $user = null): Collection
     {
         return Album::query()
@@ -35,7 +34,6 @@ class AlbumRepository extends Repository implements ScoutableRepository
             ->get();
     }
 
-    /** @return Collection<int, Album> */
     public function getMostPlayed(int $count = 6, ?User $user = null): Collection
     {
         return Album::query()
@@ -46,7 +44,6 @@ class AlbumRepository extends Repository implements ScoutableRepository
             ->get();
     }
 
-    /** @return Collection<int, Album> */
     public function getMany(array $ids, bool $preserveOrder = false, ?User $user = null): Collection
     {
         $albums = Album::query()
@@ -58,7 +55,6 @@ class AlbumRepository extends Repository implements ScoutableRepository
         return $preserveOrder ? $albums->orderByArray($ids) : $albums;
     }
 
-    /** @return Collection<int, Album> */
     public function getByArtist(Artist $artist, ?User $user = null): Collection
     {
         return Album::query()
@@ -87,7 +83,6 @@ class AlbumRepository extends Repository implements ScoutableRepository
             ->simplePaginate(21);
     }
 
-    /** @return Collection<Album>|array<array-key, Album> */
     public function search(string $keywords, int $limit, ?User $user = null): Collection
     {
         return $this->getMany(

--- a/app/Repositories/AlbumRepository.php
+++ b/app/Repositories/AlbumRepository.php
@@ -24,7 +24,7 @@ class AlbumRepository extends Repository implements ScoutableRepository
         return Album::query()->withUserContext(user: $user ?? $this->auth->user())->findOrFail($id);
     }
 
-    /** @return Collection|array<array-key, Album> */
+    /** @return Collection<int, Album> */
     public function getRecentlyAdded(int $count = 6, ?User $user = null): Collection
     {
         return Album::query()
@@ -35,7 +35,7 @@ class AlbumRepository extends Repository implements ScoutableRepository
             ->get();
     }
 
-    /** @return Collection|array<array-key, Album> */
+    /** @return Collection<int, Album> */
     public function getMostPlayed(int $count = 6, ?User $user = null): Collection
     {
         return Album::query()
@@ -46,7 +46,7 @@ class AlbumRepository extends Repository implements ScoutableRepository
             ->get();
     }
 
-    /** @return Collection|array<array-key, Album> */
+    /** @return Collection<int, Album> */
     public function getMany(array $ids, bool $preserveOrder = false, ?User $user = null): Collection
     {
         $albums = Album::query()
@@ -58,7 +58,7 @@ class AlbumRepository extends Repository implements ScoutableRepository
         return $preserveOrder ? $albums->orderByArray($ids) : $albums;
     }
 
-    /** @return Collection|array<array-key, Album> */
+    /** @return Collection<int, Album> */
     public function getByArtist(Artist $artist, ?User $user = null): Collection
     {
         return Album::query()

--- a/app/Repositories/ArtistRepository.php
+++ b/app/Repositories/ArtistRepository.php
@@ -22,7 +22,6 @@ class ArtistRepository extends Repository implements ScoutableRepository
         return Artist::query()->withUserContext(user: $user ?? $this->auth->user())->findOrFail($id);
     }
 
-    /** @return Collection<int, Artist> */
     public function getRecentlyAdded(int $count = 6, ?User $user = null): Collection
     {
         return Artist::query()
@@ -33,7 +32,6 @@ class ArtistRepository extends Repository implements ScoutableRepository
             ->get();
     }
 
-    /** @return Collection<int, Artist> */
     public function getMostPlayed(int $count = 6, ?User $user = null): Collection
     {
         return Artist::query()
@@ -44,7 +42,6 @@ class ArtistRepository extends Repository implements ScoutableRepository
             ->get();
     }
 
-    /** @return Collection<int, Artist> */
     public function getMany(array $ids, bool $preserveOrder = false, ?User $user = null): Collection
     {
         $artists = Artist::query()
@@ -69,7 +66,6 @@ class ArtistRepository extends Repository implements ScoutableRepository
             ->simplePaginate(21);
     }
 
-    /** @return Collection<Artist>|array<array-key, Artist> */
     public function search(string $keywords, int $limit, ?User $user = null): Collection
     {
         return $this->getMany(

--- a/app/Repositories/ArtistRepository.php
+++ b/app/Repositories/ArtistRepository.php
@@ -22,7 +22,7 @@ class ArtistRepository extends Repository implements ScoutableRepository
         return Artist::query()->withUserContext(user: $user ?? $this->auth->user())->findOrFail($id);
     }
 
-    /** @return Collection|array<array-key, Artist> */
+    /** @return Collection<int, Artist> */
     public function getRecentlyAdded(int $count = 6, ?User $user = null): Collection
     {
         return Artist::query()
@@ -33,7 +33,7 @@ class ArtistRepository extends Repository implements ScoutableRepository
             ->get();
     }
 
-    /** @return Collection|array<array-key, Artist> */
+    /** @return Collection<int, Artist> */
     public function getMostPlayed(int $count = 6, ?User $user = null): Collection
     {
         return Artist::query()
@@ -44,7 +44,7 @@ class ArtistRepository extends Repository implements ScoutableRepository
             ->get();
     }
 
-    /** @return Collection|array<array-key, Artist> */
+    /** @return Collection<int, Artist> */
     public function getMany(array $ids, bool $preserveOrder = false, ?User $user = null): Collection
     {
         $artists = Artist::query()

--- a/app/Repositories/Contracts/ScoutableRepository.php
+++ b/app/Repositories/Contracts/ScoutableRepository.php
@@ -18,7 +18,7 @@ interface ScoutableRepository
      * @param int $limit The maximum number of results to return.
      * @param ?User $user Optional user to scope the search.
      *
-     * @return Collection<T>|array<array-key, T> A collection of models matching the search criteria.
+     * @return Collection<array-key, T> A collection of models matching the search criteria.
      */
     public function search(string $keywords, int $limit, ?User $user = null): Collection;
 }

--- a/app/Repositories/DuplicateUploadRepository.php
+++ b/app/Repositories/DuplicateUploadRepository.php
@@ -9,7 +9,6 @@ use Illuminate\Database\Eloquent\Collection;
 /** @extends Repository<DuplicateUpload> */
 class DuplicateUploadRepository extends Repository
 {
-    /** @return Collection<DuplicateUpload>|array<array-key, DuplicateUpload> */
     public function getAllForUser(User $user): Collection
     {
         return DuplicateUpload::query()
@@ -18,7 +17,6 @@ class DuplicateUploadRepository extends Repository
             ->get();
     }
 
-    /** @return Collection<DuplicateUpload>|array<array-key, DuplicateUpload> */
     public function getStaleUploads(int $days): Collection
     {
         return DuplicateUpload::query()->where('created_at', '<', now()->subDays($days))->get();

--- a/app/Repositories/FolderRepository.php
+++ b/app/Repositories/FolderRepository.php
@@ -26,7 +26,7 @@ class FolderRepository extends Repository
         return simple_hash($path ? trim($path, DIRECTORY_SEPARATOR) : $path);
     }
 
-    /** @return Collection|array<array-key, Folder> */
+    /** @return Collection<int, Folder> */
     public function getSubfolders(?Folder $folder = null, ?User $scopedUser = null): Collection
     {
         if ($folder) {
@@ -41,7 +41,7 @@ class FolderRepository extends Repository
         return $this->findOneBy(['hash' => self::pathToHash($path)]);
     }
 
-    /** @return Collection|array<array-key, Folder> */
+    /** @return Collection<int, Folder> */
     public function getByPaths(array $paths, ?User $scopedUser = null): Collection
     {
         $hashes = array_map(self::pathToHash(...), $paths);

--- a/app/Repositories/FolderRepository.php
+++ b/app/Repositories/FolderRepository.php
@@ -9,7 +9,6 @@ use Illuminate\Database\Eloquent\Collection;
 /** @extends Repository<Folder> */
 class FolderRepository extends Repository
 {
-    /** @return Collection<Folder>|array<array-key, Folder> */
     private function getOnlyBrowsable(Collection|Folder $folders, ?User $user = null): Collection
     {
         $user ??= $this->auth->user();
@@ -26,7 +25,6 @@ class FolderRepository extends Repository
         return simple_hash($path ? trim($path, DIRECTORY_SEPARATOR) : $path);
     }
 
-    /** @return Collection<int, Folder> */
     public function getSubfolders(?Folder $folder = null, ?User $scopedUser = null): Collection
     {
         if ($folder) {
@@ -41,7 +39,6 @@ class FolderRepository extends Repository
         return $this->findOneBy(['hash' => self::pathToHash($path)]);
     }
 
-    /** @return Collection<int, Folder> */
     public function getByPaths(array $paths, ?User $scopedUser = null): Collection
     {
         $hashes = array_map(self::pathToHash(...), $paths);

--- a/app/Repositories/GenreRepository.php
+++ b/app/Repositories/GenreRepository.php
@@ -18,7 +18,6 @@ class GenreRepository extends Repository
         return Genre::query()->where('name', 'like', "%{$name}%")->first();
     }
 
-    /** @return Collection<GenreSummary>|array<array-key, GenreSummary> */
     public function getAllSummaries(?User $scopedUser = null): Collection
     {
         $genres = Genre::query()

--- a/app/Repositories/PlaylistRepository.php
+++ b/app/Repositories/PlaylistRepository.php
@@ -22,10 +22,7 @@ class PlaylistRepository extends Repository
 
     public function searchAccessibleByName(string $name, User $user): ?Playlist
     {
-        /** @var ?Playlist $playlist */
-        $playlist = $this->accessibleByUser($user)->where('playlists.name', 'like', "%{$name}%")->first();
-
-        return $playlist;
+        return $this->accessibleByUser($user)->where('playlists.name', 'like', "%{$name}%")->first();
     }
 
     private static function accessibleByUser(User $user): BelongsToMany

--- a/app/Repositories/PlaylistRepository.php
+++ b/app/Repositories/PlaylistRepository.php
@@ -11,7 +11,6 @@ use Illuminate\Support\Collection;
 /** @extends Repository<Playlist> */
 class PlaylistRepository extends Repository
 {
-    /** @return Collection<Playlist>|array<array-key, Playlist> */
     public function getAllAccessibleByUser(User $user): Collection
     {
         return $this
@@ -23,7 +22,10 @@ class PlaylistRepository extends Repository
 
     public function searchAccessibleByName(string $name, User $user): ?Playlist
     {
-        return $this->accessibleByUser($user)->where('playlists.name', 'like', "%{$name}%")->first();
+        /** @var ?Playlist $playlist */
+        $playlist = $this->accessibleByUser($user)->where('playlists.name', 'like', "%{$name}%")->first();
+
+        return $playlist;
     }
 
     private static function accessibleByUser(User $user): BelongsToMany

--- a/app/Repositories/PodcastRepository.php
+++ b/app/Repositories/PodcastRepository.php
@@ -7,7 +7,10 @@ use App\Models\User;
 use App\Repositories\Contracts\ScoutableRepository;
 use Illuminate\Database\Eloquent\Collection;
 
-/** @extends Repository<Podcast> */
+/**
+ * @extends Repository<Podcast>
+ * @implements ScoutableRepository<Podcast>
+ */
 class PodcastRepository extends Repository implements ScoutableRepository
 {
     public function findOneByUrl(string $url): ?Podcast
@@ -15,7 +18,6 @@ class PodcastRepository extends Repository implements ScoutableRepository
         return $this->findOneBy(['url' => $url]);
     }
 
-    /** @return Collection<Podcast>|array<array-key, Podcast> */
     public function getAllSubscribedByUser(bool $favoritesOnly, ?User $user = null): Collection
     {
         $user ??= $this->auth->user();
@@ -28,7 +30,6 @@ class PodcastRepository extends Repository implements ScoutableRepository
             ->get();
     }
 
-    /** @return Collection<Podcast>|array<array-key, Podcast> */
     public function getMany(array $ids, bool $preserveOrder = false, ?User $user = null): Collection
     {
         $user ??= $this->auth->user();
@@ -44,7 +45,6 @@ class PodcastRepository extends Repository implements ScoutableRepository
         return $preserveOrder ? $podcasts->orderByArray($ids) : $podcasts;
     }
 
-    /** @return Collection<Podcast>|array<array-key, Podcast> */
     public function search(string $keywords, int $limit, ?User $user = null): Collection
     {
         return $this->getMany(

--- a/app/Repositories/RadioStationRepository.php
+++ b/app/Repositories/RadioStationRepository.php
@@ -7,10 +7,12 @@ use App\Models\User;
 use App\Repositories\Contracts\ScoutableRepository;
 use Illuminate\Database\Eloquent\Collection;
 
-/** @extends Repository<RadioStation> */
+/**
+ * @extends Repository<RadioStation>
+ * @implements ScoutableRepository<RadioStation>
+ */
 class RadioStationRepository extends Repository implements ScoutableRepository
 {
-    /** @return Collection<RadioStation>|array<array-key, RadioStation> */
     public function getMany(array $ids, bool $preserveOrder = false, ?User $user = null): Collection
     {
         $stations = RadioStation::query()
@@ -21,7 +23,6 @@ class RadioStationRepository extends Repository implements ScoutableRepository
         return $preserveOrder ? $stations->orderByArray($ids) : $stations;
     }
 
-    /** @return Collection<RadioStation>|array<array-key, RadioStation> */
     public function search(string $keywords, int $limit, ?User $user = null): Collection
     {
         return $this->getMany(
@@ -34,7 +35,6 @@ class RadioStationRepository extends Repository implements ScoutableRepository
         );
     }
 
-    /** @return Collection<RadioStation>|array<array-key, RadioStation> */
     public function getAllForUser(User $user): Collection
     {
         return RadioStation::query()->withUserContext(user: $user)->get();

--- a/app/Repositories/SongRepository.php
+++ b/app/Repositories/SongRepository.php
@@ -58,13 +58,13 @@ class SongRepository extends Repository implements ScoutableRepository
             ->first();
     }
 
-    /** @return Collection|array<array-key, Song> */
+    /** @return Collection<int, Song> */
     public function getAllStoredOnCloud(): Collection
     {
         return Song::query()->storedOnCloud()->get();
     }
 
-    /** @return Collection|array<array-key, Song> */
+    /** @return Collection<int, Song> */
     public function getRecentlyAdded(int $count = 8, ?User $scopedUser = null): Collection
     {
         return Song::query(type: PlayableType::SONG, user: $scopedUser ?? $this->auth->user())
@@ -74,7 +74,7 @@ class SongRepository extends Repository implements ScoutableRepository
             ->get();
     }
 
-    /** @return Collection|array<array-key, Song> */
+    /** @return Collection<int, Song> */
     public function getMostPlayed(int $count = 8, ?User $scopedUser = null, ?PlayableType $type = null): Collection
     {
         return Song::query(type: $type, user: $scopedUser ?? $this->auth->user())
@@ -85,7 +85,7 @@ class SongRepository extends Repository implements ScoutableRepository
             ->get();
     }
 
-    /** @return Collection|array<array-key, Song> */
+    /** @return Collection<int, Song> */
     public function getLeastPlayed(int $count = 50, ?User $scopedUser = null, ?PlayableType $type = null): Collection
     {
         return Song::query(type: $type, user: $scopedUser ?? $this->auth->user())
@@ -95,7 +95,7 @@ class SongRepository extends Repository implements ScoutableRepository
             ->get();
     }
 
-    /** @return Collection|array<array-key, Song> */
+    /** @return Collection<int, Song> */
     public function getRecentlyPlayed(int $count = 8, ?User $scopedUser = null, ?PlayableType $type = null): Collection
     {
         return Song::query(type: $type, user: $scopedUser ?? $this->auth->user())
@@ -139,7 +139,7 @@ class SongRepository extends Repository implements ScoutableRepository
             ->simplePaginate($perPage);
     }
 
-    /** @return Collection|array<array-key, Song> */
+    /** @return Collection<int, Song> */
     public function getForQueue(
         array $sortColumns,
         string $sortDirection,
@@ -153,7 +153,7 @@ class SongRepository extends Repository implements ScoutableRepository
             ->get();
     }
 
-    /** @return Collection|array<array-key, Song> */
+    /** @return Collection<int, Song> */
     public function getFavorites(?User $scopedUser = null, ?PlayableType $type = null): Collection
     {
         return Song::query(type: $type, user: $scopedUser ?? $this->auth->user())
@@ -162,7 +162,7 @@ class SongRepository extends Repository implements ScoutableRepository
             ->get();
     }
 
-    /** @return Collection|array<array-key, Song> */
+    /** @return Collection<int, Song> */
     public function getByAlbum(Album|string $album, ?User $scopedUser = null): Collection
     {
         $album = $this->albumRepository->resolveOne($album);
@@ -187,7 +187,7 @@ class SongRepository extends Repository implements ScoutableRepository
             ->simplePaginate(50);
     }
 
-    /** @return Collection|array<array-key, Song> */
+    /** @return Collection<int, Song> */
     public function getByArtist(Artist|string $artist, ?User $scopedUser = null): Collection
     {
         $artist = $this->artistRepository->resolveOne($artist);
@@ -205,7 +205,7 @@ class SongRepository extends Repository implements ScoutableRepository
             ->get();
     }
 
-    /** @return Collection|array<array-key, Song> */
+    /** @return Collection<int, Song> */
     public function getByPlaylist(Playlist|string $playlist, ?User $scopedUser = null): Collection
     {
         $playlist = $this->playlistRepository->resolveOne($playlist);
@@ -217,7 +217,7 @@ class SongRepository extends Repository implements ScoutableRepository
         }
     }
 
-    /** @return Collection|array<array-key, Song> */
+    /** @return Collection<int, Song> */
     private function getByStandardPlaylist(Playlist $playlist, ?User $scopedUser = null): Collection
     {
         throw_if($playlist->is_smart, new LogicException('Not a standard playlist.'));
@@ -245,7 +245,7 @@ class SongRepository extends Repository implements ScoutableRepository
             ->get();
     }
 
-    /** @return Collection|array<array-key, Song> */
+    /** @return Collection<int, Song> */
     private function getBySmartPlaylist(Playlist $playlist, ?User $scopedUser = null): Collection
     {
         throw_unless($playlist->is_smart, NonSmartPlaylistException::create($playlist));
@@ -269,7 +269,7 @@ class SongRepository extends Repository implements ScoutableRepository
         return $query->orderBy('songs.title')->limit(self::LIST_SIZE_LIMIT)->get();
     }
 
-    /** @return Collection|array<array-key, Song> */
+    /** @return Collection<int, Song> */
     public function getRandom(int $limit, ?User $scopedUser = null): Collection
     {
         return Song::query(type: PlayableType::SONG, user: $scopedUser ?? $this->auth->user())
@@ -279,7 +279,7 @@ class SongRepository extends Repository implements ScoutableRepository
             ->get();
     }
 
-    /** @return Collection|array<array-key, Song> */
+    /** @return Collection<int, Song> */
     public function getMany(array $ids, bool $preserveOrder = false, ?User $scopedUser = null): Collection
     {
         $songs = Song::query(user: $scopedUser ?? $this->auth->user())
@@ -302,7 +302,7 @@ class SongRepository extends Repository implements ScoutableRepository
     /**
      * Gets several songs, but also includes collaborative information.
      *
-     * @return Collection|array<array-key, Song>
+     * @return Collection<int, Song>
      */
     public function getManyInCollaborativeContext(array $ids, ?User $scopedUser = null): Collection
     {
@@ -351,7 +351,7 @@ class SongRepository extends Repository implements ScoutableRepository
     /**
      * @param Genre|null $genre If null, query songs that have no genre.
      *
-     * @return Collection|array<array-key, Song>
+     * @return Collection<int, Song>
      */
     public function getByGenre(?Genre $genre, int $limit, $random = false, ?User $scopedUser = null): Collection
     {

--- a/app/Repositories/SongRepository.php
+++ b/app/Repositories/SongRepository.php
@@ -58,13 +58,11 @@ class SongRepository extends Repository implements ScoutableRepository
             ->first();
     }
 
-    /** @return Collection<int, Song> */
     public function getAllStoredOnCloud(): Collection
     {
         return Song::query()->storedOnCloud()->get();
     }
 
-    /** @return Collection<int, Song> */
     public function getRecentlyAdded(int $count = 8, ?User $scopedUser = null): Collection
     {
         return Song::query(type: PlayableType::SONG, user: $scopedUser ?? $this->auth->user())
@@ -74,7 +72,6 @@ class SongRepository extends Repository implements ScoutableRepository
             ->get();
     }
 
-    /** @return Collection<int, Song> */
     public function getMostPlayed(int $count = 8, ?User $scopedUser = null, ?PlayableType $type = null): Collection
     {
         return Song::query(type: $type, user: $scopedUser ?? $this->auth->user())
@@ -85,7 +82,6 @@ class SongRepository extends Repository implements ScoutableRepository
             ->get();
     }
 
-    /** @return Collection<int, Song> */
     public function getLeastPlayed(int $count = 50, ?User $scopedUser = null, ?PlayableType $type = null): Collection
     {
         return Song::query(type: $type, user: $scopedUser ?? $this->auth->user())
@@ -95,7 +91,6 @@ class SongRepository extends Repository implements ScoutableRepository
             ->get();
     }
 
-    /** @return Collection<int, Song> */
     public function getRecentlyPlayed(int $count = 8, ?User $scopedUser = null, ?PlayableType $type = null): Collection
     {
         return Song::query(type: $type, user: $scopedUser ?? $this->auth->user())
@@ -139,7 +134,6 @@ class SongRepository extends Repository implements ScoutableRepository
             ->simplePaginate($perPage);
     }
 
-    /** @return Collection<int, Song> */
     public function getForQueue(
         array $sortColumns,
         string $sortDirection,
@@ -153,7 +147,6 @@ class SongRepository extends Repository implements ScoutableRepository
             ->get();
     }
 
-    /** @return Collection<int, Song> */
     public function getFavorites(?User $scopedUser = null, ?PlayableType $type = null): Collection
     {
         return Song::query(type: $type, user: $scopedUser ?? $this->auth->user())
@@ -162,7 +155,6 @@ class SongRepository extends Repository implements ScoutableRepository
             ->get();
     }
 
-    /** @return Collection<int, Song> */
     public function getByAlbum(Album|string $album, ?User $scopedUser = null): Collection
     {
         $album = $this->albumRepository->resolveOne($album);
@@ -187,7 +179,6 @@ class SongRepository extends Repository implements ScoutableRepository
             ->simplePaginate(50);
     }
 
-    /** @return Collection<int, Song> */
     public function getByArtist(Artist|string $artist, ?User $scopedUser = null): Collection
     {
         $artist = $this->artistRepository->resolveOne($artist);
@@ -205,7 +196,6 @@ class SongRepository extends Repository implements ScoutableRepository
             ->get();
     }
 
-    /** @return Collection<int, Song> */
     public function getByPlaylist(Playlist|string $playlist, ?User $scopedUser = null): Collection
     {
         $playlist = $this->playlistRepository->resolveOne($playlist);
@@ -217,7 +207,6 @@ class SongRepository extends Repository implements ScoutableRepository
         }
     }
 
-    /** @return Collection<int, Song> */
     private function getByStandardPlaylist(Playlist $playlist, ?User $scopedUser = null): Collection
     {
         throw_if($playlist->is_smart, new LogicException('Not a standard playlist.'));
@@ -245,7 +234,6 @@ class SongRepository extends Repository implements ScoutableRepository
             ->get();
     }
 
-    /** @return Collection<int, Song> */
     private function getBySmartPlaylist(Playlist $playlist, ?User $scopedUser = null): Collection
     {
         throw_unless($playlist->is_smart, NonSmartPlaylistException::create($playlist));
@@ -269,7 +257,6 @@ class SongRepository extends Repository implements ScoutableRepository
         return $query->orderBy('songs.title')->limit(self::LIST_SIZE_LIMIT)->get();
     }
 
-    /** @return Collection<int, Song> */
     public function getRandom(int $limit, ?User $scopedUser = null): Collection
     {
         return Song::query(type: PlayableType::SONG, user: $scopedUser ?? $this->auth->user())
@@ -279,7 +266,6 @@ class SongRepository extends Repository implements ScoutableRepository
             ->get();
     }
 
-    /** @return Collection<int, Song> */
     public function getMany(array $ids, bool $preserveOrder = false, ?User $scopedUser = null): Collection
     {
         $songs = Song::query(user: $scopedUser ?? $this->auth->user())
@@ -301,8 +287,6 @@ class SongRepository extends Repository implements ScoutableRepository
 
     /**
      * Gets several songs, but also includes collaborative information.
-     *
-     * @return Collection<int, Song>
      */
     public function getManyInCollaborativeContext(array $ids, ?User $scopedUser = null): Collection
     {
@@ -350,8 +334,6 @@ class SongRepository extends Repository implements ScoutableRepository
 
     /**
      * @param Genre|null $genre If null, query songs that have no genre.
-     *
-     * @return Collection<int, Song>
      */
     public function getByGenre(?Genre $genre, int $limit, $random = false, ?User $scopedUser = null): Collection
     {
@@ -371,7 +353,6 @@ class SongRepository extends Repository implements ScoutableRepository
         return $podcast->episodes()->pluck('episode_guid')->toArray();
     }
 
-    /** @return Collection<Song>|array<array-key, Song> */
     public function getEpisodesByPodcast(Podcast $podcast, ?User $user = null): Collection
     {
         return Song::query(user: $user ?? $this->auth->user())
@@ -381,7 +362,6 @@ class SongRepository extends Repository implements ScoutableRepository
             ->get();
     }
 
-    /** @return Collection<Song>|array<array-key, Song> */
     public function getUnderPaths(
         array $paths,
         int $limit = 500,
@@ -414,7 +394,6 @@ class SongRepository extends Repository implements ScoutableRepository
      * Fetch songs **directly** in a specific folder (or the media root if null).
      * This does not include songs in subfolders.
      *
-     * @return Collection<Song>|array<array-key, Song>
      */
     public function getInFolder(?Folder $folder = null, int $limit = 500, ?User $scopedUser = null): Collection
     {
@@ -427,7 +406,6 @@ class SongRepository extends Repository implements ScoutableRepository
             ->get();
     }
 
-    /** @return Collection<Song>|array<array-key, Song> */
     public function searchByLyrics(string $lyrics, int $limit = 50, ?User $user = null): Collection
     {
         $query = Song::query(type: PlayableType::SONG, user: $user ?? $this->auth->user())->withUserContext();
@@ -441,7 +419,6 @@ class SongRepository extends Repository implements ScoutableRepository
         return $query->limit($limit)->get();
     }
 
-    /** @return Collection<Song>|array<array-key, Song> */
     public function getSimilar(Song $song, int $limit = 50, ?User $user = null): Collection
     {
         /** @var Collection<int, Song> $songs */
@@ -481,7 +458,6 @@ class SongRepository extends Repository implements ScoutableRepository
             ->get();
     }
 
-    /** @return Collection<Song>|array<array-key, Song> */
     public function search(string $keywords, int $limit, ?User $user = null): Collection
     {
         return $this->getMany(
@@ -494,7 +470,6 @@ class SongRepository extends Repository implements ScoutableRepository
         );
     }
 
-    /** @return Collection<Song>|array<array-key, Song> */
     public function getForEmbed(Embed $embed): Collection
     {
         throw_unless((bool) $embed->embeddable, new EmbeddableNotFoundException());

--- a/app/Repositories/ThemeRepository.php
+++ b/app/Repositories/ThemeRepository.php
@@ -11,7 +11,6 @@ use Illuminate\Database\Eloquent\Collection;
  */
 class ThemeRepository extends Repository
 {
-    /** @return Collection<Theme>|array<array-key, Theme> */
     public function getAllByUser(User $user): Collection
     {
         return $user->themes->sortByDesc('created_at');

--- a/app/Repositories/TranscodeRepository.php
+++ b/app/Repositories/TranscodeRepository.php
@@ -13,7 +13,6 @@ class TranscodeRepository extends Repository
     /**
      * @param array<string> $songIds
      *
-     * @return Collection<Transcode>|array<array-key, Transcode>
      */
     public function findBySongIds(array $songIds): Collection
     {


### PR DESCRIPTION
## Summary

Two coupled changes: declare the missing `TModel` parameter on the custom Eloquent builders, then prune the now-redundant `@return Collection|array<array-key, X>` workaround docblocks across the repositories. Doing them together because cleaning up the docblocks before fixing the builders would have broken the analyser; fixing the builders without cleaning up leaves stale unions in place.

## Builder generics

Laravel's `Eloquent\Builder` is generic over `Builder<TModel>`, but the custom builders extending the abstract `FavoriteableBuilder` weren't declaring `TModel`. Static analysers fell back to the unbound docblock — so `Album::query()->withUserContext(...)->findOrFail($id)` typed as `Model|Collection` instead of `Album`.

- `FavoriteableBuilder`: `@template TModel of Model` + `@extends Builder<TModel>`
- `AlbumBuilder`, `ArtistBuilder`, `SongBuilder`: `@extends FavoriteableBuilder<Album|Artist|Song>` to resolve the parameter at the concrete-builder level

`findOrFail`, `get`, `first`, etc. now narrow correctly to the concrete model type.

## Repository docblock cleanup

With the builders generic, 47 `@return Collection|array<array-key, X>` workaround docblocks across 11 repositories no longer carry information Larastan can't infer from the body. The bare `: Collection` signature is enough; the workaround union also tripped PHPStorm's "docblock widens beyond signature" check, so the cleanup fixes both.

The `ScoutableRepository` contract is the only docblock kept (interfaces don't have a body to infer from); tightened from `Collection<T>|array<array-key, T>` to `Collection<array-key, T>`. `PodcastRepository` and `RadioStationRepository` gained `@implements ScoutableRepository<X>` annotations so `T` resolves at the implementation site.

## Test plan

- [x] `vendor/bin/phpstan` clean project-wide (1031 files)
- [x] Full test suite passes
- [x] `composer cs` clean
- [x] No runtime changes — PHPDoc only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced type annotations in builder classes to improve type safety and IDE support.
  * Streamlined documentation in repository classes by removing redundant return-type annotations that duplicated method signatures.
  * Updated interface declarations for better code organization.

**Impact:** No functional changes. These improvements refine the codebase's type information for better developer experience and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->