### PR TITLE
chore: round out builder generics on remaining custom builders

### DIFF
--- a/app/Builders/PodcastBuilder.php
+++ b/app/Builders/PodcastBuilder.php
@@ -3,9 +3,13 @@
 namespace App\Builders;
 
 use App\Builders\Concerns\CanScopeByUser;
+use App\Models\Podcast;
 use Illuminate\Database\Query\JoinClause;
 use LogicException;
 
+/**
+ * @extends FavoriteableBuilder<Podcast>
+ */
 class PodcastBuilder extends FavoriteableBuilder
 {
     use CanScopeByUser;

--- a/app/Builders/RadioStationBuilder.php
+++ b/app/Builders/RadioStationBuilder.php
@@ -3,9 +3,13 @@
 namespace App\Builders;
 
 use App\Builders\Concerns\CanScopeByUser;
+use App\Models\RadioStation;
 use App\Models\User;
 use LogicException;
 
+/**
+ * @extends FavoriteableBuilder<RadioStation>
+ */
 class RadioStationBuilder extends FavoriteableBuilder
 {
     use CanScopeByUser;

--- a/app/Repositories/PlaylistRepository.php
+++ b/app/Repositories/PlaylistRepository.php
@@ -25,7 +25,7 @@ class PlaylistRepository extends Repository
         return $this->accessibleByUser($user)->where('playlists.name', 'like', "%{$name}%")->first();
     }
 
-    private static function accessibleByUser(User $user): BelongsToMany
+    private function accessibleByUser(User $user): BelongsToMany
     {
         return License::isCommunity() ? $user->ownedPlaylists() : $user->playlists();
     }


### PR DESCRIPTION
## Summary

Follow-up to #2429. Applies the same `@extends FavoriteableBuilder<TModel>` pattern to the two custom builders that weren't covered there:

- `PodcastBuilder` → `@extends FavoriteableBuilder<Podcast>`
- `RadioStationBuilder` → `@extends FavoriteableBuilder<RadioStation>`

`findOrFail`, `get`, `first` etc. now narrow to the concrete model type for these too.

Also: drop the `static` modifier on `PlaylistRepository::accessibleByUser`. The "methods that don't reference `\$this` must be static" rule has a documented exception for injectable services, where instance methods are preferred for testability. `PlaylistRepository` is DI-resolved, so instance is the right choice.

## Test plan

- [x] `vendor/bin/phpstan` clean across `app/Builders` and `app/Repositories`
- [x] No runtime changes — PHPDoc + visibility only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  - Improved internal code structure and type safety for enhanced maintainability across builder and repository components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->