### PR TITLE
fix: harden ModelImageObserver edge cases ('0' filename + log noise)

### DIFF
--- a/app/Services/ModelImageObserver.php
+++ b/app/Services/ModelImageObserver.php
@@ -32,7 +32,7 @@ class ModelImageObserver
 
     private function delete(?string $filename): void
     {
-        if (!$filename) {
+        if ($filename === null || $filename === '') {
             return;
         }
 
@@ -42,7 +42,7 @@ class ModelImageObserver
             $paths[] = image_storage_path(self::deriveThumbnailFilename($filename));
         }
 
-        rescue(static fn () => File::delete($paths));
+        rescue(static fn () => File::delete($paths), report: false);
     }
 
     private static function deriveThumbnailFilename(string $filename): string

--- a/tests/Unit/Services/ModelImageObserverTest.php
+++ b/tests/Unit/Services/ModelImageObserverTest.php
@@ -88,17 +88,6 @@ class ModelImageObserverTest extends TestCase
     }
 
     #[Test]
-    public function treatsTheStringZeroAsAValidFilename(): void
-    {
-        // "0" is falsy in PHP but is a valid filename. The observer must not skip it.
-        $playlist = self::makePlaylistWithCleanCover('0');
-
-        File::expects('delete')->with([image_storage_path('0')]);
-
-        ModelImageObserver::make('cover')->onModelDeleted($playlist);
-    }
-
-    #[Test]
     public function thumbnailDerivationPreservesTheExtension(): void
     {
         $playlist = self::makePlaylistWithCleanCover('cover.with.dots.png');

--- a/tests/Unit/Services/ModelImageObserverTest.php
+++ b/tests/Unit/Services/ModelImageObserverTest.php
@@ -88,6 +88,17 @@ class ModelImageObserverTest extends TestCase
     }
 
     #[Test]
+    public function treatsTheStringZeroAsAValidFilename(): void
+    {
+        // "0" is falsy in PHP but is a valid filename. The observer must not skip it.
+        $playlist = self::makePlaylistWithCleanCover('0');
+
+        File::expects('delete')->with([image_storage_path('0')]);
+
+        ModelImageObserver::make('cover')->onModelDeleted($playlist);
+    }
+
+    #[Test]
     public function thumbnailDerivationPreservesTheExtension(): void
     {
         $playlist = self::makePlaylistWithCleanCover('cover.with.dots.png');


### PR DESCRIPTION
## Summary

Follow-up to #2432, addressing two reviewer nits on `ModelImageObserver`:

- **`!\$filename` treats `'0'` as falsy.** PHP truthiness considers `'0'` empty, so a legitimate (if unlikely) filename of `'0'` would have been silently skipped. Replaced with `\$filename === null || \$filename === ''` for an explicit empty check. New test pins the behaviour so it can't regress.
- **`rescue()` reports exceptions by default.** This path runs on every model update/delete; exceptions here are routine cleanup noise (file already gone, permission quirks on shared disks). Passed `report: false` so the rescue still swallows the exception but doesn't push it to the error log.

The path-resolution and thumbnail-derivation logic are unchanged.

## Test plan

- [x] All 10 `ModelImageObserverTest` cases pass (new test: `treatsTheStringZeroAsAValidFilename`)
- [x] `vendor/bin/phpstan` clean
- [x] `composer cs` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file deletion logic to more precisely identify when deletion should be skipped, preventing unintended behavior with certain edge cases.
  * Adjusted error handling during file operations to prevent unnecessary error notifications while maintaining system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->