### PR TITLE
chore: upgrade factoria to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@vueuse/core": "^13.4.0",
     "@vueuse/integrations": "^13.4.0",
     "autoprefixer": "^10.4.21",
-    "factoria": "^4.0.1",
+    "factoria": "^5.0.0",
     "fake-indexeddb": "^6.2.5",
     "jest-serializer-vue": "^2.0.2",
     "jsdom": "^26.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,8 +172,8 @@ importers:
         specifier: ^10.4.21
         version: 10.4.21(postcss@8.5.8)
       factoria:
-        specifier: ^4.0.1
-        version: 4.0.1
+        specifier: ^5.0.0
+        version: 5.0.0(@faker-js/faker@9.8.0)
       fake-indexeddb:
         specifier: ^6.2.5
         version: 6.2.5
@@ -2208,8 +2208,10 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
-  factoria@4.0.1:
-    resolution: {integrity: sha512-YlWKnX6wTQm2xAU2RpbLddQb6WWNAOFw/Kv9C2MuuKFR4O+UuYUtESw7B6r+nxp6r3PSmmwpLN+XKrDsv3xpDA==}
+  factoria@5.0.0:
+    resolution: {integrity: sha512-8nOQLjTvxINt+4cVqW9VG9jpYgFKDMnL8i1Ecm70NBj3ICIp/bX2KFeQqezVfe5cy+x5Jpvui9/ESLoU7CcQqA==}
+    peerDependencies:
+      '@faker-js/faker': '>=6.0.0'
 
   fake-indexeddb@6.2.5:
     resolution: {integrity: sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==}
@@ -5537,7 +5539,9 @@ snapshots:
 
   extend@3.0.2: {}
 
-  factoria@4.0.1: {}
+  factoria@5.0.0(@faker-js/faker@9.8.0):
+    dependencies:
+      '@faker-js/faker': 9.8.0
 
   fake-indexeddb@6.2.5: {}
 

--- a/resources/assets/js/__tests__/TestHarness.ts
+++ b/resources/assets/js/__tests__/TestHarness.ts
@@ -71,13 +71,13 @@ class TestHarness {
   public readonly auth = (user?: CurrentUser) => this.actingAsUser(user)
 
   public actingAsUser(user?: CurrentUser) {
-    userStore.state.current = user || (factory.states('current')('user') as CurrentUser)
+    userStore.state.current = user || (factory('user').state('current').make() as CurrentUser)
     preferenceStore.init(userStore.state.current.preferences)
     return this
   }
 
   public actingAsAdmin() {
-    return this.actingAsUser(factory.states('admin')('user') as CurrentUser)
+    return this.actingAsUser(factory('user').state('admin').make() as CurrentUser)
   }
 
   public mock<T, M extends MethodOf<Required<T>>>(obj: T, methodName: M, implementation?: any) {

--- a/resources/assets/js/__tests__/factory/albumInfoFactory.ts
+++ b/resources/assets/js/__tests__/factory/albumInfoFactory.ts
@@ -7,6 +7,6 @@ export default (): AlbumInfo => ({
     summary: faker.lorem.sentence(),
     full: faker.lorem.sentences(4),
   },
-  tracks: factory('album-track', 8) as unknown as AlbumTrack[],
+  tracks: factory('album-track').make(8) as unknown as AlbumTrack[],
   url: faker.internet.url(),
 })

--- a/resources/assets/js/__tests__/factory/index.ts
+++ b/resources/assets/js/__tests__/factory/index.ts
@@ -1,61 +1,41 @@
+import factory from 'factoria'
 import type { Factoria } from 'factoria'
-import factoria from 'factoria'
 
-export interface ModelToTypeMap {
-  album: Album
-  'album-info': AlbumInfo
-  'album-track': AlbumTrack
-  artist: Artist
-  'artist-info': ArtistInfo
-  embed: Embed
-  episode: Episode
-  favorite: Favorite
-  folder: Folder
-  genre: Genre
-  interaction: Interaction
-  'live-event': LiveEvent
-  playlist: Playlist
-  'playlist-collaborator': PlaylistCollaborator
-  'playlist-folder': PlaylistFolder
-  podcast: Podcast
-  'radio-station': RadioStation
-  'smart-playlist-rule': SmartPlaylistRule
-  'smart-playlist-rule-group': SmartPlaylistRuleGroup
-  song: Song
-  theme: Theme
-  user: User
-  'you-tube-video': YouTubeVideo
+declare module 'factoria' {
+  namespace Factoria {
+    interface ModelRegistry {
+      album: Album
+      'album-info': AlbumInfo
+      'album-track': AlbumTrack
+      artist: Artist
+      'artist-info': ArtistInfo
+      embed: Embed
+      episode: Episode
+      favorite: Favorite
+      folder: Folder
+      genre: Genre
+      interaction: Interaction
+      'live-event': LiveEvent
+      playlist: Playlist
+      'playlist-collaborator': PlaylistCollaborator
+      'playlist-folder': PlaylistFolder
+      podcast: Podcast
+      'radio-station': RadioStation
+      'smart-playlist-rule': SmartPlaylistRule
+      'smart-playlist-rule-group': SmartPlaylistRuleGroup
+      song: Song
+      theme: Theme
+      user: User
+      'you-tube-video': YouTubeVideo
+    }
+  }
 }
 
-type Model = keyof ModelToTypeMap
-type Overrides<M extends Model> = Factoria.Overrides<ModelToTypeMap[M]>
-
-const define: typeof factoria.define = (model, handle, states) => factoria.define(model, handle, states)
-
-function factory<M extends Model>(model: M, overrides?: Overrides<M>): ModelToTypeMap[M]
-
-function factory<M extends Model>(model: M, count: 1, overrides?: Overrides<M>): ModelToTypeMap[M]
-
-function factory<M extends Model>(model: M, count: number, overrides?: Overrides<M>): ModelToTypeMap[M][]
-
-function factory<M extends Model>(model: M, count: number | Overrides<M> = 1, overrides?: Overrides<M>) {
-  return typeof count === 'number'
-    ? count === 1
-      ? factoria(model, overrides)
-      : factoria(model, count, overrides)
-    : factoria(model, count)
-}
-
-const states = (...states: string[]): typeof factory => {
-  factoria.states(...states)
-  return factory
-}
-
-factory.states = states
-
-export default factory as typeof factory & {
-  states: typeof states
-}
+// Distributed pair: [model name, key of that model]. Lets `it.each` narrow the
+// second tuple element to actual fields of the first.
+export type ModelFieldPair = {
+  [K in keyof Factoria.ModelRegistry]: [K, keyof Factoria.ModelRegistry[K] & string]
+}[keyof Factoria.ModelRegistry]
 
 // Dynamically import and register all factory modules
 const factoryModules = import.meta.glob('@/__tests__/factory/*Factory.ts', { eager: true })
@@ -72,5 +52,7 @@ for (const [path, mod] of Object.entries(factoryModules)) {
   const factoryFn = (mod as any).default
   const states = (mod as any).states
 
-  define(modelName, factoryFn, states)
+  factory.define(modelName, factoryFn, states)
 }
+
+export default factory

--- a/resources/assets/js/__tests__/factory/playlistFactory.ts
+++ b/resources/assets/js/__tests__/factory/playlistFactory.ts
@@ -21,7 +21,7 @@ export default (): Playlist => ({
 export const states: Record<string, () => Omit<Partial<Playlist>, 'type'>> = {
   smart: () => ({
     is_smart: true,
-    rules: [factory('smart-playlist-rule-group') as SmartPlaylistRuleGroup],
+    rules: [factory('smart-playlist-rule-group').make() as SmartPlaylistRuleGroup],
   }),
   orphan: () => ({
     folder_id: null,

--- a/resources/assets/js/__tests__/factory/smartPlaylistRuleGroupFactory.ts
+++ b/resources/assets/js/__tests__/factory/smartPlaylistRuleGroupFactory.ts
@@ -3,5 +3,5 @@ import { faker } from '@faker-js/faker'
 
 export default (): SmartPlaylistRuleGroup => ({
   id: faker.string.uuid(),
-  rules: factory('smart-playlist-rule', 3) as unknown as SmartPlaylistRule[],
+  rules: factory('smart-playlist-rule').make(3) as unknown as SmartPlaylistRule[],
 })

--- a/resources/assets/js/components/album/AlbumCard.spec.ts
+++ b/resources/assets/js/components/album/AlbumCard.spec.ts
@@ -18,7 +18,7 @@ describe('albumCard', () => {
   const h = createHarness()
 
   const createAlbum = (overrides: Partial<Album> = {}) => {
-    return h.factory('album', {
+    return h.factory('album').make({
       id: 'iv',
       name: 'IV',
       artist_id: 'led-zeppelin',
@@ -75,7 +75,7 @@ describe('albumCard', () => {
   it('shuffles', async () => {
     h.createAudioPlayer()
 
-    const songs = h.factory('song', 10)
+    const songs = h.factory('song').make(10)
     const fetchMock = h.mock(playableStore, 'fetchSongsForAlbum').mockResolvedValue(songs)
     const shuffleMock = h.mock(playbackService, 'queueAndPlay').mockResolvedValue(void 0)
     const { album } = renderComponent(undefined, false)

--- a/resources/assets/js/components/album/AlbumContextMenu.spec.ts
+++ b/resources/assets/js/components/album/AlbumContextMenu.spec.ts
@@ -32,7 +32,7 @@ describe('albumContextMenu.vue', () => {
 
     album =
       album ||
-      h.factory('album', {
+      h.factory('album').make({
         name: 'IV',
         favorite: false,
         permissions: { edit: true },
@@ -55,7 +55,7 @@ describe('albumContextMenu.vue', () => {
   it('plays all', async () => {
     h.createAudioPlayer()
 
-    const songs = h.factory('song', 10)
+    const songs = h.factory('song').make(10)
     const fetchMock = h.mock(playableStore, 'fetchSongsForAlbum').mockResolvedValue(songs)
     const playMock = h.mock(playbackService, 'queueAndPlay')
 
@@ -70,7 +70,7 @@ describe('albumContextMenu.vue', () => {
   it('shuffles all', async () => {
     h.createAudioPlayer()
 
-    const songs = h.factory('song', 10)
+    const songs = h.factory('song').make(10)
     const fetchMock = h.mock(playableStore, 'fetchSongsForAlbum').mockResolvedValue(songs)
     const playMock = h.mock(playbackService, 'queueAndPlay')
 
@@ -99,7 +99,7 @@ describe('albumContextMenu.vue', () => {
   })
 
   it('does not have an option to download or go to Unknown Album and Artist', async () => {
-    await renderComponent(factory.states('unknown')('album'))
+    await renderComponent(factory('album').state('unknown').make())
 
     expect(screen.queryByText('Go to Album')).toBeNull()
     expect(screen.queryByText('Go to Artist')).toBeNull()

--- a/resources/assets/js/components/album/AlbumInfo.spec.ts
+++ b/resources/assets/js/components/album/AlbumInfo.spec.ts
@@ -12,10 +12,10 @@ describe('albumInfo.vue', () => {
     commonStore.state.uses_last_fm = true
 
     if (info === undefined) {
-      info = h.factory('album-info')
+      info = h.factory('album-info').make()
     }
 
-    const album = h.factory('album', { name: 'IV' })
+    const album = h.factory('album').make({ name: 'IV' })
     const fetchMock = h.mock(encyclopediaService, 'fetchForAlbum').mockResolvedValue(info)
 
     const rendered = h.render(Component, {

--- a/resources/assets/js/components/album/AlbumTrackList.spec.ts
+++ b/resources/assets/js/components/album/AlbumTrackList.spec.ts
@@ -8,13 +8,13 @@ describe('albumTrackList.vue', () => {
   const h = createHarness()
 
   it('displays the tracks', async () => {
-    const album = h.factory('album')
-    const fetchMock = h.mock(playableStore, 'fetchSongsForAlbum').mockResolvedValue(h.factory('song', 5))
+    const album = h.factory('album').make()
+    const fetchMock = h.mock(playableStore, 'fetchSongsForAlbum').mockResolvedValue(h.factory('song').make(5))
 
     h.render(Component, {
       props: {
         album,
-        tracks: h.factory('album-track', 3),
+        tracks: h.factory('album-track').make(3),
       },
     })
 

--- a/resources/assets/js/components/album/AlbumTrackListItem.spec.ts
+++ b/resources/assets/js/components/album/AlbumTrackListItem.spec.ts
@@ -11,10 +11,10 @@ describe('albumTrackListItem.vue', () => {
   const h = createHarness()
 
   const renderComponent = (matchedSong?: Song) => {
-    const songsToMatchAgainst = h.factory('song', 10)
-    const album = h.factory('album')
+    const songsToMatchAgainst = h.factory('song').make(10)
+    const album = h.factory('album').make()
 
-    const track = h.factory('album-track', {
+    const track = h.factory('album-track').make({
       title: 'Fahrstuhl to Heaven',
       length: 280,
     })
@@ -43,7 +43,7 @@ describe('albumTrackListItem.vue', () => {
   it('plays', async () => {
     h.createAudioPlayer()
 
-    const matchedSong = h.factory('song')
+    const matchedSong = h.factory('song').make()
     const playMock = h.mock(playbackService, 'play')
 
     renderComponent(matchedSong)

--- a/resources/assets/js/components/album/EditAlbumForm.spec.ts
+++ b/resources/assets/js/components/album/EditAlbumForm.spec.ts
@@ -8,7 +8,7 @@ describe('editAlbumForm.vue', () => {
   const h = createHarness()
 
   const renderComponent = (album?: Album) => {
-    album = album ?? h.factory('album')
+    album = album ?? h.factory('album').make()
     albumStore.state.albums = [album]
 
     const rendered = h.render(Component, {
@@ -41,7 +41,7 @@ describe('editAlbumForm.vue', () => {
 
   it('submits with a new cover', async () => {
     const updateMock = h.mock(albumStore, 'update')
-    const { album } = renderComponent(h.factory('album'))
+    const { album } = renderComponent(h.factory('album').make())
 
     await h.type(screen.getByTitle('Album name'), 'Not So Good Actually')
     await h.type(screen.getByTitle('Release year'), '2022')
@@ -63,7 +63,7 @@ describe('editAlbumForm.vue', () => {
   })
 
   it('removes cover and submits', async () => {
-    const { album } = renderComponent(h.factory('album'))
+    const { album } = renderComponent(h.factory('album').make())
     const updateMock = h.mock(albumStore, 'update')
 
     await h.user.click(screen.getByRole('button', { name: 'Remove' }))

--- a/resources/assets/js/components/artist/ArtistCard.spec.ts
+++ b/resources/assets/js/components/artist/ArtistCard.spec.ts
@@ -18,7 +18,7 @@ describe('artistCard.vue', () => {
   const h = createHarness()
 
   const createArtist = (overrides: Partial<Artist> = {}): Artist => {
-    return h.factory('artist', {
+    return h.factory('artist').make({
       id: 'led-zeppelin',
       name: 'Led Zeppelin',
       favorite: false,
@@ -69,7 +69,7 @@ describe('artistCard.vue', () => {
   it('shuffles', async () => {
     h.createAudioPlayer()
 
-    const songs = h.factory('song', 16)
+    const songs = h.factory('song').make(16)
     const fetchMock = h.mock(playableStore, 'fetchSongsForArtist').mockResolvedValue(songs)
     const playMock = h.mock(playbackService, 'queueAndPlay')
 

--- a/resources/assets/js/components/artist/ArtistContextMenu.spec.ts
+++ b/resources/assets/js/components/artist/ArtistContextMenu.spec.ts
@@ -27,7 +27,7 @@ describe('artistContextMenu.vue', () => {
   const renderComponent = async (artist?: Artist) => {
     artist =
       artist ||
-      h.factory('artist', {
+      h.factory('artist').make({
         name: 'Accept',
         favorite: false,
         permissions: { edit: true },
@@ -50,7 +50,7 @@ describe('artistContextMenu.vue', () => {
   it('plays all', async () => {
     h.createAudioPlayer()
 
-    const songs = h.factory('song', 10)
+    const songs = h.factory('song').make(10)
     const fetchMock = h.mock(playableStore, 'fetchSongsForArtist').mockResolvedValue(songs)
     const playMock = h.mock(playbackService, 'queueAndPlay')
 
@@ -65,7 +65,7 @@ describe('artistContextMenu.vue', () => {
   it('shuffles all', async () => {
     h.createAudioPlayer()
 
-    const songs = h.factory('song', 10)
+    const songs = h.factory('song').make(10)
     const fetchMock = h.mock(playableStore, 'fetchSongsForArtist').mockResolvedValue(songs)
     const playMock = h.mock(playbackService, 'queueAndPlay')
 
@@ -94,13 +94,13 @@ describe('artistContextMenu.vue', () => {
   })
 
   it('does not have an option to download Unknown Artist', async () => {
-    await renderComponent(factory.states('unknown')('artist'))
+    await renderComponent(factory('artist').state('unknown').make())
 
     expect(screen.queryByText('Download')).toBeNull()
   })
 
   it('does not have an option to download Various Artist', async () => {
-    await renderComponent(factory.states('various')('artist'))
+    await renderComponent(factory('artist').state('various').make())
     expect(screen.queryByText('Download')).toBeNull()
   })
 

--- a/resources/assets/js/components/artist/ArtistEventItem.spec.ts
+++ b/resources/assets/js/components/artist/ArtistEventItem.spec.ts
@@ -7,7 +7,7 @@ describe('artistEvent.vue', () => {
   const h = createHarness()
 
   const renderComponent = (event?: LiveEvent) => {
-    event = event ?? h.factory('live-event')
+    event = event ?? h.factory('live-event').make()
 
     const rendered = h.render(ArtistEventItem, {
       props: {
@@ -23,7 +23,7 @@ describe('artistEvent.vue', () => {
 
   it('renders', () => {
     renderComponent(
-      h.factory('live-event', {
+      h.factory('live-event').make({
         id: 'foo',
         name: 'Metalfest',
         url: 'https://www.metalfest.com/tix',

--- a/resources/assets/js/components/artist/ArtistEventList.spec.ts
+++ b/resources/assets/js/components/artist/ArtistEventList.spec.ts
@@ -8,8 +8,8 @@ describe('artistEventList.vue', () => {
   const h = createHarness()
 
   const renderComponent = async (artist?: Artist, events?: LiveEvent[]) => {
-    events = events ?? h.factory('live-event', 5)
-    artist = artist ?? h.factory('artist')
+    events = events ?? h.factory('live-event').make(5)
+    artist = artist ?? h.factory('artist').make()
 
     const fetchEventsMock = h.mock(artistStore, 'fetchEvents').mockResolvedValueOnce(events)
 

--- a/resources/assets/js/components/artist/ArtistInfo.spec.ts
+++ b/resources/assets/js/components/artist/ArtistInfo.spec.ts
@@ -10,8 +10,8 @@ describe('artistInfo.vue', () => {
 
   const renderComponent = async (mode: EncyclopediaDisplayMode = 'aside', info?: ArtistInfo) => {
     commonStore.state.uses_last_fm = true
-    info = info ?? h.factory('artist-info')
-    const artist = h.factory('artist', { name: 'Led Zeppelin' })
+    info = info ?? h.factory('artist-info').make()
+    const artist = h.factory('artist').make({ name: 'Led Zeppelin' })
 
     const fetchMock = h.mock(encyclopediaService, 'fetchForArtist').mockResolvedValue(info)
 

--- a/resources/assets/js/components/artist/EditArtistForm.spec.ts
+++ b/resources/assets/js/components/artist/EditArtistForm.spec.ts
@@ -8,7 +8,7 @@ describe('editArtistForm.vue', () => {
   const h = createHarness()
 
   const renderComponent = (artist?: Artist) => {
-    artist = artist ?? h.factory('artist')
+    artist = artist ?? h.factory('artist').make()
     artistStore.state.artists = [artist]
 
     const rendered = h.render(Component, {
@@ -39,7 +39,7 @@ describe('editArtistForm.vue', () => {
 
   it('submits with a new image', async () => {
     const updateMock = h.mock(artistStore, 'update')
-    const { artist } = renderComponent(h.factory('artist', { image: '' }))
+    const { artist } = renderComponent(h.factory('artist').make({ image: '' }))
 
     await h.type(screen.getByTitle('Artist name'), 'Dude')
 
@@ -59,7 +59,7 @@ describe('editArtistForm.vue', () => {
   })
 
   it('removes image and submits', async () => {
-    const { artist } = renderComponent(h.factory('artist'))
+    const { artist } = renderComponent(h.factory('artist').make())
     const updateMock = h.mock(artistStore, 'update')
 
     await h.user.click(screen.getByRole('button', { name: 'Remove' }))

--- a/resources/assets/js/components/embed/CreateEmbedForm.spec.ts
+++ b/resources/assets/js/components/embed/CreateEmbedForm.spec.ts
@@ -9,11 +9,11 @@ describe('createEmbedForm.vue', () => {
   const h = createHarness()
 
   const renderComponent = async (embeddable?: Embeddable, embed?: Embed) => {
-    embeddable = embeddable ?? h.factory('playlist')
+    embeddable = embeddable ?? h.factory('playlist').make()
 
     embed =
       embed ??
-      h.factory('embed', {
+      h.factory('embed').make({
         embeddable_id: embeddable.id,
         embeddable_type: embeddable.type.slice(0, -1) as Embed['embeddable_type'],
       })

--- a/resources/assets/js/components/embed/ThemeSelectBox.spec.ts
+++ b/resources/assets/js/components/embed/ThemeSelectBox.spec.ts
@@ -8,7 +8,7 @@ describe('themeSelectBox.vue', () => {
   const h = createHarness()
 
   it('fetches and renders the options', async () => {
-    const theme = h.factory('theme', {
+    const theme = h.factory('theme').make({
       id: 'frodo',
       name: 'One Theme to Rule Them All',
     })

--- a/resources/assets/js/components/embed/widget/EmbedWidget.spec.ts
+++ b/resources/assets/js/components/embed/widget/EmbedWidget.spec.ts
@@ -10,9 +10,9 @@ describe('embedWidget.vue', async () => {
 
   const renderComponent = async (embed?: WidgetReadyEmbed, options?: EmbedOptions, getWidgetPayloadMock?: any) => {
     embed = embed ?? {
-      ...h.factory('embed'),
-      embeddable: h.factory('playlist'),
-      playables: h.factory('song', 5),
+      ...h.factory('embed').make(),
+      embeddable: h.factory('playlist').make(),
+      playables: h.factory('song').make(5),
     }
 
     options = options ?? {

--- a/resources/assets/js/components/embed/widget/EmbedWidgetBanner.spec.ts
+++ b/resources/assets/js/components/embed/widget/EmbedWidgetBanner.spec.ts
@@ -34,7 +34,7 @@ describe('embedWidgetBanner.vue', async () => {
   }
 
   it('renders a song', () => {
-    const song = h.factory('song', {
+    const song = h.factory('song').make({
       title: 'Bohemian Rhapsody',
       artist_name: 'Queen',
       album_name: 'A Night at the Opera',
@@ -42,7 +42,7 @@ describe('embedWidgetBanner.vue', async () => {
     })
 
     const embed: WidgetReadyEmbed = {
-      ...h.factory('embed', {
+      ...h.factory('embed').make({
         embeddable_type: 'playable',
         embeddable_id: song.id,
       }),
@@ -58,14 +58,14 @@ describe('embedWidgetBanner.vue', async () => {
   })
 
   it('renders a podcast episode', () => {
-    const episode = h.factory('episode', {
+    const episode = h.factory('episode').make({
       title: 'How to tell people to shut up about Queen',
       podcast_title: 'The Everyday Guide',
       podcast_author: 'The Everyday Guy',
     })
 
     const embed: WidgetReadyEmbed = {
-      ...h.factory('embed', {
+      ...h.factory('embed').make({
         embeddable_type: 'playable',
         embeddable_id: episode.id,
       }),
@@ -81,18 +81,18 @@ describe('embedWidgetBanner.vue', async () => {
   })
 
   it('renders a playlist', () => {
-    const playlist = h.factory('playlist', {
+    const playlist = h.factory('playlist').make({
       name: 'The Best of Queen',
       description: 'A collection of the best songs from Queen',
     })
 
     const embed: WidgetReadyEmbed = {
-      ...h.factory('embed', {
+      ...h.factory('embed').make({
         embeddable_type: 'playlist',
         embeddable_id: playlist.id,
       }),
       embeddable: playlist,
-      playables: h.factory('song', 5),
+      playables: h.factory('song').make(5),
     }
 
     renderComponent(embed)
@@ -103,18 +103,18 @@ describe('embedWidgetBanner.vue', async () => {
   })
 
   it('renders an album', () => {
-    const album = h.factory('album', {
+    const album = h.factory('album').make({
       name: 'A Night at the Opera',
       artist_name: 'Queen',
     })
 
     const embed: WidgetReadyEmbed = {
-      ...h.factory('embed', {
+      ...h.factory('embed').make({
         embeddable_type: 'album',
         embeddable_id: album.id,
       }),
       embeddable: album,
-      playables: h.factory('song', 5),
+      playables: h.factory('song').make(5),
     }
 
     renderComponent(embed)
@@ -125,17 +125,17 @@ describe('embedWidgetBanner.vue', async () => {
   })
 
   it('renders an artist', () => {
-    const artist = h.factory('artist', {
+    const artist = h.factory('artist').make({
       name: 'Queen',
     })
 
     const embed: WidgetReadyEmbed = {
-      ...h.factory('embed', {
+      ...h.factory('embed').make({
         embeddable_type: 'artist',
         embeddable_id: artist.id,
       }),
       embeddable: artist,
-      playables: h.factory('song', 5),
+      playables: h.factory('song').make(5),
     }
 
     renderComponent(embed)
@@ -146,10 +146,10 @@ describe('embedWidgetBanner.vue', async () => {
   })
 
   it('shows a preview badge if in preview mode', () => {
-    const song = h.factory('song')
+    const song = h.factory('song').make()
 
     const embed: WidgetReadyEmbed = {
-      ...h.factory('embed', {
+      ...h.factory('embed').make({
         embeddable_type: 'playable',
         embeddable_id: song.id,
       }),

--- a/resources/assets/js/components/embed/widget/EmbedWidgetThumbnail.spec.ts
+++ b/resources/assets/js/components/embed/widget/EmbedWidgetThumbnail.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vite-plus/test'
 import { createHarness } from '@/__tests__/TestHarness'
-import type { ModelToTypeMap } from '@/__tests__/factory'
+import type { ModelFieldPair } from '@/__tests__/factory'
 import { screen } from '@testing-library/vue'
 import EmbedWidgetThumbnail from './EmbedWidgetThumbnail.vue'
 
@@ -20,19 +20,19 @@ describe('embedThumbnail.vue', () => {
     }
   }
 
-  it.each<[keyof ModelToTypeMap, string]>([
+  it.each<ModelFieldPair>([
     ['album', 'cover'],
     ['artist', 'image'],
     ['playlist', 'cover'],
     ['song', 'album_cover'],
     ['episode', 'episode_image'],
   ])('renders thumbnail for %s', (type, imageField) => {
-    const { embeddable } = renderComponent(h.factory(type) as Embeddable)
+    const { embeddable } = renderComponent(h.factory(type).make() as Embeddable)
     expect(screen.getByRole('img').getAttribute('src')).toBe(embeddable[imageField])
   })
 
   it('renders a default placeholder', () => {
-    renderComponent(h.factory('playlist', { cover: null }))
+    renderComponent(h.factory('playlist').make({ cover: null }))
     expect(screen.getByRole('img').getAttribute('src')).toContain('/resources/assets/img/covers/default.svg')
   })
 })

--- a/resources/assets/js/components/embed/widget/EmbedWidgetTrackItem.spec.ts
+++ b/resources/assets/js/components/embed/widget/EmbedWidgetTrackItem.spec.ts
@@ -29,7 +29,7 @@ describe('playableEmbedItem.vue', async () => {
 
   it('renders a song', () => {
     const { html } = renderComponent(
-      h.factory('song', {
+      h.factory('song').make({
         title: 'Bohemian Rhapsody',
         length: 280,
         artist_name: 'Queen',
@@ -43,7 +43,7 @@ describe('playableEmbedItem.vue', async () => {
 
   it('renders a podcast episode', () => {
     const { html } = renderComponent(
-      h.factory('episode', {
+      h.factory('episode').make({
         title: 'How to tell people to shut up about Queen',
         length: 280,
         podcast_title: 'The Everyday Guide',
@@ -55,7 +55,7 @@ describe('playableEmbedItem.vue', async () => {
   })
 
   it('emits the play event on double-click', async () => {
-    const { playable, emitted } = renderComponent(h.factory('song'))
+    const { playable, emitted } = renderComponent(h.factory('song').make())
     await h.user.dblClick(screen.getByTestId('playable-embed-item'))
     expect(emitted().play[0]).toEqual([playable])
   })

--- a/resources/assets/js/components/embed/widget/EmbedWidgetTrackList.spec.ts
+++ b/resources/assets/js/components/embed/widget/EmbedWidgetTrackList.spec.ts
@@ -9,7 +9,7 @@ describe('embedWidgetTrackList.vue', async () => {
   it('renders the track list', () => {
     h.render(Component, {
       props: {
-        playables: h.factory('song', 10),
+        playables: h.factory('song').make(10),
       },
       global: {
         stubs: {

--- a/resources/assets/js/components/embed/widget/audio-player/EmbedAudioPlayerNextButton.spec.ts
+++ b/resources/assets/js/components/embed/widget/audio-player/EmbedAudioPlayerNextButton.spec.ts
@@ -9,7 +9,7 @@ describe('embedPlayerNextButton.vue', async () => {
   it('renders and works', async () => {
     const { emitted } = h.render(Component, {
       props: {
-        playable: h.factory('song'),
+        playable: h.factory('song').make(),
       },
     })
 

--- a/resources/assets/js/components/embed/widget/audio-player/EmbedAudioPlayerPlayButton.spec.ts
+++ b/resources/assets/js/components/embed/widget/audio-player/EmbedAudioPlayerPlayButton.spec.ts
@@ -29,7 +29,7 @@ describe('embedAudioPlayerPlayButton.vue', async () => {
     const playable =
       playbackState === undefined
         ? undefined
-        : h.factory('song', {
+        : h.factory('song').make({
             playback_state: playbackState,
           })
 
@@ -42,7 +42,7 @@ describe('embedAudioPlayerPlayButton.vue', async () => {
   })
 
   it('applies a .preview-wrapper class in Preview mode', () => {
-    renderComponent(h.factory('song'), true)
+    renderComponent(h.factory('song').make(), true)
     expect(screen.getByTestId('wrapper').classList.contains('preview-wrapper')).toBe(true)
   })
 })

--- a/resources/assets/js/components/embed/widget/audio-player/EmbedAudioPlayerProgressBar.spec.ts
+++ b/resources/assets/js/components/embed/widget/audio-player/EmbedAudioPlayerProgressBar.spec.ts
@@ -6,7 +6,7 @@ describe('embedAudioPlayerProgressBar.vue', () => {
   const h = createHarness()
 
   it('renders with progress', () => {
-    const playable = h.factory('song', { playback_state: 'Playing' })
+    const playable = h.factory('song').make({ playback_state: 'Playing' })
 
     const { container } = h.render(Component, {
       props: { playable, progress: 50 },

--- a/resources/assets/js/components/genre/GenreCard.spec.ts
+++ b/resources/assets/js/components/genre/GenreCard.spec.ts
@@ -13,7 +13,7 @@ describe('genreCard.vue', () => {
   const h = createHarness()
 
   const createGenre = (overrides: Partial<Genre> = {}): Genre => {
-    return h.factory('genre', {
+    return h.factory('genre').make({
       id: 'foo',
       name: 'Classical',
       song_count: 99,

--- a/resources/assets/js/components/genre/GenreContextMenu.spec.ts
+++ b/resources/assets/js/components/genre/GenreContextMenu.spec.ts
@@ -13,7 +13,7 @@ describe('genreContextMenu.vue', () => {
   const renderComponent = async (genre?: Genre) => {
     genre =
       genre ||
-      h.factory('genre', {
+      h.factory('genre').make({
         name: 'Classical',
       })
 
@@ -34,7 +34,7 @@ describe('genreContextMenu.vue', () => {
   it('plays all', async () => {
     h.createAudioPlayer()
 
-    const songs = h.factory('song', 10)
+    const songs = h.factory('song').make(10)
     const fetchMock = h.mock(playableStore, 'fetchSongsByGenre').mockResolvedValue(songs)
     const playMock = h.mock(playbackService, 'queueAndPlay')
     const goMock = h.mock(Router, 'go')
@@ -51,7 +51,7 @@ describe('genreContextMenu.vue', () => {
   it('shuffles all', async () => {
     h.createAudioPlayer()
 
-    const songs = h.factory('song', 10)
+    const songs = h.factory('song').make(10)
     const fetchMock = h.mock(playableStore, 'fetchSongsByGenre').mockResolvedValue(songs)
     const playMock = h.mock(playbackService, 'queueAndPlay')
     const goMock = h.mock(Router, 'go')
@@ -66,7 +66,7 @@ describe('genreContextMenu.vue', () => {
   })
 
   it('adds to queue', async () => {
-    const songs = h.factory('song', 10)
+    const songs = h.factory('song').make(10)
     const fetchMock = h.mock(playableStore, 'fetchSongsByGenre').mockResolvedValue(songs)
     const queueMock = h.mock(queueStore, 'queue')
 

--- a/resources/assets/js/components/invitation/AcceptInvitation.spec.ts
+++ b/resources/assets/js/components/invitation/AcceptInvitation.spec.ts
@@ -11,7 +11,7 @@ describe('acceptInvitation.vue', () => {
   it('accepts invitation', async () => {
     const getProspectMock = h
       .mock(invitationService, 'getUserProspect')
-      .mockResolvedValue(factory.states('prospect')('user'))
+      .mockResolvedValue(factory('user').state('prospect').make())
 
     const acceptMock = h.mock(invitationService, 'accept').mockResolvedValue({
       token: 'my-api-token',

--- a/resources/assets/js/components/layout/app-footer/FooterPlayableInfo.spec.ts
+++ b/resources/assets/js/components/layout/app-footer/FooterPlayableInfo.spec.ts
@@ -12,7 +12,7 @@ describe('footerPlayableInfo.vue', () => {
   it('renders with no current playable', () => expect(h.render(Component).html()).toMatchSnapshot())
 
   it('renders with current playable', () => {
-    const song = h.factory('song', {
+    const song = h.factory('song').make({
       title: 'Fahrstuhl zum Mond',
       album_cover: 'https://via.placeholder.com/150',
       playback_state: 'Playing',
@@ -34,7 +34,7 @@ describe('footerPlayableInfo.vue', () => {
   })
 
   it('navigates to queue and sets scroll intent on thumbnail click', async () => {
-    const song = h.factory('song', {
+    const song = h.factory('song').make({
       title: 'Test Song',
       album_cover: 'https://via.placeholder.com/150',
       playback_state: 'Playing',

--- a/resources/assets/js/components/layout/app-footer/FooterPlaybackControls.spec.ts
+++ b/resources/assets/js/components/layout/app-footer/FooterPlaybackControls.spec.ts
@@ -11,7 +11,7 @@ describe('footerPlaybackControls.vue', () => {
 
   const renderComponent = (playable?: Playable | null) => {
     if (playable === undefined) {
-      playable = h.factory('song', {
+      playable = h.factory('song').make({
         id: '00000000-0000-0000-0000-000000000000',
         title: 'Fahrstuhl to Heaven',
         artist_name: 'Led Zeppelin',

--- a/resources/assets/js/components/layout/app-footer/FooterRadioStationInfo.spec.ts
+++ b/resources/assets/js/components/layout/app-footer/FooterRadioStationInfo.spec.ts
@@ -13,7 +13,7 @@ describe('footerRadioStationInfo.vue', () => {
   })
 
   it('renders with current radio', () => {
-    const station = h.factory('radio-station', {
+    const station = h.factory('radio-station').make({
       name: 'Classic Rock',
       logo: 'https://via.placeholder.com/150',
       description: 'The best classic rock hits',
@@ -34,7 +34,7 @@ describe('footerRadioStationInfo.vue', () => {
   })
 
   it('shows now-playing info when available', async () => {
-    const station = h.factory('radio-station', {
+    const station = h.factory('radio-station').make({
       name: 'Classic Rock',
       description: 'The best classic rock hits',
       playback_state: 'Playing',
@@ -55,7 +55,7 @@ describe('footerRadioStationInfo.vue', () => {
   })
 
   it('shows description when no now-playing info', () => {
-    const station = h.factory('radio-station', {
+    const station = h.factory('radio-station').make({
       name: 'Classic Rock',
       description: 'The best classic rock hits',
       playback_state: 'Playing',

--- a/resources/assets/js/components/layout/app-footer/UpNext.spec.ts
+++ b/resources/assets/js/components/layout/app-footer/UpNext.spec.ts
@@ -7,7 +7,7 @@ describe('upNext.vue', () => {
   const h = createHarness()
 
   it('renders playable title and author', () => {
-    const song = h.factory('song')
+    const song = h.factory('song').make()
 
     h.render(Component, {
       props: { playable: song },

--- a/resources/assets/js/components/layout/main-wrapper/MainContent.spec.ts
+++ b/resources/assets/js/components/layout/main-wrapper/MainContent.spec.ts
@@ -15,7 +15,7 @@ describe('mainContent.vue', () => {
     return h.render(Component, {
       global: {
         provide: {
-          [<symbol>CurrentStreamableKey]: ref(h.factory('song')),
+          [<symbol>CurrentStreamableKey]: ref(h.factory('song').make()),
         },
         stubs: {
           AlbumArtOverlay,

--- a/resources/assets/js/components/layout/main-wrapper/side-sheet/SideSheet.spec.ts
+++ b/resources/assets/js/components/layout/main-wrapper/side-sheet/SideSheet.spec.ts
@@ -32,10 +32,10 @@ describe('sideSheet.vue', () => {
   })
 
   const renderComponent = (songRef: Ref<Song | null> = ref(null)) => {
-    const artist = h.factory('artist')
+    const artist = h.factory('artist').make()
     const resolveArtistMock = h.mock(artistStore, 'resolve').mockResolvedValue(artist)
 
-    const album = h.factory('album')
+    const album = h.factory('album').make()
     const resolveAlbumMock = h.mock(albumStore, 'resolve').mockResolvedValue(album)
 
     const rendered = h.render(Component, {
@@ -70,7 +70,7 @@ describe('sideSheet.vue', () => {
 
   it('gets active tab from the preference', async () => {
     preferenceStore.active_extra_panel_tab = 'Lyrics'
-    renderComponent(ref(h.factory('song')))
+    renderComponent(ref(h.factory('song').make()))
 
     await waitFor(() => {
       expect(screen.getByTestId<HTMLElement>('side-sheet-lyrics').style.display).toBe('')
@@ -79,7 +79,7 @@ describe('sideSheet.vue', () => {
 
   it('activates and sets active tab to the preference', async () => {
     preferenceStore.active_extra_panel_tab = 'Lyrics'
-    renderComponent(ref(h.factory('song')))
+    renderComponent(ref(h.factory('song').make()))
     await h.tick()
     await h.user.click(screen.getByTestId('side-sheet-album-tab-header'))
 
@@ -92,7 +92,7 @@ describe('sideSheet.vue', () => {
 
   it('persists collapsed state when closing a tab', async () => {
     preferenceStore.active_extra_panel_tab = 'Lyrics'
-    renderComponent(ref(h.factory('song')))
+    renderComponent(ref(h.factory('song').make()))
     await h.tick()
 
     // Click the same tab again to collapse
@@ -111,7 +111,7 @@ describe('sideSheet.vue', () => {
     const { resolveAlbumMock } = renderComponent(songRef)
 
     // trigger the side sheet to show album info
-    songRef.value = h.factory('song')
+    songRef.value = h.factory('song').make()
 
     await waitFor(() => {
       screen.getByTestId('side-sheet-album')
@@ -128,7 +128,7 @@ describe('sideSheet.vue', () => {
     const { resolveArtistMock } = renderComponent(songRef)
 
     // trigger the side sheet to show artist info
-    songRef.value = h.factory('song')
+    songRef.value = h.factory('song').make()
 
     await waitFor(() => {
       screen.getByTestId('side-sheet-artist')

--- a/resources/assets/js/components/layout/main-wrapper/sidebar/PlaylistFolderSidebarItem.spec.ts
+++ b/resources/assets/js/components/layout/main-wrapper/sidebar/PlaylistFolderSidebarItem.spec.ts
@@ -7,7 +7,7 @@ describe('playlistFolderSidebarItem.vue', () => {
   const h = createHarness()
 
   it('renders folder name', () => {
-    const folder = h.factory('playlist-folder')
+    const folder = h.factory('playlist-folder').make()
 
     h.render(Component, {
       props: { folder },

--- a/resources/assets/js/components/layout/main-wrapper/sidebar/PlaylistSidebarItem.spec.ts
+++ b/resources/assets/js/components/layout/main-wrapper/sidebar/PlaylistSidebarItem.spec.ts
@@ -13,7 +13,7 @@ describe('playlistSidebarItem.vue', () => {
   const h = createHarness()
 
   const renderComponent = (list?: PlaylistLike) => {
-    list = list ?? h.factory('playlist')
+    list = list ?? h.factory('playlist').make()
 
     const rendered = h.render(Component, {
       props: {

--- a/resources/assets/js/components/layout/main-wrapper/sidebar/SidebarPlaylistsSection.spec.ts
+++ b/resources/assets/js/components/layout/main-wrapper/sidebar/SidebarPlaylistsSection.spec.ts
@@ -24,9 +24,9 @@ describe('sidebarPlaylistsSection.vue', () => {
 
   it('displays orphan playlists', () => {
     playlistStore.state.playlists = [
-      factory.states('orphan')('playlist', { name: 'Foo Playlist' }),
-      factory.states('orphan')('playlist', { name: 'Bar Playlist' }),
-      factory.states('smart', 'orphan')('playlist', { name: 'Smart Playlist' }),
+      factory('playlist').state('orphan').make({ name: 'Foo Playlist' }),
+      factory('playlist').state('orphan').make({ name: 'Bar Playlist' }),
+      factory('playlist').state('smart', 'orphan').make({ name: 'Smart Playlist' }),
     ]
 
     renderComponent()
@@ -38,8 +38,8 @@ describe('sidebarPlaylistsSection.vue', () => {
 
   it('displays playlist folders', () => {
     playlistFolderStore.state.folders = [
-      h.factory('playlist-folder', { name: 'Foo Folder' }),
-      h.factory('playlist-folder', { name: 'Bar Folder' }),
+      h.factory('playlist-folder').make({ name: 'Foo Folder' }),
+      h.factory('playlist-folder').make({ name: 'Bar Folder' }),
     ]
 
     renderComponent()

--- a/resources/assets/js/components/media-browser/MediaBrowserContextMenu.spec.ts
+++ b/resources/assets/js/components/media-browser/MediaBrowserContextMenu.spec.ts
@@ -22,7 +22,7 @@ describe('mediaBrowserContextMenu.vue', () => {
   }
 
   it('opens the folder if the only item is a folder', async () => {
-    const folder = h.factory('folder', { path: 'foo/bar' })
+    const folder = h.factory('folder').make({ path: 'foo/bar' })
     const items = [folder]
     const goMock = h.mock(Router, 'go')
 
@@ -35,7 +35,7 @@ describe('mediaBrowserContextMenu.vue', () => {
   it('plays', async () => {
     h.createAudioPlayer()
 
-    const resolvedSongs = h.factory('song', 3)
+    const resolvedSongs = h.factory('song').make(3)
     const playMock = h.mock(playbackService, 'queueAndPlay')
     const resolveMock = h.mock(playableStore, 'resolveSongsFromMediaReferences').mockResolvedValue(resolvedSongs)
     const goMock = h.mock(Router, 'go')
@@ -49,7 +49,7 @@ describe('mediaBrowserContextMenu.vue', () => {
       },
     ])
 
-    const items = [...h.factory('song', 2), h.factory('folder')]
+    const items = [...h.factory('song').make(2), h.factory('folder').make()]
 
     renderComponent(items)
 
@@ -71,7 +71,7 @@ describe('mediaBrowserContextMenu.vue', () => {
   it('shuffles', async () => {
     h.createAudioPlayer()
 
-    const resolvedSongs = h.factory('song', 3)
+    const resolvedSongs = h.factory('song').make(3)
     const playMock = h.mock(playbackService, 'queueAndPlay')
     const resolveMock = h.mock(playableStore, 'resolveSongsFromMediaReferences').mockResolvedValue(resolvedSongs)
     const goMock = h.mock(Router, 'go')
@@ -85,7 +85,7 @@ describe('mediaBrowserContextMenu.vue', () => {
       },
     ])
 
-    const items = [...h.factory('song', 2), h.factory('folder')]
+    const items = [...h.factory('song').make(2), h.factory('folder').make()]
 
     renderComponent(items)
 
@@ -108,7 +108,7 @@ describe('mediaBrowserContextMenu.vue', () => {
   })
 
   it('adds to queue', async () => {
-    const resolvedSongs = h.factory('song', 3)
+    const resolvedSongs = h.factory('song').make(3)
     const queueMock = h.mock(queueStore, 'queue')
     const resolveMock = h.mock(playableStore, 'resolveSongsFromMediaReferences').mockResolvedValue(resolvedSongs)
 
@@ -121,7 +121,7 @@ describe('mediaBrowserContextMenu.vue', () => {
       },
     ])
 
-    const items = [...h.factory('song', 2), h.factory('folder')]
+    const items = [...h.factory('song').make(2), h.factory('folder').make()]
 
     renderComponent(items)
 

--- a/resources/assets/js/components/playable/AddToMenu.spec.ts
+++ b/resources/assets/js/components/playable/AddToMenu.spec.ts
@@ -26,7 +26,7 @@ describe('addToMenu.vue', () => {
   })
 
   const renderComponent = (customConfig: Partial<AddToMenuConfig> = {}) => {
-    const playables = h.factory('song', 5)
+    const playables = h.factory('song').make(5)
 
     const config: AddToMenuConfig = {
       queue: true,
@@ -54,9 +54,9 @@ describe('addToMenu.vue', () => {
 
   it('renders', () => {
     playlistStore.state.playlists = [
-      h.factory('playlist', { name: 'Foo' }),
-      h.factory('playlist', { name: 'Bar' }),
-      h.factory('playlist', { name: 'Baz' }),
+      h.factory('playlist').make({ name: 'Foo' }),
+      h.factory('playlist').make({ name: 'Bar' }),
+      h.factory('playlist').make({ name: 'Baz' }),
     ]
 
     expect(renderComponent().html()).toMatchSnapshot()
@@ -75,7 +75,7 @@ describe('addToMenu.vue', () => {
     ['to top', 'queue-top', 'queueToTop'],
     ['to bottom', 'queue-bottom', 'queue'],
   ])('queues songs %s', async (_: string, testId: string, queueMethod: MethodOf<typeof queueStore>) => {
-    queueStore.state.playables = h.factory('song', 5)
+    queueStore.state.playables = h.factory('song').make(5)
     playableStore.syncWithVault(queueStore.state.playables)
     queueStore.state.playables[2].playback_state = 'Playing'
 
@@ -98,7 +98,7 @@ describe('addToMenu.vue', () => {
 
   it('adds songs to existing playlist', async () => {
     const mock = h.mock(playlistStore, 'addContent')
-    playlistStore.state.playlists = h.factory('playlist', 3)
+    playlistStore.state.playlists = h.factory('playlist').make(3)
     const { playables } = renderComponent()
 
     await h.user.click(screen.getAllByTestId('add-to-playlist')[1])

--- a/resources/assets/js/components/playable/EditSongForm.spec.ts
+++ b/resources/assets/js/components/playable/EditSongForm.spec.ts
@@ -45,7 +45,7 @@ describe('editSongForm.vue', () => {
     const alertMock = h.mock(MessageToasterStub.value, 'success')
 
     const { songs, html } = await renderComponent(
-      h.factory('song', {
+      h.factory('song').make({
         title: 'Rocket to Heaven',
         artist_name: 'Led Zeppelin',
         album_name: 'IV',
@@ -99,7 +99,7 @@ describe('editSongForm.vue', () => {
     const emitMock = h.mock(eventBus, 'emit')
     const alertMock = h.mock(MessageToasterStub.value, 'success')
 
-    const { songs, html } = await renderComponent(h.factory('song', 3))
+    const { songs, html } = await renderComponent(h.factory('song').make(3))
 
     expect(html()).toMatchSnapshot()
     expect(screen.queryByTestId('title-input')).toBeNull()
@@ -131,12 +131,15 @@ describe('editSongForm.vue', () => {
 
   it('displays artist name if all songs have the same artist', async () => {
     await renderComponent(
-      h.factory('song', 4, {
-        artist_id: 'led-zeppelin',
-        artist_name: 'Led Zeppelin',
-        album_id: 'iv',
-        album_name: 'IV',
-      }),
+      h.factory('song').make(
+        {
+          artist_id: 'led-zeppelin',
+          artist_name: 'Led Zeppelin',
+          album_id: 'iv',
+          album_name: 'IV',
+        },
+        4,
+      ),
     )
 
     expect(screen.getByTestId('displayed-artist-name').textContent).toBe('Led Zeppelin')

--- a/resources/assets/js/components/playable/PlayableContextMenu.spec.ts
+++ b/resources/assets/js/components/playable/PlayableContextMenu.spec.ts
@@ -59,7 +59,7 @@ describe('playableContextMenu.vue', () => {
   })
 
   const renderComponent = async (playables?: MaybeArray<Playable>) => {
-    playables = playables ? arrayify(playables) : h.factory('song', 5)
+    playables = playables ? arrayify(playables) : h.factory('song').make(5)
 
     const rendered = h.render(Component, {
       props: {
@@ -76,7 +76,7 @@ describe('playableContextMenu.vue', () => {
   }
 
   const fillQueue = () => {
-    queueStore.state.playables = h.factory('song', 5)
+    queueStore.state.playables = h.factory('song').make(5)
     playableStore.syncWithVault(queueStore.state.playables)
     queueStore.state.playables[2].playback_state = 'Playing'
   }
@@ -85,7 +85,7 @@ describe('playableContextMenu.vue', () => {
     h.createAudioPlayer()
 
     const playMock = h.mock(playbackService, 'play')
-    const song = h.factory('song', { playback_state: 'Stopped' })
+    const song = h.factory('song').make({ playback_state: 'Stopped' })
     await renderComponent(song)
 
     await h.user.click(screen.getByText('Play'))
@@ -97,7 +97,7 @@ describe('playableContextMenu.vue', () => {
     h.createAudioPlayer()
 
     const pauseMock = h.mock(playbackService, 'pause')
-    await renderComponent(h.factory('song', { playback_state: 'Playing' }))
+    await renderComponent(h.factory('song').make({ playback_state: 'Playing' }))
 
     await h.user.click(screen.getByText('Pause'))
 
@@ -108,7 +108,7 @@ describe('playableContextMenu.vue', () => {
     h.createAudioPlayer()
 
     const resumeMock = h.mock(playbackService, 'resume')
-    await renderComponent(h.factory('song', { playback_state: 'Paused' }))
+    await renderComponent(h.factory('song').make({ playback_state: 'Paused' }))
 
     await h.user.click(screen.getByText('Play'))
 
@@ -117,7 +117,7 @@ describe('playableContextMenu.vue', () => {
 
   it('goes to album details screen', async () => {
     const goMock = h.mock(Router, 'go')
-    const song = h.factory('song')
+    const song = h.factory('song').make()
     await renderComponent(song)
 
     await h.user.click(screen.getByText(song.album_name))
@@ -127,7 +127,7 @@ describe('playableContextMenu.vue', () => {
 
   it('goes to artist details screen', async () => {
     const goMock = h.mock(Router, 'go')
-    const song = h.factory('song')
+    const song = h.factory('song').make()
     await renderComponent(song)
 
     await h.user.click(screen.getByText(song.artist_name))
@@ -137,7 +137,7 @@ describe('playableContextMenu.vue', () => {
 
   it('goes to podcast screen', async () => {
     const goMock = h.mock(Router, 'go')
-    const episode = h.factory('episode')
+    const episode = h.factory('episode').make()
     await renderComponent(episode)
 
     await h.user.click(screen.getByText('Podcast'))
@@ -147,7 +147,7 @@ describe('playableContextMenu.vue', () => {
 
   it('goes to episode description', async () => {
     const goMock = h.mock(Router, 'go')
-    const episode = h.factory('episode')
+    const episode = h.factory('episode').make()
     await renderComponent(episode)
 
     await h.user.click(screen.getByText('Episode'))
@@ -252,7 +252,7 @@ describe('playableContextMenu.vue', () => {
   })
 
   it('lists and adds to existing playlist', async () => {
-    playlistStore.state.playlists = h.factory('playlist', 3)
+    playlistStore.state.playlists = h.factory('playlist').make(3)
     const addMock = h.mock(playlistStore, 'addContent')
     h.mock(MessageToasterStub.value, 'success')
     const { playables } = await renderComponent()
@@ -265,8 +265,8 @@ describe('playableContextMenu.vue', () => {
   })
 
   it('does not list smart playlists', async () => {
-    playlistStore.state.playlists = h.factory('playlist', 3)
-    playlistStore.state.playlists.push(factory.states('smart')('playlist', { name: 'My Smart Playlist' }))
+    playlistStore.state.playlists = h.factory('playlist').make(3)
+    playlistStore.state.playlists.push(factory('playlist').state('smart').make({ name: 'My Smart Playlist' }))
 
     await renderComponent()
 
@@ -274,7 +274,7 @@ describe('playableContextMenu.vue', () => {
   })
 
   it('removes from playlist', async () => {
-    const playlist = h.factory('playlist')
+    const playlist = h.factory('playlist').make()
     playlistStore.state.playlists.push(playlist)
 
     h.visit(`/playlists/${playlist.id}`)
@@ -314,20 +314,20 @@ describe('playableContextMenu.vue', () => {
   })
 
   it('has an option to copy shareable URL in Community edition', async () => {
-    await renderComponent(h.factory('song'))
+    await renderComponent(h.factory('song').make())
     screen.getByText('Copy URL')
   })
 
   it('has an option to copy shareable URL if song is public in Plus edition', async () => {
     await h.withPlusEdition(async () => {
-      await renderComponent(h.factory('song', { is_public: true }))
+      await renderComponent(h.factory('song').make({ is_public: true }))
       screen.getByText('Copy URL')
     })
   })
 
   it('does not have an option to share if song is private in Plus edition', async () => {
     await h.withPlusEdition(async () => {
-      await renderComponent(h.factory('song', { is_public: false }))
+      await renderComponent(h.factory('song').make({ is_public: false }))
       expect(screen.queryByText('Copy URL')).toBeNull()
     })
   })
@@ -367,18 +367,21 @@ describe('playableContextMenu.vue', () => {
   })
 
   it('does not have the options to mark song as private or public in Community edition', async () => {
-    await renderComponent(h.factory('song'))
+    await renderComponent(h.factory('song').make())
     expect(screen.queryByText('Mark as Private')).toBeNull()
     expect(screen.queryByText('Unmark as Private')).toBeNull()
   })
 
   it('makes songs private', async () =>
     await h.withPlusEdition(async () => {
-      const user = h.factory.states('current')('user') as CurrentUser
-      const songs = h.factory('song', 5, {
-        is_public: true,
-        owner_id: user.id,
-      })
+      const user = h.factory('user').state('current').make() as CurrentUser
+      const songs = h.factory('song').make(
+        {
+          is_public: true,
+          owner_id: user.id,
+        },
+        5,
+      )
 
       h.actingAsUser(user)
 
@@ -392,11 +395,14 @@ describe('playableContextMenu.vue', () => {
 
   it('makes songs public', async () =>
     await h.withPlusEdition(async () => {
-      const user = h.factory.states('current')('user') as CurrentUser
-      const songs = h.factory('song', 5, {
-        is_public: false,
-        owner_id: user.id,
-      })
+      const user = h.factory('user').state('current').make() as CurrentUser
+      const songs = h.factory('song').make(
+        {
+          is_public: false,
+          owner_id: user.id,
+        },
+        5,
+      )
 
       h.actingAsUser(user)
 
@@ -410,12 +416,15 @@ describe('playableContextMenu.vue', () => {
 
   it('does not have an option to make songs public or private if current user is not owner', async () => {
     await h.withPlusEdition(async () => {
-      const user = h.factory.states('current')('user') as CurrentUser
-      const owner = h.factory('user')
-      const songs = h.factory('song', 5, {
-        is_public: false,
-        owner_id: owner.id,
-      })
+      const user = h.factory('user').state('current').make() as CurrentUser
+      const owner = h.factory('user').make()
+      const songs = h.factory('song').make(
+        {
+          is_public: false,
+          owner_id: owner.id,
+        },
+        5,
+      )
 
       h.actingAsUser(user)
 
@@ -428,17 +437,24 @@ describe('playableContextMenu.vue', () => {
 
   it('has both options to make public and private if songs have mixed visibilities', async () => {
     await h.withPlusEdition(async () => {
-      const owner = h.factory.states('current')('user') as CurrentUser
+      const owner = h.factory('user').state('current').make() as CurrentUser
       const songs = h
-        .factory('song', 2, {
-          is_public: false,
-          owner_id: owner.id,
-        })
-        .concat(
-          ...h.factory('song', 3, {
-            is_public: true,
+        .factory('song')
+        .make(
+          {
+            is_public: false,
             owner_id: owner.id,
-          }),
+          },
+          2,
+        )
+        .concat(
+          ...h.factory('song').make(
+            {
+              is_public: true,
+              owner_id: owner.id,
+            },
+            3,
+          ),
         )
 
       h.actingAsUser(owner)
@@ -450,11 +466,14 @@ describe('playableContextMenu.vue', () => {
   })
 
   it('does not have an option to make songs public or private or Community edition', async () => {
-    const owner = h.factory.states('current')('user') as CurrentUser
-    const songs = h.factory('song', 5, {
-      is_public: false,
-      owner_id: owner.id,
-    })
+    const owner = h.factory('user').state('current').make() as CurrentUser
+    const songs = h.factory('song').make(
+      {
+        is_public: false,
+        owner_id: owner.id,
+      },
+      5,
+    )
 
     h.actingAsUser(owner)
     await renderComponent(songs)
@@ -464,7 +483,7 @@ describe('playableContextMenu.vue', () => {
   })
 
   it('requests the embed form', async () => {
-    const { playables } = await renderComponent(h.factory('song'))
+    const { playables } = await renderComponent(h.factory('song').make())
     await h.user.click(screen.getByText('Embed…'))
 
     await assertOpenModal(openModalMock, CreateEmbedForm, { embeddable: playables[0] })
@@ -481,7 +500,7 @@ describe('playableContextMenu.vue', () => {
   })
 
   it('does not show offline option for episodes', async () => {
-    await renderComponent(h.factory('episode'))
+    await renderComponent(h.factory('episode').make())
     expect(screen.queryByText('Make Available Offline')).toBeNull()
   })
 

--- a/resources/assets/js/components/playable/PlayableThumbnail.spec.ts
+++ b/resources/assets/js/components/playable/PlayableThumbnail.spec.ts
@@ -7,7 +7,7 @@ describe('playableThumbnail.vue', () => {
   const h = createHarness()
 
   const renderComponent = (playbackState: PlaybackState = 'Stopped') => {
-    const playable = h.factory('song', {
+    const playable = h.factory('song').make({
       playback_state: playbackState,
       play_count: 10,
       title: 'Foo bar',

--- a/resources/assets/js/components/playable/media-browser/MediaListItem.spec.ts
+++ b/resources/assets/js/components/playable/media-browser/MediaListItem.spec.ts
@@ -7,7 +7,7 @@ describe('mediaListItem.vue', () => {
   const h = createHarness()
 
   it('renders a playable', async () => {
-    const item = h.factory('song', {
+    const item = h.factory('song').make({
       basename: 'whatever.mp3',
     })
 
@@ -23,7 +23,7 @@ describe('mediaListItem.vue', () => {
   })
 
   it('renders a folder', async () => {
-    const item = h.factory('folder')
+    const item = h.factory('folder').make()
 
     const { emitted } = h.render(Component, {
       props: {

--- a/resources/assets/js/components/playable/media-browser/MediaListView.vue
+++ b/resources/assets/js/components/playable/media-browser/MediaListView.vue
@@ -124,7 +124,7 @@ const onDragStart = async (row: MediaRow, event: DragEvent) => {
 }
 
 const onClick = (row: MediaRow, event: MouseEvent) => {
-  // If we're on a touch device, or if Ctrl/Cmd key is pressed, just toggle selection.
+  // If we're on a touch device, or if the Ctrl/Cmd key is pressed, just toggle selection.
   if (isMobile.any) {
     toggleSelected(row)
     return

--- a/resources/assets/js/components/playable/playable-list/PlayableList.spec.ts
+++ b/resources/assets/js/components/playable/playable-list/PlayableList.spec.ts
@@ -61,7 +61,7 @@ describe('playableList.vue', () => {
   }
 
   it('renders', async () => {
-    const { html } = await renderComponent(h.factory('song', 5))
+    const { html } = await renderComponent(h.factory('song').make(5))
     expect(html()).toMatchSnapshot()
   })
 })

--- a/resources/assets/js/components/playable/playable-list/PlayableListControls.spec.ts
+++ b/resources/assets/js/components/playable/playable-list/PlayableListControls.spec.ts
@@ -10,7 +10,7 @@ describe('playableListControls.vue', () => {
   const h = createHarness()
 
   const renderComponent = (selectedCount = 1, configOverrides: Partial<PlayableListControlsConfig> = {}) => {
-    const songs = h.factory('song', 5)
+    const songs = h.factory('song').make(5)
     const config: PlayableListControlsConfig = merge(
       {
         addTo: {

--- a/resources/assets/js/components/playable/playable-list/PlayableListItem.spec.ts
+++ b/resources/assets/js/components/playable/playable-list/PlayableListItem.spec.ts
@@ -35,7 +35,7 @@ describe('playableListItem.vue', () => {
   })
 
   const renderComponent = (playable?: Playable, showDisc = false) => {
-    playable = playable ?? h.factory('song', { favorite: false })
+    playable = playable ?? h.factory('song').make({ favorite: false })
 
     const row = {
       playable,
@@ -56,7 +56,7 @@ describe('playableListItem.vue', () => {
   }
 
   it('renders song details', () => {
-    const song = h.factory('song', {
+    const song = h.factory('song').make({
       title: 'Test Song',
       album_name: 'Test Album',
       artist_name: 'Test Artist',
@@ -82,7 +82,7 @@ describe('playableListItem.vue', () => {
   })
 
   it('renders disc info when showDisc is true', async () => {
-    const song = h.factory('song', {
+    const song = h.factory('song').make({
       disc: 2,
       title: 'Test Song',
     })
@@ -93,7 +93,7 @@ describe('playableListItem.vue', () => {
   })
 
   it('shows collaboration info when collaborative', () => {
-    const song = h.factory('song', {
+    const song = h.factory('song').make({
       collaboration: {
         user: { name: 'Alice', avatar: 'https://example.com/alice.jpg' },
         added_at: '2025-01-01',
@@ -116,7 +116,7 @@ describe('playableListItem.vue', () => {
   })
 
   it('does not show collaboration info when not collaborative', () => {
-    const song = h.factory('song', {
+    const song = h.factory('song').make({
       collaboration: {
         user: { name: 'Alice', avatar: 'https://example.com/alice.jpg' },
         added_at: '2025-01-01',

--- a/resources/assets/js/components/playlist/CreatePlaylistFolderForm.spec.ts
+++ b/resources/assets/js/components/playlist/CreatePlaylistFolderForm.spec.ts
@@ -8,7 +8,7 @@ describe('createPlaylistFolderForm.vue', () => {
   const h = createHarness()
 
   it('submits', async () => {
-    const storeMock = h.mock(playlistFolderStore, 'store').mockResolvedValue(h.factory('playlist-folder'))
+    const storeMock = h.mock(playlistFolderStore, 'store').mockResolvedValue(h.factory('playlist-folder').make())
 
     h.render(Component)
 

--- a/resources/assets/js/components/playlist/CreatePlaylistForm.spec.ts
+++ b/resources/assets/js/components/playlist/CreatePlaylistForm.spec.ts
@@ -8,8 +8,8 @@ describe('createPlaylistForm.vue', () => {
   const h = createHarness()
 
   const renderComponent = (folder?: PlaylistFolder, playables?: Playable[]) => {
-    folder = folder ?? h.factory('playlist-folder')
-    playables = playables ?? h.factory('song', 2)
+    folder = folder ?? h.factory('playlist-folder').make()
+    playables = playables ?? h.factory('song').make(2)
 
     const rendered = h.render(Component, {
       props: {
@@ -27,7 +27,7 @@ describe('createPlaylistForm.vue', () => {
 
   it('creates playlist with no playables', async () => {
     const { folder } = renderComponent(undefined, [])
-    const storeMock = h.mock(playlistStore, 'store').mockResolvedValue(h.factory('playlist'))
+    const storeMock = h.mock(playlistStore, 'store').mockResolvedValue(h.factory('playlist').make())
     expect(screen.queryByTestId('from-playables')).toBeNull()
 
     await h.type(screen.getByRole('textbox', { name: 'name' }), 'My playlist')
@@ -47,7 +47,7 @@ describe('createPlaylistForm.vue', () => {
   })
 
   it('creates playlist with playables', async () => {
-    const storeMock = h.mock(playlistStore, 'store').mockResolvedValue(h.factory('playlist'))
+    const storeMock = h.mock(playlistStore, 'store').mockResolvedValue(h.factory('playlist').make())
     const { folder, playables } = renderComponent()
 
     screen.getByText(`from ${playables.length} songs`)
@@ -70,7 +70,7 @@ describe('createPlaylistForm.vue', () => {
 
   it('creates playlist with a cover', async () => {
     const { folder } = renderComponent(undefined, [])
-    const storeMock = h.mock(playlistStore, 'store').mockResolvedValue(h.factory('playlist'))
+    const storeMock = h.mock(playlistStore, 'store').mockResolvedValue(h.factory('playlist').make())
 
     await h.user.upload(
       screen.getByLabelText('Pick or paste a cover (optional)'),

--- a/resources/assets/js/components/playlist/EditPlaylistFolderForm.spec.ts
+++ b/resources/assets/js/components/playlist/EditPlaylistFolderForm.spec.ts
@@ -8,7 +8,7 @@ describe('editPlaylistFolderForm.vue', () => {
   const h = createHarness()
 
   it('submits', async () => {
-    const folder = h.factory('playlist-folder', { name: 'My folder' })
+    const folder = h.factory('playlist-folder').make({ name: 'My folder' })
     const renameMock = h.mock(playlistFolderStore, 'rename')
     h.render(Component, {
       props: {

--- a/resources/assets/js/components/playlist/EditPlaylistForm.spec.ts
+++ b/resources/assets/js/components/playlist/EditPlaylistForm.spec.ts
@@ -9,7 +9,7 @@ describe('editPlaylistForm.vue', () => {
   const h = createHarness()
 
   const renderComponent = (playlist?: Playlist) => {
-    playlist = playlist || h.factory('playlist')
+    playlist = playlist || h.factory('playlist').make()
     playlistStore.state.playlists = [playlist]
 
     const rendered = h.render(Component, {
@@ -26,10 +26,10 @@ describe('editPlaylistForm.vue', () => {
 
   it('edits the playlist with no changes to cover', async () => {
     const updateMock = h.mock(playlistStore, 'update')
-    playlistFolderStore.state.folders = h.factory('playlist-folder', 3)
+    playlistFolderStore.state.folders = h.factory('playlist-folder').make(3)
 
     const { playlist } = renderComponent(
-      h.factory('playlist', {
+      h.factory('playlist').make({
         name: 'My playlist',
         folder_id: playlistFolderStore.state.folders[0].id,
       }),
@@ -53,7 +53,7 @@ describe('editPlaylistForm.vue', () => {
     const updateMock = h.mock(playlistStore, 'update')
 
     const { playlist } = renderComponent(
-      h.factory('playlist', {
+      h.factory('playlist').make({
         name: 'My playlist',
         cover: 'https://localhost:3000/img/storage/cover.webp',
       }),
@@ -80,7 +80,7 @@ describe('editPlaylistForm.vue', () => {
     const updateMock = h.mock(playlistStore, 'update')
 
     const { playlist } = renderComponent(
-      h.factory('playlist', {
+      h.factory('playlist').make({
         name: 'My playlist',
         cover: 'https://localhost:3000/img/storage/cover.webp',
       }),

--- a/resources/assets/js/components/playlist/InvitePlaylistCollaborators.spec.ts
+++ b/resources/assets/js/components/playlist/InvitePlaylistCollaborators.spec.ts
@@ -9,7 +9,7 @@ describe('invitePlaylistCollaborators.vue', () => {
 
   it('works', async () => {
     h.mock(playlistCollaborationService, 'createInviteLink').mockResolvedValue('http://localhost:3000/invite/1234')
-    const playlist = h.factory('playlist')
+    const playlist = h.factory('playlist').make()
 
     h.render(Component, {
       props: {

--- a/resources/assets/js/components/playlist/PlaylistCollaborationModal.spec.ts
+++ b/resources/assets/js/components/playlist/PlaylistCollaborationModal.spec.ts
@@ -8,7 +8,7 @@ describe('playlistCollaborationModal.vue', () => {
   it('renders the modal', async () => {
     const { html } = h.render(Component, {
       props: {
-        playlist: h.factory('playlist'),
+        playlist: h.factory('playlist').make(),
       },
       global: {
         stubs: {

--- a/resources/assets/js/components/playlist/PlaylistCollaboratorList.spec.ts
+++ b/resources/assets/js/components/playlist/PlaylistCollaboratorList.spec.ts
@@ -24,13 +24,13 @@ describe('playlistCollaboratorList.vue', () => {
   }
 
   it('renders', async () => {
-    const playlist = h.factory('playlist', {
+    const playlist = h.factory('playlist').make({
       is_collaborative: true,
     })
 
     const fetchMock = h
       .mock(playlistCollaborationService, 'fetchCollaborators')
-      .mockResolvedValue(h.factory('playlist-collaborator', 5))
+      .mockResolvedValue(h.factory('playlist-collaborator').make(5))
 
     h.actingAsUser()
     const { html } = await renderComponent(playlist)

--- a/resources/assets/js/components/playlist/PlaylistCollaboratorListItem.spec.ts
+++ b/resources/assets/js/components/playlist/PlaylistCollaboratorListItem.spec.ts
@@ -23,10 +23,10 @@ describe('playlistCollaboratorListItem.vue', () => {
   }
 
   it('does not show a badge when current user is not the collaborator', async () => {
-    const currentUser = h.factory('user') as CurrentUser
+    const currentUser = h.factory('user').make() as CurrentUser
     h.actingAsUser(currentUser)
     renderComponent({
-      collaborator: h.factory('playlist-collaborator', { id: currentUser.id + 1 }),
+      collaborator: h.factory('playlist-collaborator').make({ id: currentUser.id + 1 }),
       removable: true,
       manageable: true,
       role: 'owner',
@@ -36,10 +36,10 @@ describe('playlistCollaboratorListItem.vue', () => {
   })
 
   it('shows a badge when current user is the collaborator', async () => {
-    const currentUser = h.factory('user') as CurrentUser
+    const currentUser = h.factory('user').make() as CurrentUser
     h.actingAsUser(currentUser)
     renderComponent({
-      collaborator: h.factory('playlist-collaborator', {
+      collaborator: h.factory('playlist-collaborator').make({
         id: currentUser.id,
         name: currentUser.name,
         avatar: currentUser.avatar,
@@ -53,7 +53,7 @@ describe('playlistCollaboratorListItem.vue', () => {
   })
 
   it('shows the role', async () => {
-    const collaborator = h.factory('playlist-collaborator')
+    const collaborator = h.factory('playlist-collaborator').make()
 
     h.actingAsUser()
     renderComponent({
@@ -77,7 +77,7 @@ describe('playlistCollaboratorListItem.vue', () => {
   })
 
   it('emits the remove event when the remove button is clicked', async () => {
-    const collaborator = h.factory('playlist-collaborator')
+    const collaborator = h.factory('playlist-collaborator').make()
     h.actingAsUser()
     const { emitted } = renderComponent({
       collaborator,

--- a/resources/assets/js/components/playlist/PlaylistCollaboratorsBadge.spec.ts
+++ b/resources/assets/js/components/playlist/PlaylistCollaboratorsBadge.spec.ts
@@ -7,19 +7,19 @@ describe('PlaylistCollaboratorsBadge', () => {
   const h = createHarness()
 
   it('displays up to 3 collaborators', () => {
-    const collaborators = [h.factory('user'), h.factory('user'), h.factory('user')]
+    const collaborators = [h.factory('user').make(), h.factory('user').make(), h.factory('user').make()]
     const { container } = h.render(Component, { props: { collaborators } })
     expect(container.querySelectorAll('li')).toHaveLength(3)
   })
 
   it('shows remainder count when more than 3', () => {
-    const collaborators = Array.from({ length: 5 }, () => h.factory('user'))
+    const collaborators = Array.from({ length: 5 }, () => h.factory('user').make())
     h.render(Component, { props: { collaborators } })
     screen.getByText('+2 more')
   })
 
   it('does not show remainder for 3 or fewer', () => {
-    const collaborators = [h.factory('user'), h.factory('user')]
+    const collaborators = [h.factory('user').make(), h.factory('user').make()]
     h.render(Component, { props: { collaborators } })
     expect(screen.queryByText(/more/)).toBeNull()
   })

--- a/resources/assets/js/components/playlist/PlaylistContextMenu.spec.ts
+++ b/resources/assets/js/components/playlist/PlaylistContextMenu.spec.ts
@@ -38,7 +38,7 @@ describe('playlistContextMenu.vue', () => {
       h.mock(playableStore, 'fetchForPlaylist').mockResolvedValue([])
     }
 
-    user = user || (h.factory.states('current')('user') as CurrentUser)
+    user = user || (h.factory('user').state('current').make() as CurrentUser)
 
     userStore.state.current = user
 
@@ -58,10 +58,10 @@ describe('playlistContextMenu.vue', () => {
   }
 
   const makeEditablePlaylist = (overrides: Partial<Playlist> = {}) =>
-    h.factory('playlist', { permissions: { edit: true, delete: false }, ...overrides })
+    h.factory('playlist').make({ permissions: { edit: true, delete: false }, ...overrides })
 
   const makeDeletablePlaylist = (overrides: Partial<Playlist> = {}) =>
-    h.factory('playlist', { permissions: { edit: false, delete: true }, ...overrides })
+    h.factory('playlist').make({ permissions: { edit: false, delete: true }, ...overrides })
 
   it('edits a standard playlist', async () => {
     const { playlist } = await renderComponent(makeEditablePlaylist())
@@ -73,7 +73,9 @@ describe('playlistContextMenu.vue', () => {
 
   it('edits a smart playlist', async () => {
     const { playlist } = await renderComponent(
-      factory.states('smart')('playlist', { permissions: { edit: true, delete: false } }),
+      factory('playlist')
+        .state('smart')
+        .make({ permissions: { edit: true, delete: false } }),
     )
 
     await h.user.click(screen.getByText('Edit…'))
@@ -105,11 +107,11 @@ describe('playlistContextMenu.vue', () => {
   it('plays', async () => {
     h.createAudioPlayer()
 
-    const songs = h.factory('song', 3)
+    const songs = h.factory('song').make(3)
     const fetchMock = h.mock(playableStore, 'fetchForPlaylist').mockResolvedValue(songs)
     const queueMock = h.mock(playbackService, 'queueAndPlay')
     const goMock = h.mock(Router, 'go')
-    const { playlist } = await renderComponent(h.factory('playlist'))
+    const { playlist } = await renderComponent(h.factory('playlist').make())
 
     await h.user.click(screen.getByText('Play'))
 
@@ -128,7 +130,7 @@ describe('playlistContextMenu.vue', () => {
     const goMock = h.mock(Router, 'go')
     const warnMock = h.mock(MessageToasterStub.value, 'warning')
 
-    const { playlist } = await renderComponent(h.factory('playlist'))
+    const { playlist } = await renderComponent(h.factory('playlist').make())
 
     await h.user.click(screen.getByText('Play'))
 
@@ -143,11 +145,11 @@ describe('playlistContextMenu.vue', () => {
   it('shuffles', async () => {
     h.createAudioPlayer()
 
-    const songs = h.factory('song', 3)
+    const songs = h.factory('song').make(3)
     const fetchMock = h.mock(playableStore, 'fetchForPlaylist').mockResolvedValue(songs)
     const queueMock = h.mock(playbackService, 'queueAndPlay')
     const goMock = h.mock(Router, 'go')
-    const { playlist } = await renderComponent(h.factory('playlist'))
+    const { playlist } = await renderComponent(h.factory('playlist').make())
 
     await h.user.click(screen.getByText('Shuffle'))
 
@@ -166,7 +168,7 @@ describe('playlistContextMenu.vue', () => {
     const goMock = h.mock(Router, 'go')
     const warnMock = h.mock(MessageToasterStub.value, 'warning')
 
-    const { playlist } = await renderComponent(h.factory('playlist'))
+    const { playlist } = await renderComponent(h.factory('playlist').make())
 
     await h.user.click(screen.getByText('Shuffle'))
 
@@ -181,11 +183,11 @@ describe('playlistContextMenu.vue', () => {
   it('queues', async () => {
     h.createAudioPlayer()
 
-    const songs = h.factory('song', 3)
+    const songs = h.factory('song').make(3)
     const fetchMock = h.mock(playableStore, 'fetchForPlaylist').mockResolvedValue(songs)
     const queueMock = h.mock(queueStore, 'queueAfterCurrent')
     const toastMock = h.mock(MessageToasterStub.value, 'success')
-    const { playlist } = await renderComponent(h.factory('playlist'))
+    const { playlist } = await renderComponent(h.factory('playlist').make())
 
     await h.user.click(screen.getByText('Add to Queue'))
 
@@ -197,8 +199,8 @@ describe('playlistContextMenu.vue', () => {
   })
 
   it('does not have an option to edit or delete if the playlist is not owned by the current user', async () => {
-    const playlist = h.factory('playlist', { permissions: { edit: false, delete: false } })
-    await renderComponent(playlist, h.factory.states('current')('user') as CurrentUser)
+    const playlist = h.factory('playlist').make({ permissions: { edit: false, delete: false } })
+    await renderComponent(playlist, h.factory('user').state('current').make() as CurrentUser)
 
     expect(screen.queryByText('Edit…')).toBeNull()
     expect(screen.queryByText('Delete')).toBeNull()
@@ -206,7 +208,7 @@ describe('playlistContextMenu.vue', () => {
 
   it('opens collaboration form', async () =>
     await h.withPlusEdition(async () => {
-      const { playlist } = await renderComponent(h.factory('playlist'))
+      const { playlist } = await renderComponent(h.factory('playlist').make())
 
       await h.user.click(screen.getByText('Collaborate…'))
 
@@ -214,7 +216,7 @@ describe('playlistContextMenu.vue', () => {
     }))
 
   it('requests the embed form', async () => {
-    const { playlist } = await renderComponent(h.factory('playlist'))
+    const { playlist } = await renderComponent(h.factory('playlist').make())
     await h.user.click(screen.getByText('Embed…'))
 
     await assertOpenModal(openModalMock, CreateEmbedForm, { embeddable: playlist })

--- a/resources/assets/js/components/playlist/PlaylistFolderContextMenu.spec.ts
+++ b/resources/assets/js/components/playlist/PlaylistFolderContextMenu.spec.ts
@@ -26,7 +26,7 @@ describe('playlistFolderContextMenu.vue', () => {
   })
 
   const renderComponent = async (folder?: PlaylistFolder) => {
-    folder = folder || h.factory('playlist-folder')
+    folder = folder || h.factory('playlist-folder').make()
 
     const rendered = h.render(Component, {
       props: {
@@ -41,8 +41,8 @@ describe('playlistFolderContextMenu.vue', () => {
   }
 
   const createPlayableFolder = () => {
-    const folder = h.factory('playlist-folder')
-    h.mock(playlistStore, 'byFolder', h.factory('playlist', 3, { folder_id: folder.id }))
+    const folder = h.factory('playlist-folder').make()
+    h.mock(playlistStore, 'byFolder', h.factory('playlist').make({ folder_id: folder.id }, 3))
     return folder
   }
 
@@ -65,7 +65,7 @@ describe('playlistFolderContextMenu.vue', () => {
   it('plays', async () => {
     h.createAudioPlayer()
 
-    const songs = h.factory('song', 3)
+    const songs = h.factory('song').make(3)
     const fetchMock = h.mock(playableStore, 'fetchForPlaylistFolder').mockResolvedValue(songs)
     const queueMock = h.mock(playbackService, 'queueAndPlay')
     const goMock = h.mock(Router, 'go')
@@ -103,7 +103,7 @@ describe('playlistFolderContextMenu.vue', () => {
   it('shuffles', async () => {
     h.createAudioPlayer()
 
-    const songs = h.factory('song', 3)
+    const songs = h.factory('song').make(3)
     const fetchMock = h.mock(playableStore, 'fetchForPlaylistFolder').mockResolvedValue(songs)
     const queueMock = h.mock(playbackService, 'queueAndPlay')
     const goMock = h.mock(Router, 'go')

--- a/resources/assets/js/components/playlist/smart-playlist/CreateSmartPlaylistForm.spec.ts
+++ b/resources/assets/js/components/playlist/smart-playlist/CreateSmartPlaylistForm.spec.ts
@@ -9,7 +9,7 @@ describe('createSmartPlaylistForm', () => {
   const h = createHarness()
 
   const renderComponent = (folder?: PlaylistFolder | null) => {
-    playlistFolderStore.state.folders = h.factory('playlist-folder', 2)
+    playlistFolderStore.state.folders = h.factory('playlist-folder').make(2)
 
     return h.render(Component, {
       props: {
@@ -46,7 +46,7 @@ describe('createSmartPlaylistForm', () => {
   })
 
   it('submits form data with empty rules when no groups added', async () => {
-    const playlist = h.factory('playlist')
+    const playlist = h.factory('playlist').make()
     const storeMock = h.mock(playlistStore, 'store').mockResolvedValue(playlist)
     renderComponent()
 
@@ -64,7 +64,7 @@ describe('createSmartPlaylistForm', () => {
   })
 
   it('submits form data with rule groups when groups are added', async () => {
-    const playlist = h.factory('playlist')
+    const playlist = h.factory('playlist').make()
     const storeMock = h.mock(playlistStore, 'store').mockResolvedValue(playlist)
     renderComponent()
 
@@ -91,7 +91,7 @@ describe('createSmartPlaylistForm', () => {
   })
 
   it('pre-selects folder when folder prop is provided', () => {
-    const folder = h.factory('playlist-folder')
+    const folder = h.factory('playlist-folder').make()
     playlistFolderStore.state.folders = [folder]
 
     h.render(Component, {

--- a/resources/assets/js/components/playlist/smart-playlist/EditSmartPlaylistForm.spec.ts
+++ b/resources/assets/js/components/playlist/smart-playlist/EditSmartPlaylistForm.spec.ts
@@ -26,7 +26,7 @@ describe('editSmartPlaylistForm', () => {
 
   const createSmartPlaylist = (overrides: Partial<Playlist> = {}): Playlist => {
     return {
-      ...h.factory('playlist'),
+      ...h.factory('playlist').make(),
       is_smart: true,
       rules: [createValidRuleGroup()],
       ...overrides,
@@ -35,7 +35,7 @@ describe('editSmartPlaylistForm', () => {
 
   const renderComponent = (playlist?: Playlist) => {
     playlist = playlist ?? createSmartPlaylist()
-    playlistFolderStore.state.folders = h.factory('playlist-folder', 2)
+    playlistFolderStore.state.folders = h.factory('playlist-folder').make(2)
     playlistStore.state.playlists = [playlist]
 
     return {

--- a/resources/assets/js/components/podcast/AddPodcastForm.spec.ts
+++ b/resources/assets/js/components/podcast/AddPodcastForm.spec.ts
@@ -8,7 +8,7 @@ describe('addPodcastForm.vue', () => {
   const h = createHarness()
 
   it('adds a new podcast', async () => {
-    const storeMock = h.mock(podcastStore, 'store').mockResolvedValue(h.factory('podcast'))
+    const storeMock = h.mock(podcastStore, 'store').mockResolvedValue(h.factory('podcast').make())
     h.render(Component)
     await h.type(screen.getByPlaceholderText('https://example.com/feed.xml'), 'https://foo.bar/feed.xml')
     await h.user.click(screen.getByRole('button', { name: 'Save' }))

--- a/resources/assets/js/components/podcast/EpisodeItem.spec.ts
+++ b/resources/assets/js/components/podcast/EpisodeItem.spec.ts
@@ -9,8 +9,8 @@ describe('episodeItem.vue', () => {
   const h = createHarness()
 
   const renderComponent = (episode?: Episode, podcast?: Podcast) => {
-    episode = episode || h.factory('episode')
-    podcast = podcast || h.factory('podcast', { id: episode.podcast_id })
+    episode = episode || h.factory('episode').make()
+    podcast = podcast || h.factory('podcast').make({ id: episode.podcast_id })
 
     const rendered = h.render(Component, {
       props: {
@@ -35,7 +35,7 @@ describe('episodeItem.vue', () => {
     h.createAudioPlayer()
 
     const pauseMock = h.mock(playbackService, 'pause')
-    renderComponent(h.factory('episode', { playback_state: 'Playing' }))
+    renderComponent(h.factory('episode').make({ playback_state: 'Playing' }))
 
     await h.user.click(screen.getByTestId('play-button'))
 
@@ -46,7 +46,7 @@ describe('episodeItem.vue', () => {
     h.createAudioPlayer()
 
     const resumeMock = h.mock(playbackService, 'resume')
-    renderComponent(h.factory('episode', { playback_state: 'Paused' }))
+    renderComponent(h.factory('episode').make({ playback_state: 'Paused' }))
 
     await h.user.click(screen.getByTestId('play-button'))
 
@@ -63,11 +63,11 @@ describe('episodeItem.vue', () => {
     preferenceStore.temporary.continuous_playback = false
     const playMock = h.mock(playbackService, 'play')
 
-    const episode = h.factory('episode', {
+    const episode = h.factory('episode').make({
       length: episodeLength,
     })
 
-    const podcast = h.factory('podcast', {
+    const podcast = h.factory('podcast').make({
       id: episode.podcast_id,
       state: {
         current_episode: episode.id,
@@ -97,11 +97,11 @@ describe('episodeItem.vue', () => {
   it('shows progress bar if there is progress', async () => {
     h.createAudioPlayer()
 
-    const episode = h.factory('episode', {
+    const episode = h.factory('episode').make({
       length: 300,
     })
 
-    const podcast = h.factory('podcast', {
+    const podcast = h.factory('podcast').make({
       id: episode.podcast_id,
       state: {
         current_episode: episode.id,

--- a/resources/assets/js/components/podcast/EpisodePogress.spec.ts
+++ b/resources/assets/js/components/podcast/EpisodePogress.spec.ts
@@ -8,7 +8,7 @@ describe('episodeProgress.vue', () => {
   it('renders', () => {
     const { html } = h.render(Component, {
       props: {
-        episode: h.factory('episode', {
+        episode: h.factory('episode').make({
           length: 300,
         }),
         position: 60,

--- a/resources/assets/js/components/podcast/EpisodeProgress.spec.ts
+++ b/resources/assets/js/components/podcast/EpisodeProgress.spec.ts
@@ -6,7 +6,7 @@ describe('EpisodeProgress', () => {
   const h = createHarness()
 
   it('renders progress bar with correct percentage', () => {
-    const episode = h.factory('episode', { length: 200 })
+    const episode = h.factory('episode').make({ length: 200 })
     const { container } = h.render(Component, { props: { episode, position: 50 } })
 
     const bar = container.querySelector('span')!
@@ -14,7 +14,7 @@ describe('EpisodeProgress', () => {
   })
 
   it('renders 0% for position 0', () => {
-    const episode = h.factory('episode', { length: 100 })
+    const episode = h.factory('episode').make({ length: 100 })
     const { container } = h.render(Component, { props: { episode, position: 0 } })
 
     const bar = container.querySelector('span')!
@@ -22,7 +22,7 @@ describe('EpisodeProgress', () => {
   })
 
   it('renders 100% when fully played', () => {
-    const episode = h.factory('episode', { length: 300 })
+    const episode = h.factory('episode').make({ length: 300 })
     const { container } = h.render(Component, { props: { episode, position: 300 } })
 
     const bar = container.querySelector('span')!

--- a/resources/assets/js/components/podcast/PodcastCard.spec.ts
+++ b/resources/assets/js/components/podcast/PodcastCard.spec.ts
@@ -10,7 +10,7 @@ describe('podcastCard.vue', () => {
   const renderComponent = (podcast?: Podcast) => {
     podcast =
       podcast ||
-      h.factory('podcast', {
+      h.factory('podcast').make({
         title: 'A Brief History of Time',
         author: 'Stephen Hawking',
         favorite: false,
@@ -46,7 +46,7 @@ describe('podcastCard.vue', () => {
 
   it('if a favorite podcast, shows the favorite button which toggles favorite state', async () => {
     const toggleFavoriteMock = h.mock(podcastStore, 'toggleFavorite')
-    const podcast = h.factory('podcast', { favorite: true })
+    const podcast = h.factory('podcast').make({ favorite: true })
 
     renderComponent(podcast)
     await h.user.click(screen.getByRole('button', { name: 'Undo Favorite' }))

--- a/resources/assets/js/components/podcast/PodcastContextMenu.spec.ts
+++ b/resources/assets/js/components/podcast/PodcastContextMenu.spec.ts
@@ -12,7 +12,7 @@ describe('podcastContextMenu.vue', () => {
   const renderComponent = async (podcast?: Podcast) => {
     podcast =
       podcast ||
-      h.factory('podcast', {
+      h.factory('podcast').make({
         title: 'A Brief History of Time',
         author: 'Stephen Hawking',
         favorite: false,
@@ -37,7 +37,7 @@ describe('podcastContextMenu.vue', () => {
   it('plays all', async () => {
     h.createAudioPlayer()
 
-    const episodes = h.factory('episode', 10)
+    const episodes = h.factory('episode').make(10)
     const fetchMock = h.mock(episodeStore, 'fetchEpisodesInPodcast').mockResolvedValue(episodes)
     const playMock = h.mock(playbackService, 'queueAndPlay')
 
@@ -52,7 +52,7 @@ describe('podcastContextMenu.vue', () => {
   it('shuffles all', async () => {
     h.createAudioPlayer()
 
-    const episodes = h.factory('episode', 10)
+    const episodes = h.factory('episode').make(10)
     const fetchMock = h.mock(episodeStore, 'fetchEpisodesInPodcast').mockResolvedValue(episodes)
     const playMock = h.mock(playbackService, 'queueAndPlay')
 
@@ -74,7 +74,7 @@ describe('podcastContextMenu.vue', () => {
   })
 
   it('undoes favorite', async () => {
-    const { podcast } = await renderComponent(h.factory('podcast', { favorite: true }))
+    const { podcast } = await renderComponent(h.factory('podcast').make({ favorite: true }))
     const favoriteMock = h.mock(podcastStore, 'toggleFavorite')
 
     await h.user.click(screen.getByText('Undo Favorite'))

--- a/resources/assets/js/components/podcast/PodcastItem.spec.ts
+++ b/resources/assets/js/components/podcast/PodcastItem.spec.ts
@@ -10,7 +10,7 @@ describe('podcastItem.vue', () => {
   const renderComponent = (podcast?: Podcast) => {
     podcast =
       podcast ||
-      h.factory('podcast', {
+      h.factory('podcast').make({
         title: 'A Brief History of Time',
         author: 'Stephen Hawking',
         favorite: false,
@@ -47,7 +47,7 @@ describe('podcastItem.vue', () => {
 
   it('if a favorite podcast, shows the favorite button which toggles favorite state', async () => {
     const toggleFavoriteMock = h.mock(podcastStore, 'toggleFavorite')
-    const podcast = h.factory('podcast', { favorite: true })
+    const podcast = h.factory('podcast').make({ favorite: true })
 
     renderComponent(podcast)
     await fireEvent(screen.getByTestId('favorite-button'), new CustomEvent('toggle'))

--- a/resources/assets/js/components/profile-preferences/OfflineStorage.spec.ts
+++ b/resources/assets/js/components/profile-preferences/OfflineStorage.spec.ts
@@ -46,7 +46,7 @@ describe('offlineStorage.vue', () => {
   })
 
   it('shows cached songs count', () => {
-    const songs = h.factory('song', 3)
+    const songs = h.factory('song').make(3)
     songs.forEach(s => {
       cachedSongIds.value.add(s.id)
       h.mock(playableStore, 'byId').mockImplementation((id: string) => songs.find(song => song.id === id))
@@ -57,7 +57,7 @@ describe('offlineStorage.vue', () => {
   })
 
   it('clears all offline songs with confirmation', async () => {
-    const song = h.factory('song')
+    const song = h.factory('song').make()
     cachedSongIds.value.add(song.id)
     h.mock(playableStore, 'byId').mockReturnValue(song)
 

--- a/resources/assets/js/components/profile-preferences/ProfileForm.spec.ts
+++ b/resources/assets/js/components/profile-preferences/ProfileForm.spec.ts
@@ -17,7 +17,7 @@ describe('profileForm.vue', () => {
     const alertMock = h.mock(MessageToasterStub.value, 'success')
 
     renderComponent(
-      h.factory('user', {
+      h.factory('user').make({
         avatar: 'https://gravatar.com/foo',
       }) as CurrentUser,
     )

--- a/resources/assets/js/components/profile-preferences/theme/CreateThemeForm.spec.ts
+++ b/resources/assets/js/components/profile-preferences/theme/CreateThemeForm.spec.ts
@@ -28,7 +28,7 @@ describe('createThemeForm.vue', () => {
   }
 
   it('submits', async () => {
-    const createdTheme = h.factory('theme')
+    const createdTheme = h.factory('theme').make()
     const storeMock = h.mock(themeStore, 'store').mockResolvedValueOnce(createdTheme)
     const setThemeMock = h.mock(themeStore, 'setTheme')
 

--- a/resources/assets/js/components/profile-preferences/theme/ThemeCard.spec.ts
+++ b/resources/assets/js/components/profile-preferences/theme/ThemeCard.spec.ts
@@ -8,7 +8,7 @@ describe('themeCard.vue', () => {
   const h = createHarness()
 
   const renderComponent = () => {
-    const theme = h.factory('theme', {
+    const theme = h.factory('theme').make({
       name: 'Sample',
     })
 

--- a/resources/assets/js/components/profile-preferences/theme/ThemeContextMenu.spec.ts
+++ b/resources/assets/js/components/profile-preferences/theme/ThemeContextMenu.spec.ts
@@ -8,7 +8,7 @@ describe('themeContextMenu.vue', () => {
   const h = createHarness()
 
   const renderComponent = (theme?: Theme) => {
-    theme = theme || h.factory('theme')
+    theme = theme || h.factory('theme').make()
 
     const rendered = h.actingAsAdmin().render(Component, {
       props: {
@@ -41,7 +41,7 @@ describe('themeContextMenu.vue', () => {
   })
 
   it('does not have an option to delete built-in theme', async () => {
-    renderComponent(h.factory('theme', { is_custom: false }))
+    renderComponent(h.factory('theme').make({ is_custom: false }))
     expect(screen.queryByText('Delete')).toBeNull()
   })
 })

--- a/resources/assets/js/components/profile-preferences/theme/ThemeList.spec.ts
+++ b/resources/assets/js/components/profile-preferences/theme/ThemeList.spec.ts
@@ -9,7 +9,7 @@ describe('themeList.vue', () => {
   it('renders a list of themes', async () => {
     h.render(Component, {
       props: {
-        themes: h.factory('theme', 9),
+        themes: h.factory('theme').make(9),
       },
       global: {
         stubs: {

--- a/resources/assets/js/components/profile-preferences/theme/ThemePreferences.spec.ts
+++ b/resources/assets/js/components/profile-preferences/theme/ThemePreferences.spec.ts
@@ -33,7 +33,7 @@ describe('themeList.vue', () => {
     await h.withPlusEdition(async () => {
       h.mock(themeStore, 'fetchCustomThemes').mockImplementation(() => {
         // manually modify the internal state, as the mock will prevent the real method from running
-        themeStore.state.themes = themeStore.state.themes.concat(...h.factory('theme', 4))
+        themeStore.state.themes = themeStore.state.themes.concat(...h.factory('theme').make(4))
       })
 
       h.render(Component)

--- a/resources/assets/js/components/radio/AddRadioStationForm.spec.ts
+++ b/resources/assets/js/components/radio/AddRadioStationForm.spec.ts
@@ -8,7 +8,7 @@ describe('addRadioStationForm.vue', () => {
   const h = createHarness()
 
   it('adds a radio station without a logo', async () => {
-    const storeMock = h.mock(radioStationStore, 'store').mockResolvedValue(h.factory('radio-station'))
+    const storeMock = h.mock(radioStationStore, 'store').mockResolvedValue(h.factory('radio-station').make())
 
     h.render(Component)
     await h.type(screen.getByPlaceholderText('My Favorite Radio Station'), 'Beethoven Goes Metal')
@@ -27,7 +27,7 @@ describe('addRadioStationForm.vue', () => {
   })
 
   it('adds a radio station with a logo', async () => {
-    const storeMock = h.mock(radioStationStore, 'store').mockResolvedValue(h.factory('radio-station'))
+    const storeMock = h.mock(radioStationStore, 'store').mockResolvedValue(h.factory('radio-station').make())
 
     h.render(Component)
     await h.type(screen.getByPlaceholderText('My Favorite Radio Station'), 'Beethoven Goes Metal')

--- a/resources/assets/js/components/radio/EditRadioStationForm.spec.ts
+++ b/resources/assets/js/components/radio/EditRadioStationForm.spec.ts
@@ -10,7 +10,7 @@ describe('editRadioStationForm.vue', () => {
   const h = createHarness()
 
   const renderComponent = (station?: RadioStation | Reactive<RadioStation>) => {
-    station = station ?? h.factory('radio-station')
+    station = station ?? h.factory('radio-station').make()
 
     const rendered = h.render(Component, {
       props: {
@@ -26,7 +26,7 @@ describe('editRadioStationForm.vue', () => {
 
   it('edits a radio station without logo changing', async () => {
     const updateMock = h.mock(radioStationStore, 'update')
-    const { station } = renderComponent(reactive(h.factory('radio-station', { is_public: false })))
+    const { station } = renderComponent(reactive(h.factory('radio-station').make({ is_public: false })))
 
     await h.type(screen.getByPlaceholderText('My Favorite Radio Station'), 'Beethoven Goes Pop')
     await h.type(screen.getByPlaceholderText('https://radio.example.com/stream'), 'https://beet.stream/pop')
@@ -44,7 +44,7 @@ describe('editRadioStationForm.vue', () => {
 
   it('edits a radio station, removing the logo', async () => {
     const updateMock = h.mock(radioStationStore, 'update')
-    const { station } = renderComponent(reactive(h.factory('radio-station', { is_public: false })))
+    const { station } = renderComponent(reactive(h.factory('radio-station').make({ is_public: false })))
 
     await h.user.click(screen.getByRole('button', { name: 'Remove' }))
 
@@ -65,7 +65,7 @@ describe('editRadioStationForm.vue', () => {
 
   it('edits a radio station, replacing the logo', async () => {
     const updateMock = h.mock(radioStationStore, 'update')
-    const { station } = renderComponent(reactive(h.factory('radio-station', { is_public: false })))
+    const { station } = renderComponent(reactive(h.factory('radio-station').make({ is_public: false })))
 
     await h.user.click(screen.getByRole('button', { name: 'Remove' }))
 

--- a/resources/assets/js/components/radio/RadioStationCard.spec.ts
+++ b/resources/assets/js/components/radio/RadioStationCard.spec.ts
@@ -15,7 +15,7 @@ describe('radioStationCard', () => {
   const h = createHarness()
 
   const createRadioStation = (overrides: Partial<RadioStation> = {}): RadioStation => {
-    return h.factory('radio-station', {
+    return h.factory('radio-station').make({
       id: '----',
       name: 'Beethoven Goes Metal',
       url: 'https://beet.stream/metal',

--- a/resources/assets/js/components/radio/RadioStationContextMenu.spec.ts
+++ b/resources/assets/js/components/radio/RadioStationContextMenu.spec.ts
@@ -24,7 +24,7 @@ describe('radioStationContextMenu.vue', () => {
   const renderComponent = async (station?: RadioStation, manageable = true) => {
     station =
       station ||
-      h.factory('radio-station', {
+      h.factory('radio-station').make({
         favorite: false,
         permissions: { edit: manageable, delete: manageable },
       })
@@ -60,14 +60,14 @@ describe('radioStationContextMenu.vue', () => {
   })
 
   it('hides Edit when only delete is permitted', async () => {
-    await renderComponent(h.factory('radio-station', { permissions: { edit: false, delete: true } }))
+    await renderComponent(h.factory('radio-station').make({ permissions: { edit: false, delete: true } }))
 
     expect(screen.queryByText('Edit…')).toBeNull()
     screen.getByText('Delete')
   })
 
   it('hides Delete when only edit is permitted', async () => {
-    await renderComponent(h.factory('radio-station', { permissions: { edit: true, delete: false } }))
+    await renderComponent(h.factory('radio-station').make({ permissions: { edit: true, delete: false } }))
 
     expect(screen.queryByText('Delete')).toBeNull()
     screen.getByText('Edit…')
@@ -89,7 +89,7 @@ describe('radioStationContextMenu.vue', () => {
 
     const stopMock = h.mock(playbackService, 'stop')
 
-    await renderComponent(h.factory('radio-station', { playback_state: 'Playing' }))
+    await renderComponent(h.factory('radio-station').make({ playback_state: 'Playing' }))
     await h.user.click(screen.getByText('Stop'))
 
     expect(stopMock).toHaveBeenCalled()
@@ -97,7 +97,7 @@ describe('radioStationContextMenu.vue', () => {
 
   it('favorites', async () => {
     const toggleMock = h.mock(radioStationStore, 'toggleFavorite')
-    const { station } = await renderComponent(h.factory('radio-station', { favorite: false }))
+    const { station } = await renderComponent(h.factory('radio-station').make({ favorite: false }))
 
     await h.user.click(screen.getByText('Favorite'))
     expect(toggleMock).toHaveBeenCalledWith(station)
@@ -105,7 +105,7 @@ describe('radioStationContextMenu.vue', () => {
 
   it('undoes favorite', async () => {
     const toggleMock = h.mock(radioStationStore, 'toggleFavorite')
-    const { station } = await renderComponent(h.factory('radio-station', { favorite: true }))
+    const { station } = await renderComponent(h.factory('radio-station').make({ favorite: true }))
 
     await h.user.click(screen.getByText('Undo Favorite'))
     expect(toggleMock).toHaveBeenCalledWith(station)

--- a/resources/assets/js/components/radio/RadioStationThumbnail.spec.ts
+++ b/resources/assets/js/components/radio/RadioStationThumbnail.spec.ts
@@ -9,7 +9,7 @@ describe('radioStationThumbnail.vue', () => {
   const renderComponent = (station?: RadioStation) => {
     station =
       station ||
-      h.factory('radio-station', {
+      h.factory('radio-station').make({
         name: 'Beethoven Goes Metal',
         logo: 'https://test/beet.jpg',
       })

--- a/resources/assets/js/components/screens/AcceptPlaylistCollaborationInvite.spec.ts
+++ b/resources/assets/js/components/screens/AcceptPlaylistCollaborationInvite.spec.ts
@@ -21,7 +21,7 @@ describe('acceptPlaylistCollaborationInvite.vue', () => {
   const h = createHarness()
 
   it('accepts invite and redirects on mount', async () => {
-    const playlist = h.factory('playlist')
+    const playlist = h.factory('playlist').make()
     h.mock(playlistCollaborationService, 'acceptInvite').mockResolvedValue(playlist)
 
     h.render(Component)

--- a/resources/assets/js/components/screens/AlbumListScreen.spec.ts
+++ b/resources/assets/js/components/screens/AlbumListScreen.spec.ts
@@ -22,7 +22,7 @@ describe('albumListScreen.vue', () => {
 
   const renderComponent = async () => {
     const paginator: PaginatorResource<Album> = {
-      data: h.factory('album', 9),
+      data: h.factory('album').make(9),
       links: {
         next: '?page=1',
       },
@@ -32,7 +32,7 @@ describe('albumListScreen.vue', () => {
     }
 
     const paginateMock = h.mock(albumStore, 'paginate').mockResolvedValueOnce(paginator)
-    albumStore.state.albums = h.factory('album', 9)
+    albumStore.state.albums = h.factory('album').make(9)
 
     const rendered = h.render(Component, {
       global: {
@@ -115,7 +115,7 @@ describe('albumListScreen.vue', () => {
   })
 
   it('filters out unfavorited albums in favorites mode', async () => {
-    const albums = h.factory('album', 5, { favorite: true })
+    const albums = h.factory('album').make({ favorite: true }, 5)
     albumStore.state.albums = albums
 
     h.mock(albumStore, 'paginate').mockResolvedValue(null)

--- a/resources/assets/js/components/screens/AlbumScreen.spec.ts
+++ b/resources/assets/js/components/screens/AlbumScreen.spec.ts
@@ -22,7 +22,7 @@ describe('albumScreen.vue', () => {
 
     album =
       album ||
-      h.factory('album', {
+      h.factory('album').make({
         name: 'Led Zeppelin IV',
         artist_id: 'bar',
         artist_name: 'Led Zeppelin',
@@ -30,7 +30,7 @@ describe('albumScreen.vue', () => {
 
     const resolveAlbumMock = h.mock(albumStore, 'resolve').mockResolvedValue(album)
 
-    const songs = h.factory('song', 13)
+    const songs = h.factory('song').make(13)
     const fetchSongsMock = h.mock(playableStore, 'fetchSongsForAlbum').mockResolvedValue(songs)
 
     h.visit(`albums/${album.id}/${tab}`)
@@ -83,7 +83,7 @@ describe('albumScreen.vue', () => {
   })
 
   it('shows other albums from the same artist', async () => {
-    const albums = h.factory('album', 3)
+    const albums = h.factory('album').make(3)
     const fetchMock = h.mock(albumStore, 'fetchForArtist').mockResolvedValue(albums)
     const { album } = await renderComponent('other-albums')
 
@@ -96,7 +96,7 @@ describe('albumScreen.vue', () => {
   })
 
   it('has a Favorite button if album is favorite', async () => {
-    const { album } = await renderComponent('songs', h.factory('album', { favorite: true }))
+    const { album } = await renderComponent('songs', h.factory('album').make({ favorite: true }))
     const favoriteMock = h.mock(albumStore, 'toggleFavorite')
 
     await waitFor(async () => {
@@ -106,7 +106,7 @@ describe('albumScreen.vue', () => {
   })
 
   it('does not have a Favorite button if album is not favorite', async () => {
-    await renderComponent('songs', h.factory('album', { favorite: false }))
+    await renderComponent('songs', h.factory('album').make({ favorite: false }))
     expect(screen.queryByRole('button', { name: 'Favorite' })).toBeNull()
   })
 

--- a/resources/assets/js/components/screens/AllSongsScreen.spec.ts
+++ b/resources/assets/js/components/screens/AllSongsScreen.spec.ts
@@ -13,7 +13,7 @@ describe('allSongsScreen.vue', () => {
     beforeEach: () => {
       commonStore.state.song_count = 420
       commonStore.state.song_length = 123_456
-      playableStore.state.playables = h.factory('song', 20)
+      playableStore.state.playables = h.factory('song').make(20)
       h.actingAsUser()
     },
   })

--- a/resources/assets/js/components/screens/ArtistListScreen.spec.ts
+++ b/resources/assets/js/components/screens/ArtistListScreen.spec.ts
@@ -22,7 +22,7 @@ describe('artistListScreen.vue', () => {
 
   const renderComponent = async () => {
     const paginator: PaginatorResource<Artist> = {
-      data: h.factory('artist', 9),
+      data: h.factory('artist').make(9),
       links: {
         next: '?page=1',
       },
@@ -117,7 +117,7 @@ describe('artistListScreen.vue', () => {
   })
 
   it('filters out unfavorited artists in favorites mode', async () => {
-    const artists = h.factory('artist', 5, { favorite: true })
+    const artists = h.factory('artist').make({ favorite: true }, 5)
     artistStore.state.artists = artists
 
     h.mock(artistStore, 'paginate').mockResolvedValue(null)

--- a/resources/assets/js/components/screens/ArtistScreen.spec.ts
+++ b/resources/assets/js/components/screens/ArtistScreen.spec.ts
@@ -22,13 +22,13 @@ describe('artistScreen.vue', () => {
 
     artist =
       artist ||
-      h.factory('artist', {
+      h.factory('artist').make({
         name: 'Led Zeppelin',
       })
 
     const resolveArtistMock = h.mock(artistStore, 'resolve').mockResolvedValue(artist)
 
-    const songs = h.factory('song', 13)
+    const songs = h.factory('song').make(13)
     const fetchSongsMock = h.mock(playableStore, 'fetchSongsForArtist').mockResolvedValue(songs)
 
     const rendered = h.visit(`artists/${artist.id}/${tab}`).render(Component, {
@@ -94,7 +94,7 @@ describe('artistScreen.vue', () => {
   })
 
   it('has a Favorite button if artist is favorite', async () => {
-    const { artist } = await renderComponent('songs', h.factory('artist', { favorite: true }))
+    const { artist } = await renderComponent('songs', h.factory('artist').make({ favorite: true }))
     const favoriteMock = h.mock(artistStore, 'toggleFavorite')
 
     await waitFor(async () => {
@@ -104,7 +104,7 @@ describe('artistScreen.vue', () => {
   })
 
   it('does not have a Favorite button if artist is not favorite', async () => {
-    await renderComponent('songs', h.factory('artist', { favorite: false }))
+    await renderComponent('songs', h.factory('artist').make({ favorite: false }))
     expect(screen.queryByRole('button', { name: 'Favorite' })).toBeNull()
   })
 

--- a/resources/assets/js/components/screens/EpisodeScreen.spec.ts
+++ b/resources/assets/js/components/screens/EpisodeScreen.spec.ts
@@ -14,7 +14,7 @@ describe('episodeScreen.vue', () => {
   const h = createHarness()
 
   const renderComponent = async (episode?: Episode) => {
-    episode = episode || h.factory('episode')
+    episode = episode || h.factory('episode').make()
 
     const resolveEpisodeMock = h.mock(episodeStore, 'resolve').mockResolvedValue(episode)
 
@@ -32,7 +32,7 @@ describe('episodeScreen.vue', () => {
   }
 
   it('has a Favorite button if episode is favorite', async () => {
-    const { episode } = await renderComponent(h.factory('episode', { favorite: true }))
+    const { episode } = await renderComponent(h.factory('episode').make({ favorite: true }))
     const favoriteMock = h.mock(episodeStore, 'toggleFavorite')
 
     await waitFor(async () => {
@@ -42,7 +42,7 @@ describe('episodeScreen.vue', () => {
   })
 
   it('does not have a Favorite button if episode is not favorite', async () => {
-    await renderComponent(h.factory('episode', { favorite: false }))
+    await renderComponent(h.factory('episode').make({ favorite: false }))
     expect(screen.queryByRole('button', { name: 'Favorite' })).toBeNull()
   })
 

--- a/resources/assets/js/components/screens/FavoritesScreen.spec.ts
+++ b/resources/assets/js/components/screens/FavoritesScreen.spec.ts
@@ -8,7 +8,7 @@ describe('favoritesScreen.vue', () => {
   const h = createHarness()
 
   const renderComponent = async (favorites?: Playable[]) => {
-    favorites = favorites ?? h.factory('song', 13)
+    favorites = favorites ?? h.factory('song').make(13)
     playableStore.state.favorites = favorites
 
     const fetchMock = h.mock(playableStore, 'fetchFavorites').mockResolvedValue(favorites)

--- a/resources/assets/js/components/screens/GenreListScreen.spec.ts
+++ b/resources/assets/js/components/screens/GenreListScreen.spec.ts
@@ -9,7 +9,7 @@ describe('genreListScreen', () => {
   const h = createHarness()
 
   const renderComponent = async (genres?: Genre[]) => {
-    genres = genres || h.factory('genre', 5)
+    genres = genres || h.factory('genre').make(5)
     const fetchMock = h.mock(genreStore, 'fetchAll').mockResolvedValue(genres)
 
     const rendered = h.render(Component, {

--- a/resources/assets/js/components/screens/GenreScreen.spec.ts
+++ b/resources/assets/js/components/screens/GenreScreen.spec.ts
@@ -9,12 +9,12 @@ describe('genreScreen', () => {
   const h = createHarness()
 
   const renderComponent = async (genre?: Genre, songs?: Song[]) => {
-    genre = genre || h.factory('genre')
+    genre = genre || h.factory('genre').make()
 
     const fetchGenreMock = h.mock(genreStore, 'fetchOne').mockResolvedValue(genre)
     const paginateMock = h.mock(playableStore, 'paginateSongsByGenre').mockResolvedValue({
       nextPage: 2,
-      songs: songs || h.factory('song', 13),
+      songs: songs || h.factory('song').make(13),
     })
 
     const rendered = h.visit(`genres/${genre.id}`).render(Component, {

--- a/resources/assets/js/components/screens/OfflineSongsScreen.spec.ts
+++ b/resources/assets/js/components/screens/OfflineSongsScreen.spec.ts
@@ -40,7 +40,7 @@ describe('offlineSongsScreen', () => {
   })
 
   it('shows cached songs count in header', () => {
-    const songs = h.factory('song', 3)
+    const songs = h.factory('song').make(3)
     songs.forEach(s => {
       cachedSongIds.value.add(s.id)
     })

--- a/resources/assets/js/components/screens/PlaylistScreen.spec.ts
+++ b/resources/assets/js/components/screens/PlaylistScreen.spec.ts
@@ -18,8 +18,8 @@ describe('playlistScreen.vue', () => {
   const h = createHarness()
 
   const renderComponent = async (songs: Playable[] = []) => {
-    const playlist = h.factory('playlist')
-    h.actingAsUser(h.factory.states('current')('user', { id: playlist.owner_id }) as CurrentUser)
+    const playlist = h.factory('playlist').make()
+    h.actingAsUser(h.factory('user').state('current').make({ id: playlist.owner_id }) as CurrentUser)
 
     playlistStore.state.playlists = []
     playlistStore.init([playlist])
@@ -47,7 +47,7 @@ describe('playlistScreen.vue', () => {
   }
 
   it('renders the playlist', async () => {
-    await renderComponent(h.factory('song', 10))
+    await renderComponent(h.factory('song').make(10))
 
     await waitFor(() => {
       screen.getByTestId('song-list')
@@ -66,7 +66,7 @@ describe('playlistScreen.vue', () => {
 
   it('refreshes the playlist', async () => {
     const { playlist, fetchSongsMock } = await renderComponent()
-    fetchSongsMock.mockResolvedValue(h.factory('song', 5))
+    fetchSongsMock.mockResolvedValue(h.factory('song').make(5))
 
     await h.user.click(screen.getByRole('button', { name: 'Refresh' }))
 
@@ -97,7 +97,7 @@ describe('playlistScreen.vue', () => {
     'refreshes upon %s event trigger',
     async eventKey => {
       const { playlist, fetchSongsMock } = await renderComponent()
-      fetchSongsMock.mockResolvedValueOnce(h.factory('song', 5))
+      fetchSongsMock.mockResolvedValueOnce(h.factory('song').make(5))
 
       eventBus.emit(eventKey, playlist)
 

--- a/resources/assets/js/components/screens/PodcastListScreen.spec.ts
+++ b/resources/assets/js/components/screens/PodcastListScreen.spec.ts
@@ -24,7 +24,7 @@ describe('podcastListScreen.vue', () => {
 
   it('renders', async () => {
     const fetchMock = h.mock(podcastStore, 'fetchAll')
-    podcastStore.state.podcasts = h.factory('podcast', 9)
+    podcastStore.state.podcasts = h.factory('podcast').make(9)
 
     await renderComponent()
 
@@ -42,8 +42,8 @@ describe('podcastListScreen.vue', () => {
 
   it('shows all or only favorites upon toggling the button', async () => {
     podcastStore.state.podcasts = [
-      ...h.factory('podcast', 3, { favorite: true }),
-      ...h.factory('podcast', 6, { favorite: false }),
+      ...h.factory('podcast').make({ favorite: true }, 3),
+      ...h.factory('podcast').make({ favorite: false }, 6),
     ]
 
     h.mock(podcastStore, 'fetchAll')
@@ -59,7 +59,7 @@ describe('podcastListScreen.vue', () => {
   })
 
   it('shows contextual empty state when no favorite podcasts', async () => {
-    podcastStore.state.podcasts = h.factory('podcast', 3, { favorite: false })
+    podcastStore.state.podcasts = h.factory('podcast').make({ favorite: false }, 3)
     h.mock(podcastStore, 'fetchAll')
 
     await renderComponent()

--- a/resources/assets/js/components/screens/PodcastScreen.spec.ts
+++ b/resources/assets/js/components/screens/PodcastScreen.spec.ts
@@ -21,12 +21,12 @@ describe('podcastScreen.vue', () => {
   const renderComponent = async (podcast?: Podcast, episodes?: Episode[]) => {
     podcast =
       podcast ||
-      h.factory('podcast', {
+      h.factory('podcast').make({
         title: 'A Brief History of Time',
         favorite: false,
       })
 
-    episodes = episodes || h.factory('episode', 9, { podcast_id: podcast.id })
+    episodes = episodes || h.factory('episode').make({ podcast_id: podcast.id }, 9)
 
     const resolvePodcastMock = h.mock(podcastStore, 'resolve').mockResolvedValue(podcast)
     const fetchEpisodesMock = h.mock(episodeStore, 'fetchEpisodesInPodcast').mockResolvedValue(episodes)
@@ -99,8 +99,8 @@ describe('podcastScreen.vue', () => {
 
     const playMock = h.mock(playbackService, 'play')
 
-    const podcast = h.factory('podcast')
-    const episodes = h.factory('episode', 2, { podcast_id: podcast.id })
+    const podcast = h.factory('podcast').make()
+    const episodes = h.factory('episode').make({ podcast_id: podcast.id }, 2)
     podcast.state.current_episode = episodes[0].id
     podcast.state.progresses = {
       [episodes[0].id]: 123,
@@ -123,7 +123,7 @@ describe('podcastScreen.vue', () => {
   })
 
   it('has a Favorite button if podcast is favorite', async () => {
-    const { podcast } = await renderComponent(h.factory('podcast', { favorite: true }))
+    const { podcast } = await renderComponent(h.factory('podcast').make({ favorite: true }))
     const toggleFavoriteMock = h.mock(podcastStore, 'toggleFavorite')
 
     await waitFor(async () => await h.user.click(screen.getByRole('button', { name: 'Undo Favorite' })))
@@ -132,7 +132,7 @@ describe('podcastScreen.vue', () => {
   })
 
   it('does not have a Favorite button if podcast is not favorite', async () => {
-    await renderComponent(h.factory('podcast', { favorite: false }))
+    await renderComponent(h.factory('podcast').make({ favorite: false }))
     expect(screen.queryByRole('button', { name: 'Favorite' })).toBeNull()
   })
 

--- a/resources/assets/js/components/screens/QueueScreen.spec.ts
+++ b/resources/assets/js/components/screens/QueueScreen.spec.ts
@@ -22,7 +22,7 @@ describe('queueScreen.vue', () => {
   }
 
   it('renders the queue', () => {
-    renderComponent(h.factory('song', 3))
+    renderComponent(h.factory('song').make(3))
 
     expect(screen.queryByTestId('song-list')).toBeTruthy()
     expect(screen.queryByTestId('screen-empty-state')).toBeNull()
@@ -54,7 +54,7 @@ describe('queueScreen.vue', () => {
   it('shuffles all', async () => {
     h.createAudioPlayer()
 
-    const songs = h.factory('song', 3)
+    const songs = h.factory('song').make(3)
     renderComponent(songs)
     const playMock = h.mock(playbackService, 'queueAndPlay')
 

--- a/resources/assets/js/components/screens/RadioStationListScreen.spec.ts
+++ b/resources/assets/js/components/screens/RadioStationListScreen.spec.ts
@@ -25,7 +25,7 @@ describe('radioStationListScreen.vue', () => {
   })
 
   const renderComponent = async (stations?: RadioStation[]) => {
-    radioStationStore.state.stations = stations || h.factory('radio-station', 9)
+    radioStationStore.state.stations = stations || h.factory('radio-station').make(9)
 
     const rendered = h.render(Component, {
       global: {
@@ -100,8 +100,8 @@ describe('radioStationListScreen.vue', () => {
 
   it('shows all or only favorites upon toggling the button', async () => {
     await renderComponent([
-      ...h.factory('radio-station', 3, { favorite: true }),
-      ...h.factory('radio-station', 6, { favorite: false }),
+      ...h.factory('radio-station').make({ favorite: true }, 3),
+      ...h.factory('radio-station').make({ favorite: false }, 6),
     ])
 
     expect(screen.getAllByTestId('radio-station-card')).toHaveLength(9)
@@ -114,7 +114,7 @@ describe('radioStationListScreen.vue', () => {
   })
 
   it('shows contextual empty state when no favorite stations', async () => {
-    await renderComponent(h.factory('radio-station', 3, { favorite: false }))
+    await renderComponent(h.factory('radio-station').make({ favorite: false }, 3))
 
     await h.user.click(screen.getByRole('button', { name: 'Show favorites only' }))
 

--- a/resources/assets/js/components/screens/RecentlyPlayedScreen.spec.ts
+++ b/resources/assets/js/components/screens/RecentlyPlayedScreen.spec.ts
@@ -25,7 +25,7 @@ describe('recentlyPlayedScreen.vue', () => {
   }
 
   it('displays the songs', async () => {
-    await renderComponent(h.factory('song', 3))
+    await renderComponent(h.factory('song').make(3))
 
     screen.getByTestId('song-list')
     expect(screen.queryByTestId('screen-empty-state')).toBeNull()

--- a/resources/assets/js/components/screens/UserListScreen.spec.ts
+++ b/resources/assets/js/components/screens/UserListScreen.spec.ts
@@ -29,7 +29,7 @@ describe('userListScreen.vue', () => {
 
   const renderComponent = async (users: User[] = []) => {
     if (users.length === 0) {
-      users = h.factory('user', 6)
+      users = h.factory('user').make(6)
     }
 
     const fetchMock = h.mock(http, 'get').mockResolvedValue(users)
@@ -57,7 +57,7 @@ describe('userListScreen.vue', () => {
   })
 
   it('displays a list of user prospects', async () => {
-    const users = [...factory.states('prospect')('user', 2), ...h.factory('user', 3)]
+    const users = [...factory('user').state('prospect').make(2), ...h.factory('user').make(3)]
     await renderComponent(users)
 
     expect(screen.getAllByTestId('user-card')).toHaveLength(5)

--- a/resources/assets/js/components/screens/home/LeastPlayedSongs.spec.ts
+++ b/resources/assets/js/components/screens/home/LeastPlayedSongs.spec.ts
@@ -8,7 +8,7 @@ describe('leastPlayedSongs.vue', () => {
   const h = createHarness()
 
   it('displays the songs', async () => {
-    overviewStore.state.leastPlayedSongs = h.factory('song', 6)
+    overviewStore.state.leastPlayedSongs = h.factory('song').make(6)
     h.render(Component)
     await waitFor(() => expect(screen.getAllByTestId('song-card')).toHaveLength(6))
   })

--- a/resources/assets/js/components/screens/home/MostPlayedSongs.spec.ts
+++ b/resources/assets/js/components/screens/home/MostPlayedSongs.spec.ts
@@ -8,7 +8,7 @@ describe('mostPlayedSongs.vue', () => {
   const h = createHarness()
 
   it('displays the songs', async () => {
-    overviewStore.state.mostPlayedSongs = h.factory('song', 6)
+    overviewStore.state.mostPlayedSongs = h.factory('song').make(6)
     h.render(Component)
     await waitFor(() => expect(screen.getAllByTestId('song-card')).toHaveLength(6))
   })

--- a/resources/assets/js/components/screens/home/NewAlbums.spec.ts
+++ b/resources/assets/js/components/screens/home/NewAlbums.spec.ts
@@ -7,7 +7,7 @@ describe('newAlbums.vue', () => {
   const h = createHarness()
 
   it('displays the albums', () => {
-    overviewStore.state.recentlyAddedAlbums = h.factory('album', 6)
+    overviewStore.state.recentlyAddedAlbums = h.factory('album').make(6)
     expect(
       h
         .render(Component, {

--- a/resources/assets/js/components/screens/home/NewArtists.spec.ts
+++ b/resources/assets/js/components/screens/home/NewArtists.spec.ts
@@ -8,7 +8,7 @@ describe('newArtists.vue', () => {
   const h = createHarness()
 
   it('displays the artists', async () => {
-    overviewStore.state.recentlyAddedArtists = h.factory('artist', 4)
+    overviewStore.state.recentlyAddedArtists = h.factory('artist').make(4)
     h.render(Component)
     await waitFor(() => expect(screen.getAllByTestId('artist-album-card')).toHaveLength(4))
   })

--- a/resources/assets/js/components/screens/home/NewSongs.spec.ts
+++ b/resources/assets/js/components/screens/home/NewSongs.spec.ts
@@ -8,7 +8,7 @@ describe('newSongs.vue', () => {
   const h = createHarness()
 
   it('displays the songs', async () => {
-    overviewStore.state.recentlyAddedSongs = h.factory('song', 6)
+    overviewStore.state.recentlyAddedSongs = h.factory('song').make(6)
     h.render(Component)
     await waitFor(() => expect(screen.getAllByTestId('song-card')).toHaveLength(6))
   })

--- a/resources/assets/js/components/screens/home/PlayableCard.spec.ts
+++ b/resources/assets/js/components/screens/home/PlayableCard.spec.ts
@@ -33,7 +33,7 @@ describe('playableCard.vue', () => {
   })
 
   const renderCard = (overrides: Partial<Song> = {}) => {
-    const song = h.factory('song', {
+    const song = h.factory('song').make({
       title: 'Test Song',
       artist_name: 'Test Artist',
       length: 195,

--- a/resources/assets/js/components/screens/home/PlayableCardGrid.spec.ts
+++ b/resources/assets/js/components/screens/home/PlayableCardGrid.spec.ts
@@ -7,7 +7,7 @@ describe('playableCardGrid.vue', () => {
   const h = createHarness()
 
   it('renders a grid of playable cards', () => {
-    const songs = h.factory('song', 4)
+    const songs = h.factory('song').make(4)
     h.render(Component, { props: { playables: songs } })
     expect(screen.getAllByTestId('song-card')).toHaveLength(4)
   })

--- a/resources/assets/js/components/screens/home/RandomSongs.spec.ts
+++ b/resources/assets/js/components/screens/home/RandomSongs.spec.ts
@@ -8,13 +8,13 @@ describe('randomSongs.vue', () => {
   const h = createHarness()
 
   it('displays the songs', async () => {
-    overviewStore.state.randomSongs = h.factory('song', 6)
+    overviewStore.state.randomSongs = h.factory('song').make(6)
     h.render(Component)
     await waitFor(() => expect(screen.getAllByTestId('song-card')).toHaveLength(6))
   })
 
   it('refreshes random songs on button click', async () => {
-    overviewStore.state.randomSongs = h.factory('song', 6)
+    overviewStore.state.randomSongs = h.factory('song').make(6)
     const refreshMock = h.mock(overviewStore, 'refreshRandomSongs')
     h.render(Component)
 
@@ -24,7 +24,7 @@ describe('randomSongs.vue', () => {
   })
 
   it('marks grid as busy during refresh', async () => {
-    overviewStore.state.randomSongs = h.factory('song', 6)
+    overviewStore.state.randomSongs = h.factory('song').make(6)
     h.mock(overviewStore, 'refreshRandomSongs').mockReturnValue(new Promise(() => {}))
     h.render(Component)
 

--- a/resources/assets/js/components/screens/home/RecentlyPlayedPlayables.spec.ts
+++ b/resources/assets/js/components/screens/home/RecentlyPlayedPlayables.spec.ts
@@ -9,7 +9,7 @@ describe('recentlyPlayedPlayables.vue', () => {
   const h = createHarness()
 
   it('displays the songs', async () => {
-    overviewStore.state.recentlyPlayed = h.factory('song', 6)
+    overviewStore.state.recentlyPlayed = h.factory('song').make(6)
     h.render(Component)
     await waitFor(() => expect(screen.getAllByTestId('song-card')).toHaveLength(6))
   })

--- a/resources/assets/js/components/screens/home/SimilarSongs.spec.ts
+++ b/resources/assets/js/components/screens/home/SimilarSongs.spec.ts
@@ -8,7 +8,7 @@ describe('similarSongs.vue', () => {
   const h = createHarness()
 
   it('displays the songs', async () => {
-    overviewStore.state.similarSongs = h.factory('song', 6)
+    overviewStore.state.similarSongs = h.factory('song').make(6)
     h.render(Component)
     await waitFor(() => expect(screen.getAllByTestId('song-card')).toHaveLength(6))
   })

--- a/resources/assets/js/components/screens/home/TopAlbums.spec.ts
+++ b/resources/assets/js/components/screens/home/TopAlbums.spec.ts
@@ -7,7 +7,7 @@ describe('topAlbums.vue', () => {
   const h = createHarness()
 
   it('displays the albums', () => {
-    overviewStore.state.mostPlayedAlbums = h.factory('album', 6)
+    overviewStore.state.mostPlayedAlbums = h.factory('album').make(6)
     expect(
       h
         .render(TopAlbums, {

--- a/resources/assets/js/components/screens/home/TopArtists.spec.ts
+++ b/resources/assets/js/components/screens/home/TopArtists.spec.ts
@@ -7,7 +7,7 @@ describe('topArtists.vue', () => {
   const h = createHarness()
 
   it('displays the artists', () => {
-    overviewStore.state.mostPlayedArtists = h.factory('artist', 6)
+    overviewStore.state.mostPlayedArtists = h.factory('artist').make(6)
     expect(
       h
         .render(TopArtists, {

--- a/resources/assets/js/components/screens/search/AlbumExcerptResultsBlock.spec.ts
+++ b/resources/assets/js/components/screens/search/AlbumExcerptResultsBlock.spec.ts
@@ -15,7 +15,7 @@ describe('albumExcerptResultsBlock.vue', () => {
   })
 
   it('renders album cards when albums are provided', () => {
-    const albums = h.factory('album', 3)
+    const albums = h.factory('album').make(3)
 
     h.render(Component, {
       props: { albums, searching: false },

--- a/resources/assets/js/components/screens/search/ArtistExcerptResultsBlock.spec.ts
+++ b/resources/assets/js/components/screens/search/ArtistExcerptResultsBlock.spec.ts
@@ -15,7 +15,7 @@ describe('artistExcerptResultsBlock.vue', () => {
   })
 
   it('renders artist cards when artists are provided', () => {
-    const artists = h.factory('artist', 3)
+    const artists = h.factory('artist').make(3)
 
     h.render(Component, {
       props: { artists, searching: false },

--- a/resources/assets/js/components/screens/search/PodcastExcerptResultsBlock.spec.ts
+++ b/resources/assets/js/components/screens/search/PodcastExcerptResultsBlock.spec.ts
@@ -15,7 +15,7 @@ describe('podcastExcerptResultsBlock.vue', () => {
   })
 
   it('renders podcast cards when podcasts are provided', () => {
-    const podcasts = h.factory('podcast', 3)
+    const podcasts = h.factory('podcast').make(3)
 
     h.render(Component, {
       props: { podcasts, searching: false },

--- a/resources/assets/js/components/screens/search/RadioStationExcerptResultsBlock.spec.ts
+++ b/resources/assets/js/components/screens/search/RadioStationExcerptResultsBlock.spec.ts
@@ -15,7 +15,7 @@ describe('radioStationExcerptResultsBlock.vue', () => {
   })
 
   it('renders station cards when stations are provided', () => {
-    const stations = h.factory('radio-station', 3)
+    const stations = h.factory('radio-station').make(3)
 
     h.render(Component, {
       props: { stations, searching: false },

--- a/resources/assets/js/components/ui/FooterPlayButton.spec.ts
+++ b/resources/assets/js/components/ui/FooterPlayButton.spec.ts
@@ -27,7 +27,7 @@ describe('footerPlayButton.vue', () => {
     h.createAudioPlayer()
 
     const toggleMock = h.mock(playbackService, 'toggle')
-    renderComponent(h.factory('song'))
+    renderComponent(h.factory('song').make())
 
     await h.user.click(screen.getByRole('button'))
 
@@ -42,7 +42,7 @@ describe('footerPlayButton.vue', () => {
     h.createAudioPlayer()
 
     commonStore.state.song_count = 10
-    const songs = h.factory('song', 3)
+    const songs = h.factory('song').make(3)
     const fetchMock = h.mock(playableStore, fetchMethod).mockResolvedValue(songs)
     const playMock = h.mock(playbackService, 'queueAndPlay')
     const goMock = h.mock(Router, 'go')
@@ -66,7 +66,7 @@ describe('footerPlayButton.vue', () => {
     h.createAudioPlayer()
 
     commonStore.state.song_count = 10
-    const songs = h.factory('song', 3)
+    const songs = h.factory('song').make(3)
     const fetchMock = h.mock(store, fetchMethod).mockResolvedValue(songs)
     const playMock = h.mock(playbackService, 'queueAndPlay')
     const goMock = h.mock(Router, 'go')

--- a/resources/assets/js/components/ui/PlaylistThumbnail.spec.ts
+++ b/resources/assets/js/components/ui/PlaylistThumbnail.spec.ts
@@ -6,13 +6,13 @@ describe('PlaylistThumbnail', () => {
   const h = createHarness()
 
   it('renders the thumbnail article', () => {
-    const playlist = h.factory('playlist')
+    const playlist = h.factory('playlist').make()
     const { getByTestId } = h.render(Component, { props: { playlist } })
     expect(getByTestId('playlist-thumbnail')).toBeTruthy()
   })
 
   it('renders slot content', () => {
-    const playlist = h.factory('playlist')
+    const playlist = h.factory('playlist').make()
     const { getByTestId } = h.render(Component, {
       props: { playlist },
       slots: { default: '<span>Overlay</span>' },

--- a/resources/assets/js/components/ui/ProfileAvatar.spec.ts
+++ b/resources/assets/js/components/ui/ProfileAvatar.spec.ts
@@ -6,7 +6,7 @@ describe('profileAvatar.vue', () => {
   const h = createHarness()
 
   it('renders', () => {
-    const user = h.factory('user', {
+    const user = h.factory('user').make({
       name: 'John Doe',
       avatar: 'https://example.com/avatar.jpg',
     })

--- a/resources/assets/js/components/ui/album-artist/AlbumOrArtistCard.spec.ts
+++ b/resources/assets/js/components/ui/album-artist/AlbumOrArtistCard.spec.ts
@@ -9,7 +9,7 @@ describe('albumOrArtistCard.vue', () => {
   it('emits events on user actions', async () => {
     const { emitted } = h.render(Component, {
       props: {
-        entity: h.factory('album'),
+        entity: h.factory('album').make(),
       },
     })
 

--- a/resources/assets/js/components/ui/album-artist/AlbumOrArtistThumbnail.spec.ts
+++ b/resources/assets/js/components/ui/album-artist/AlbumOrArtistThumbnail.spec.ts
@@ -11,7 +11,7 @@ describe('albumOrArtistThumbnail.vue', () => {
   const h = createHarness()
 
   const renderForAlbum = () => {
-    const album = h.factory('album', {
+    const album = h.factory('album').make({
       name: 'IV',
       cover: 'https://test/album.jpg',
     })
@@ -29,7 +29,7 @@ describe('albumOrArtistThumbnail.vue', () => {
   }
 
   const renderForArtist = () => {
-    const artist = h.factory('artist', {
+    const artist = h.factory('artist').make({
       name: 'Led Zeppelin',
       image: 'https://test/blimp.jpg',
     })
@@ -57,7 +57,7 @@ describe('albumOrArtistThumbnail.vue', () => {
   it('plays album', async () => {
     h.createAudioPlayer()
 
-    const songs = h.factory('song', 10)
+    const songs = h.factory('song').make(10)
     const fetchMock = h.mock(playableStore, 'fetchSongsForAlbum').mockResolvedValue(songs)
     const playMock = h.mock(playbackService, 'queueAndPlay')
     const { album } = renderForAlbum()
@@ -73,7 +73,7 @@ describe('albumOrArtistThumbnail.vue', () => {
   it('queues album', async () => {
     h.createAudioPlayer()
 
-    const songs = h.factory('song', 10)
+    const songs = h.factory('song').make(10)
     const fetchMock = h.mock(playableStore, 'fetchSongsForAlbum').mockResolvedValue(songs)
     const queueMock = h.mock(queueStore, 'queue')
     const { album } = renderForAlbum()
@@ -89,7 +89,7 @@ describe('albumOrArtistThumbnail.vue', () => {
   })
 
   it('plays artist', async () => {
-    const songs = h.factory('song', 10)
+    const songs = h.factory('song').make(10)
     const fetchMock = h.mock(playableStore, 'fetchSongsForArtist').mockResolvedValue(songs)
     const playMock = h.mock(playbackService, 'queueAndPlay')
     const { artist } = renderForArtist()
@@ -103,7 +103,7 @@ describe('albumOrArtistThumbnail.vue', () => {
   })
 
   it('queues artist', async () => {
-    const songs = h.factory('song', 10)
+    const songs = h.factory('song').make(10)
     const fetchMock = h.mock(playableStore, 'fetchSongsForArtist').mockResolvedValue(songs)
     const queueMock = h.mock(queueStore, 'queue')
     const { artist } = renderForArtist()

--- a/resources/assets/js/components/ui/form/FolderSelect.spec.ts
+++ b/resources/assets/js/components/ui/form/FolderSelect.spec.ts
@@ -8,7 +8,7 @@ describe('folderSelect', () => {
   const h = createHarness()
 
   const renderComponent = (folderId: PlaylistFolder['id'] | null = null) => {
-    playlistFolderStore.state.folders = h.factory('playlist-folder', 3)
+    playlistFolderStore.state.folders = h.factory('playlist-folder').make(3)
 
     return h.render(Component, {
       props: {
@@ -82,7 +82,7 @@ describe('folderSelect', () => {
   })
 
   it('clears folder name when selecting an existing folder', async () => {
-    playlistFolderStore.state.folders = h.factory('playlist-folder', 3)
+    playlistFolderStore.state.folders = h.factory('playlist-folder').make(3)
     const folders = playlistFolderStore.state.folders
 
     const { emitted } = h.render(Component, {

--- a/resources/assets/js/components/ui/lyrics/LyricsPane.spec.ts
+++ b/resources/assets/js/components/ui/lyrics/LyricsPane.spec.ts
@@ -22,7 +22,7 @@ describe('lyricsPane.vue', () => {
   const renderComponent = (song?: Song) => {
     song =
       song ||
-      h.factory('song', {
+      h.factory('song').make({
         lyrics: 'Foo bar baz qux',
       })
 
@@ -48,7 +48,7 @@ describe('lyricsPane.vue', () => {
 
   it('renders plain text lyrics when lyrics are not synced', () => {
     renderComponent(
-      h.factory('song', {
+      h.factory('song').make({
         lyrics: 'Plain lyrics\nLine 2\nLine 3',
       }),
     )
@@ -58,7 +58,7 @@ describe('lyricsPane.vue', () => {
   })
 
   it('renders LRC pane when lyrics are in LRC format', () => {
-    const song = h.factory('song', {
+    const song = h.factory('song').make({
       lyrics: '[00:12.00]First line\n[00:17.20]Second line\n[00:21.00]Third line',
     })
 
@@ -69,7 +69,7 @@ describe('lyricsPane.vue', () => {
   })
 
   it('provides a button to add lyrics if current user is admin', async () => {
-    const song = h.factory('song', { lyrics: null })
+    const song = h.factory('song').make({ lyrics: null })
 
     h.actingAsAdmin()
     renderComponent(song)
@@ -81,7 +81,7 @@ describe('lyricsPane.vue', () => {
 
   it('does not have a button to add lyrics if current user is not an admin', async () => {
     h.actingAsUser()
-    renderComponent(h.factory('song', { lyrics: null }))
+    renderComponent(h.factory('song').make({ lyrics: null }))
     expect(screen.queryByRole('button', { name: 'Click here' })).toBeNull()
   })
 })

--- a/resources/assets/js/components/ui/youtube/YouTubeVideoList.spec.ts
+++ b/resources/assets/js/components/ui/youtube/YouTubeVideoList.spec.ts
@@ -23,17 +23,17 @@ describe('youTubeVideoList', () => {
       }),
     )
 
-    const song = h.factory('song')
+    const song = h.factory('song').make()
 
     const searchMock = h
       .mock(youTubeService, 'searchVideosBySong')
       .mockResolvedValueOnce({
         nextPageToken: 'foo',
-        items: h.factory('you-tube-video', 5),
+        items: h.factory('you-tube-video').make(5),
       })
       .mockResolvedValueOnce({
         nextPageToken: '',
-        items: h.factory('you-tube-video', 3),
+        items: h.factory('you-tube-video').make(3),
       })
 
     h.render(Component, {

--- a/resources/assets/js/components/user/AddUserForm.spec.ts
+++ b/resources/assets/js/components/user/AddUserForm.spec.ts
@@ -20,7 +20,7 @@ describe('addUserForm.vue', () => {
 
   it('creates a new user', async () => {
     const storeMock = h.mock(userStore, 'store').mockResolvedValue(
-      h.factory('user', {
+      h.factory('user').make({
         name: 'John Doe',
         email: 'john@doe.com',
       }),

--- a/resources/assets/js/components/user/EditUserForm.spec.ts
+++ b/resources/assets/js/components/user/EditUserForm.spec.ts
@@ -9,7 +9,7 @@ describe('editUserForm.vue', () => {
   const h = createHarness()
 
   const renderComponent = (user?: User) => {
-    user = user ?? h.factory('user')
+    user = user ?? h.factory('user').make()
 
     const rendered = h.render(Component, {
       props: {

--- a/resources/assets/js/components/user/UserAvatar.spec.ts
+++ b/resources/assets/js/components/user/UserAvatar.spec.ts
@@ -6,7 +6,7 @@ describe('UserAvatar', () => {
   const h = createHarness()
 
   it('renders avatar image with alt text', () => {
-    const user = h.factory('user', { name: 'Alice', avatar: 'https://example.com/avatar.png' })
+    const user = h.factory('user').make({ name: 'Alice', avatar: 'https://example.com/avatar.png' })
     const { container } = h.render(Component, { props: { user } })
     const img = container.querySelector('img')!
     expect(img.alt).toBe('Avatar of Alice')

--- a/resources/assets/js/components/user/UserCard.spec.ts
+++ b/resources/assets/js/components/user/UserCard.spec.ts
@@ -15,7 +15,7 @@ describe('userCard.vue', () => {
   })
 
   const renderComponent = (user?: User) => {
-    user = user ?? h.factory('user')
+    user = user ?? h.factory('user').make()
 
     const rendered = h.render(Component, {
       props: {
@@ -30,7 +30,7 @@ describe('userCard.vue', () => {
   }
 
   it('shows the profile link for the current user', () => {
-    const user = h.factory.states('current')('user') as CurrentUser
+    const user = h.factory('user').state('current').make() as CurrentUser
     h.actingAsUser(user)
     renderComponent(user)
 
@@ -39,8 +39,8 @@ describe('userCard.vue', () => {
   })
 
   it('does not show profile link for other users', () => {
-    h.actingAsUser(h.factory.states('current')('user') as CurrentUser)
-    renderComponent(h.factory('user'))
+    h.actingAsUser(h.factory('user').state('current').make() as CurrentUser)
+    renderComponent(h.factory('user').make())
 
     expect(screen.queryByRole('link', { name: 'Your Profile' })).toBeNull()
   })
@@ -62,7 +62,7 @@ describe('userCard.vue', () => {
   })
 
   it('does not show the More Actions button for the current user', () => {
-    const user = h.factory.states('current')('user') as CurrentUser
+    const user = h.factory('user').state('current').make() as CurrentUser
     h.actingAsUser(user)
     renderComponent(user)
 

--- a/resources/assets/js/components/user/UserContextMenu.spec.ts
+++ b/resources/assets/js/components/user/UserContextMenu.spec.ts
@@ -11,7 +11,7 @@ describe('userContextMenu.vue', () => {
   const h = createHarness()
 
   const renderComponent = async (user?: User) => {
-    user = user || h.factory('user')
+    user = user || h.factory('user').make()
 
     const rendered = h.render(Component, {
       props: {
@@ -27,7 +27,7 @@ describe('userContextMenu.vue', () => {
 
   it('deletes user if confirmed', async () => {
     h.mock(DialogBoxStub.value, 'confirm').mockResolvedValue(true)
-    const { user } = await renderComponent(h.factory('user', { permissions: { edit: true, delete: true } }))
+    const { user } = await renderComponent(h.factory('user').make({ permissions: { edit: true, delete: true } }))
     const destroyMock = h.mock(userStore, 'destroy')
 
     await h.user.click(screen.getByText('Delete'))
@@ -37,7 +37,7 @@ describe('userContextMenu.vue', () => {
 
   it('does not delete user if not confirmed', async () => {
     h.mock(DialogBoxStub.value, 'confirm').mockResolvedValue(false)
-    await renderComponent(h.factory('user', { permissions: { edit: true, delete: true } }))
+    await renderComponent(h.factory('user').make({ permissions: { edit: true, delete: true } }))
     const destroyMock = h.mock(userStore, 'destroy')
 
     await h.user.click(screen.getByText('Delete'))
@@ -47,7 +47,9 @@ describe('userContextMenu.vue', () => {
 
   it('revokes invite for prospects', async () => {
     h.mock(DialogBoxStub.value, 'confirm').mockResolvedValue(true)
-    const prospect = factory.states('prospect')('user', { permissions: { edit: false, delete: true } })
+    const prospect = factory('user')
+      .state('prospect')
+      .make({ permissions: { edit: false, delete: true } })
     await renderComponent(prospect)
     const revokeMock = h.mock(invitationService, 'revoke')
 
@@ -58,7 +60,11 @@ describe('userContextMenu.vue', () => {
 
   it('does not revoke invite for prospects if not confirmed', async () => {
     h.mock(DialogBoxStub.value, 'confirm').mockResolvedValue(false)
-    await renderComponent(factory.states('prospect')('user', { permissions: { edit: false, delete: true } }))
+    await renderComponent(
+      factory('user')
+        .state('prospect')
+        .make({ permissions: { edit: false, delete: true } }),
+    )
     await h.user.click(screen.getByText('Revoke Invitation'))
     const revokeMock = h.mock(invitationService, 'revoke')
 
@@ -68,7 +74,7 @@ describe('userContextMenu.vue', () => {
   })
 
   it('respects the permissions', async () => {
-    await renderComponent(h.factory('user', { permissions: { edit: false, delete: false } }))
+    await renderComponent(h.factory('user').make({ permissions: { edit: false, delete: false } }))
     expect(screen.queryByText('Edit')).toBeNull()
     expect(screen.queryByText('Delete')).toBeNull()
   })

--- a/resources/assets/js/composables/useAuthorization.spec.ts
+++ b/resources/assets/js/composables/useAuthorization.spec.ts
@@ -7,7 +7,7 @@ describe('useAuthorization', () => {
   const h = createHarness()
 
   it('returns a ref to the current user', () => {
-    const user = h.factory('user', { name: 'Alice' }) as CurrentUser
+    const user = h.factory('user').make({ name: 'Alice' }) as CurrentUser
     userStore.state.current = user
 
     const { currentUser } = useAuthorization()
@@ -17,7 +17,7 @@ describe('useAuthorization', () => {
   it('reacts to user changes', () => {
     const { currentUser } = useAuthorization()
 
-    userStore.state.current = h.factory('user', { name: 'Bob' }) as CurrentUser
+    userStore.state.current = h.factory('user').make({ name: 'Bob' }) as CurrentUser
     expect(currentUser.value.name).toBe('Bob')
   })
 })

--- a/resources/assets/js/composables/useDragAndDrop.spec.ts
+++ b/resources/assets/js/composables/useDragAndDrop.spec.ts
@@ -20,7 +20,7 @@ describe('useDragAndDrop', () => {
   describe('useDraggable', () => {
     it('sets drag data for a single playable', () => {
       const { startDragging } = useDraggable('playables')
-      const song = h.factory('song')
+      const song = h.factory('song').make()
       const event = createDragEvent()
 
       startDragging(event, song)
@@ -33,7 +33,7 @@ describe('useDragAndDrop', () => {
 
     it('sets drag data for an album', () => {
       const { startDragging } = useDraggable('album')
-      const album = h.factory('album')
+      const album = h.factory('album').make()
       const event = createDragEvent()
 
       startDragging(event, album)
@@ -43,7 +43,7 @@ describe('useDragAndDrop', () => {
 
     it('sets drag data for an artist', () => {
       const { startDragging } = useDraggable('artist')
-      const artist = h.factory('artist')
+      const artist = h.factory('artist').make()
       const event = createDragEvent()
 
       startDragging(event, artist)
@@ -53,7 +53,7 @@ describe('useDragAndDrop', () => {
 
     it('sets drag data for a playlist', () => {
       const { startDragging } = useDraggable('playlist')
-      const playlist = h.factory('playlist')
+      const playlist = h.factory('playlist').make()
       const event = createDragEvent()
 
       startDragging(event, playlist)
@@ -67,12 +67,12 @@ describe('useDragAndDrop', () => {
     it('does nothing without dataTransfer', () => {
       const { startDragging } = useDraggable('playables')
       const event = { dataTransfer: null } as unknown as DragEvent
-      expect(() => startDragging(event, h.factory('song'))).not.toThrow()
+      expect(() => startDragging(event, h.factory('song').make())).not.toThrow()
     })
 
     it('creates a ghost drag image', () => {
       const { startDragging } = useDraggable('playables')
-      const song = h.factory('song')
+      const song = h.factory('song').make()
       const event = createDragEvent()
 
       startDragging(event, song)

--- a/resources/assets/js/composables/useEpisodeProgressTracking.spec.ts
+++ b/resources/assets/js/composables/useEpisodeProgressTracking.spec.ts
@@ -25,14 +25,14 @@ describe('useEpisodeProgressTracking', () => {
   })
 
   it('updates progress on tracked episode', async () => {
-    const podcast = h.factory('podcast')
+    const podcast = h.factory('podcast').make()
     podcast.state.current_episode = null
     podcast.state.progresses = {}
     mockResolve.mockResolvedValue(podcast)
 
     const { trackEpisode } = useEpisodeProgressTracking()
 
-    const episode = h.factory('episode')
+    const episode = h.factory('episode').make()
     trackEpisode(episode)
 
     eventBus.emit('EPISODE_PROGRESS_UPDATED', episode, 0.75)
@@ -46,8 +46,8 @@ describe('useEpisodeProgressTracking', () => {
   it('ignores progress for non-tracked episode', async () => {
     const { trackEpisode } = useEpisodeProgressTracking()
 
-    const tracked = h.factory('episode')
-    const other = h.factory('episode')
+    const tracked = h.factory('episode').make()
+    const other = h.factory('episode').make()
 
     trackEpisode(tracked)
 

--- a/resources/assets/js/composables/useLocalStorage.spec.ts
+++ b/resources/assets/js/composables/useLocalStorage.spec.ts
@@ -35,7 +35,7 @@ describe('useLocalStorage', () => {
   })
 
   it('namespaces keys with provided user id', () => {
-    const user = h.factory('user', { id: '99' })
+    const user = h.factory('user').make({ id: '99' })
     const { set } = useLocalStorage(true, user)
     set('volume', 80)
     expect(mockSet).toHaveBeenCalledWith('99::volume', 80)

--- a/resources/assets/js/composables/useLyrics.spec.ts
+++ b/resources/assets/js/composables/useLyrics.spec.ts
@@ -8,7 +8,7 @@ describe('useLyrics', () => {
 
   it('handles non-LRC lyrics', () => {
     const song = ref(
-      h.factory('song', {
+      h.factory('song').make({
         lyrics: 'This is a normal text\n without any LRC format',
       }),
     )
@@ -23,7 +23,7 @@ describe('useLyrics', () => {
 
   it('handles LRC format', () => {
     const song = ref(
-      h.factory('song', {
+      h.factory('song').make({
         lyrics: '[00:05.00]First line\n[00:12.00]Second line\n[00:21.00]Third line',
       }),
     )
@@ -43,7 +43,7 @@ describe('useLyrics', () => {
 
   it('handles empty lyrics', () => {
     const song = ref(
-      h.factory('song', {
+      h.factory('song').make({
         lyrics: '',
       }),
     )
@@ -58,7 +58,7 @@ describe('useLyrics', () => {
 
   it('assigns 00:00.00 timestamp first line if it has no timestamp', () => {
     const song = ref(
-      h.factory('song', {
+      h.factory('song').make({
         lyrics: 'First line without timestamp\n[00:12.00]Second line\n[00:21.00]Third line',
       }),
     )
@@ -70,7 +70,7 @@ describe('useLyrics', () => {
 
   it('assigns previous timestamp to last line if it has no timestamp', () => {
     const song = ref(
-      h.factory('song', {
+      h.factory('song').make({
         lyrics: '[00:12.00]First line\n[00:21.00]Second line\nLast line without timestamp',
       }),
     )
@@ -82,7 +82,7 @@ describe('useLyrics', () => {
 
   it('assigns an average timestamp to a line if it has no timestamp', () => {
     const song = ref(
-      h.factory('song', {
+      h.factory('song').make({
         lyrics: '[00:12.00]First line\nSecond line without timestamp\n[00:16.00]Last line',
       }),
     )

--- a/resources/assets/js/composables/useOfflinePlayback.spec.ts
+++ b/resources/assets/js/composables/useOfflinePlayback.spec.ts
@@ -62,7 +62,7 @@ describe('useOfflinePlayback', () => {
   })
 
   it('sends CACHE_AUDIO message to SW', () => {
-    const song = h.factory('song')
+    const song = h.factory('song').make()
     const sourceUrl = 'http://localhost/play/abc123?t=token'
     h.mock(playableStore, 'getSourceUrl').mockReturnValue(sourceUrl)
 
@@ -76,7 +76,7 @@ describe('useOfflinePlayback', () => {
   })
 
   it('sends DELETE_AUDIO_CACHE message to SW', () => {
-    const song = h.factory('song')
+    const song = h.factory('song').make()
     const sourceUrl = 'http://localhost/play/abc123?t=token'
     h.mock(playableStore, 'getSourceUrl').mockReturnValue(sourceUrl)
 
@@ -90,7 +90,7 @@ describe('useOfflinePlayback', () => {
   })
 
   it('tracks caching progress from SW messages', () => {
-    const song = h.factory('song')
+    const song = h.factory('song').make()
 
     cachingProgress.value.set(song.id, 0)
     expect(isCaching(song)).toBe(true)
@@ -107,7 +107,7 @@ describe('useOfflinePlayback', () => {
   })
 
   it('marks song as cached on CACHE_AUDIO_COMPLETE and persists to manifest', () => {
-    const song = h.factory('song')
+    const song = h.factory('song').make()
     h.mock(playableStore, 'byId').mockReturnValue(song)
 
     cachingProgress.value.set(song.id, 0.5)
@@ -127,7 +127,7 @@ describe('useOfflinePlayback', () => {
   })
 
   it('removes song from cached set and manifest on DELETE_AUDIO_CACHE_COMPLETE', () => {
-    const song = h.factory('song')
+    const song = h.factory('song').make()
 
     cachedSongIds.value.add(song.id)
     expect(isCached(song)).toBe(true)
@@ -142,7 +142,7 @@ describe('useOfflinePlayback', () => {
   })
 
   it('cleans up progress on CACHE_AUDIO_ERROR', () => {
-    const song = h.factory('song')
+    const song = h.factory('song').make()
 
     cachingProgress.value.set(song.id, 0.3)
 
@@ -156,7 +156,7 @@ describe('useOfflinePlayback', () => {
   })
 
   it('sends GET_CACHE_STATUS message to SW', () => {
-    const songs = [h.factory('song'), h.factory('song')]
+    const songs = [h.factory('song').make(), h.factory('song').make()]
     const urls = ['http://localhost/play/a?t=t1', 'http://localhost/play/b?t=t2']
     h.mock(playableStore, 'getSourceUrl').mockReturnValueOnce(urls[0]).mockReturnValueOnce(urls[1])
 
@@ -169,7 +169,7 @@ describe('useOfflinePlayback', () => {
   })
 
   it('returns caching progress value', () => {
-    const song = h.factory('song')
+    const song = h.factory('song').make()
     expect(getCachingProgress(song)).toBe(0)
 
     cachingProgress.value.set(song.id, 0.75)
@@ -184,7 +184,7 @@ describe('useOfflinePlayback', () => {
   })
 
   it('clears all offline cache', async () => {
-    const song = h.factory('song')
+    const song = h.factory('song').make()
     const sourceUrl = 'http://localhost/play/x?t=token'
     h.mock(playableStore, 'byId').mockReturnValue(song)
     h.mock(playableStore, 'getSourceUrl').mockReturnValue(sourceUrl)

--- a/resources/assets/js/composables/usePlayableMenuMethods.spec.ts
+++ b/resources/assets/js/composables/usePlayableMenuMethods.spec.ts
@@ -28,7 +28,7 @@ describe('usePlayableMenuMethods', () => {
   })
 
   it('queues to bottom', async () => {
-    const songs = [h.factory('song')]
+    const songs = [h.factory('song').make()]
     const playables = ref<Playable[]>(songs)
     const close = vi.fn()
 
@@ -42,7 +42,7 @@ describe('usePlayableMenuMethods', () => {
   })
 
   it('queues to top', async () => {
-    const songs = [h.factory('song')]
+    const songs = [h.factory('song').make()]
     const playables = ref<Playable[]>(songs)
     const close = vi.fn()
 
@@ -55,7 +55,7 @@ describe('usePlayableMenuMethods', () => {
   })
 
   it('adds to favorites', async () => {
-    const songs = [h.factory('song')]
+    const songs = [h.factory('song').make()]
     const playables = ref<Playable[]>(songs)
     const close = vi.fn()
 
@@ -68,7 +68,7 @@ describe('usePlayableMenuMethods', () => {
   })
 
   it('opens new playlist modal', async () => {
-    const songs = [h.factory('song')]
+    const songs = [h.factory('song').make()]
     const playables = ref<Playable[]>(songs)
     const close = vi.fn()
 

--- a/resources/assets/js/composables/usePlaylistContentManagement.spec.ts
+++ b/resources/assets/js/composables/usePlaylistContentManagement.spec.ts
@@ -21,8 +21,8 @@ describe('usePlaylistContentManagement', () => {
   const h = createHarness()
 
   it('adds content to a playlist', async () => {
-    const playlist = h.factory('playlist', { is_smart: false })
-    const songs = [h.factory('song')]
+    const playlist = h.factory('playlist').make({ is_smart: false })
+    const songs = [h.factory('song').make()]
     const emitMock = h.mock(eventBus, 'emit')
     h.mock(playlistStore, 'addContent').mockResolvedValue(undefined)
 
@@ -34,8 +34,8 @@ describe('usePlaylistContentManagement', () => {
   })
 
   it('does not add to smart playlists', async () => {
-    const playlist = h.factory('playlist', { is_smart: true })
-    const songs = [h.factory('song')]
+    const playlist = h.factory('playlist').make({ is_smart: true })
+    const songs = [h.factory('song').make()]
     h.mock(playlistStore, 'addContent')
 
     const { addToPlaylist } = usePlaylistContentManagement()
@@ -45,8 +45,8 @@ describe('usePlaylistContentManagement', () => {
   })
 
   it('removes content from a playlist', async () => {
-    const playlist = h.factory('playlist', { is_smart: false })
-    const songs = [h.factory('song')]
+    const playlist = h.factory('playlist').make({ is_smart: false })
+    const songs = [h.factory('song').make()]
     const emitMock = h.mock(eventBus, 'emit')
     h.mock(playlistStore, 'removeContent').mockResolvedValue(undefined)
 

--- a/resources/assets/js/composables/usePolicies.spec.ts
+++ b/resources/assets/js/composables/usePolicies.spec.ts
@@ -8,35 +8,35 @@ describe('usePolicies', () => {
 
   it('allows admin to edit any song', () => {
     h.actingAsUser({
-      ...h.factory('user'),
+      ...h.factory('user').make(),
       abilities: ['manage songs'],
     } as CurrentUser)
 
     const { currentUserCan } = usePolicies()
-    const song = h.factory('song', { owner_id: '999' })
+    const song = h.factory('song').make({ owner_id: '999' })
 
     expect(currentUserCan.editSong(song)).toBe(true)
   })
 
   it('allows Plus user to edit their own songs', async () => {
-    const user = h.factory('user', { abilities: [] }) as CurrentUser
+    const user = h.factory('user').make({ abilities: [] }) as CurrentUser
     h.actingAsUser(user)
 
     await h.withPlusEdition(async () => {
       const { currentUserCan } = usePolicies()
-      const ownSong = h.factory('song', { owner_id: user.id })
+      const ownSong = h.factory('song').make({ owner_id: user.id })
 
       expect(currentUserCan.editSong(ownSong)).toBe(true)
     })
   })
 
   it('denies Plus user editing others songs', async () => {
-    const user = h.factory('user', { abilities: [] }) as CurrentUser
+    const user = h.factory('user').make({ abilities: [] }) as CurrentUser
     h.actingAsUser(user)
 
     await h.withPlusEdition(async () => {
       const { currentUserCan } = usePolicies()
-      const otherSong = h.factory('song', { owner_id: '999' })
+      const otherSong = h.factory('song').make({ owner_id: '999' })
 
       expect(currentUserCan.editSong(otherSong)).toBe(false)
     })
@@ -44,20 +44,20 @@ describe('usePolicies', () => {
 
   it('denies non-Plus non-admin editing songs', () => {
     h.actingAsUser({
-      ...h.factory('user'),
+      ...h.factory('user').make(),
       abilities: [],
     } as CurrentUser)
 
     commonStore.state.koel_plus.active = false
     const { currentUserCan } = usePolicies()
 
-    expect(currentUserCan.editSong(h.factory('song'))).toBe(false)
+    expect(currentUserCan.editSong(h.factory('song').make())).toBe(false)
   })
 
   it('reads the edit permission embedded in the playlist', () => {
     const { currentUserCan } = usePolicies()
-    const editable = h.factory('playlist', { permissions: { edit: true, delete: false } })
-    const readonly = h.factory('playlist', { permissions: { edit: false, delete: false } })
+    const editable = h.factory('playlist').make({ permissions: { edit: true, delete: false } })
+    const readonly = h.factory('playlist').make({ permissions: { edit: false, delete: false } })
 
     expect(currentUserCan.editPlaylist(editable)).toBe(true)
     expect(currentUserCan.editPlaylist(readonly)).toBe(false)
@@ -65,8 +65,8 @@ describe('usePolicies', () => {
 
   it('reads the delete permission embedded in the playlist', () => {
     const { currentUserCan } = usePolicies()
-    const deletable = h.factory('playlist', { permissions: { edit: false, delete: true } })
-    const readonly = h.factory('playlist', { permissions: { edit: false, delete: false } })
+    const deletable = h.factory('playlist').make({ permissions: { edit: false, delete: true } })
+    const readonly = h.factory('playlist').make({ permissions: { edit: false, delete: false } })
 
     expect(currentUserCan.deletePlaylist(deletable)).toBe(true)
     expect(currentUserCan.deletePlaylist(readonly)).toBe(false)
@@ -74,8 +74,8 @@ describe('usePolicies', () => {
 
   it('reads the edit permission embedded in the album', () => {
     const { currentUserCan } = usePolicies()
-    const editable = h.factory('album', { permissions: { edit: true } })
-    const readonly = h.factory('album', { permissions: { edit: false } })
+    const editable = h.factory('album').make({ permissions: { edit: true } })
+    const readonly = h.factory('album').make({ permissions: { edit: false } })
 
     expect(currentUserCan.editAlbum(editable)).toBe(true)
     expect(currentUserCan.editAlbum(readonly)).toBe(false)
@@ -83,8 +83,8 @@ describe('usePolicies', () => {
 
   it('reads the edit permission embedded in the artist', () => {
     const { currentUserCan } = usePolicies()
-    const editable = h.factory('artist', { permissions: { edit: true } })
-    const readonly = h.factory('artist', { permissions: { edit: false } })
+    const editable = h.factory('artist').make({ permissions: { edit: true } })
+    const readonly = h.factory('artist').make({ permissions: { edit: false } })
 
     expect(currentUserCan.editArtist(editable)).toBe(true)
     expect(currentUserCan.editArtist(readonly)).toBe(false)
@@ -92,7 +92,7 @@ describe('usePolicies', () => {
 
   it('checks manageSettings permission', () => {
     h.actingAsUser({
-      ...h.factory('user'),
+      ...h.factory('user').make(),
       abilities: ['manage settings'],
     } as CurrentUser)
 
@@ -102,7 +102,7 @@ describe('usePolicies', () => {
 
   it('checks manageUsers permission', () => {
     h.actingAsUser({
-      ...h.factory('user'),
+      ...h.factory('user').make(),
       abilities: [],
     } as CurrentUser)
 
@@ -111,7 +111,7 @@ describe('usePolicies', () => {
   })
 
   it('allows upload for Plus users', async () => {
-    const user = h.factory('user', { abilities: [] }) as CurrentUser
+    const user = h.factory('user').make({ abilities: [] }) as CurrentUser
     h.actingAsUser(user)
 
     await h.withPlusEdition(async () => {
@@ -122,7 +122,7 @@ describe('usePolicies', () => {
 
   it('allows upload for users with manage songs permission', () => {
     h.actingAsUser({
-      ...h.factory('user'),
+      ...h.factory('user').make(),
       abilities: ['manage songs'],
     } as CurrentUser)
 
@@ -132,8 +132,8 @@ describe('usePolicies', () => {
 
   it('reads the edit permission embedded in the user', () => {
     const { currentUserCan } = usePolicies()
-    const editable = h.factory('user', { permissions: { edit: true, delete: false } })
-    const readonly = h.factory('user', { permissions: { edit: false, delete: false } })
+    const editable = h.factory('user').make({ permissions: { edit: true, delete: false } })
+    const readonly = h.factory('user').make({ permissions: { edit: false, delete: false } })
 
     expect(currentUserCan.editUser(editable)).toBe(true)
     expect(currentUserCan.editUser(readonly)).toBe(false)
@@ -141,8 +141,8 @@ describe('usePolicies', () => {
 
   it('reads the delete permission embedded in the user', () => {
     const { currentUserCan } = usePolicies()
-    const deletable = h.factory('user', { permissions: { edit: false, delete: true } })
-    const readonly = h.factory('user', { permissions: { edit: false, delete: false } })
+    const deletable = h.factory('user').make({ permissions: { edit: false, delete: true } })
+    const readonly = h.factory('user').make({ permissions: { edit: false, delete: false } })
 
     expect(currentUserCan.deleteUser(deletable)).toBe(true)
     expect(currentUserCan.deleteUser(readonly)).toBe(false)
@@ -150,8 +150,8 @@ describe('usePolicies', () => {
 
   it('reads the edit permission embedded in the radio station', () => {
     const { currentUserCan } = usePolicies()
-    const editable = h.factory('radio-station', { permissions: { edit: true, delete: false } })
-    const readonly = h.factory('radio-station', { permissions: { edit: false, delete: false } })
+    const editable = h.factory('radio-station').make({ permissions: { edit: true, delete: false } })
+    const readonly = h.factory('radio-station').make({ permissions: { edit: false, delete: false } })
 
     expect(currentUserCan.editRadioStation(editable)).toBe(true)
     expect(currentUserCan.editRadioStation(readonly)).toBe(false)
@@ -159,8 +159,8 @@ describe('usePolicies', () => {
 
   it('reads the delete permission embedded in the radio station', () => {
     const { currentUserCan } = usePolicies()
-    const deletable = h.factory('radio-station', { permissions: { edit: false, delete: true } })
-    const readonly = h.factory('radio-station', { permissions: { edit: false, delete: false } })
+    const deletable = h.factory('radio-station').make({ permissions: { edit: false, delete: true } })
+    const readonly = h.factory('radio-station').make({ permissions: { edit: false, delete: false } })
 
     expect(currentUserCan.deleteRadioStation(deletable)).toBe(true)
     expect(currentUserCan.deleteRadioStation(readonly)).toBe(false)

--- a/resources/assets/js/remote/components/RemoteFooter.spec.ts
+++ b/resources/assets/js/remote/components/RemoteFooter.spec.ts
@@ -8,7 +8,7 @@ describe('remoteFooter.vue', () => {
   const h = createHarness()
 
   const renderComponent = (streamable?: Streamable) => {
-    streamable = streamable || h.factory('song')
+    streamable = streamable || h.factory('song').make()
 
     h.render(Component, {
       props: {
@@ -31,7 +31,7 @@ describe('remoteFooter.vue', () => {
 
   it('toggles like', async () => {
     const broadcastMock = h.mock(socketService, 'broadcast')
-    const playable = h.factory('song', { favorite: false })
+    const playable = h.factory('song').make({ favorite: false })
     renderComponent(playable)
 
     await h.user.click(screen.getByTestId('btn-toggle-favorite'))
@@ -61,7 +61,7 @@ describe('remoteFooter.vue', () => {
     ['starts', 'Stopped', 'Playing'],
   ])('%s playback', async (_, currentState, newState) => {
     const broadcastMock = h.mock(socketService, 'broadcast')
-    const playable = h.factory('episode', { playback_state: currentState })
+    const playable = h.factory('episode').make({ playback_state: currentState })
     renderComponent(playable)
 
     await h.user.click(screen.getByTestId('btn-toggle-playback'))

--- a/resources/assets/js/remote/components/StreamableDetails.spec.ts
+++ b/resources/assets/js/remote/components/StreamableDetails.spec.ts
@@ -23,7 +23,7 @@ describe('streamableDetails.vue', () => {
 
   it('renders a song', () => {
     const { html } = renderComponent(
-      h.factory('song', {
+      h.factory('song').make({
         title: 'Afraid to Shoot Strangers',
         album_name: 'Fear of the Dark',
         artist_name: 'Iron Maiden',
@@ -36,7 +36,7 @@ describe('streamableDetails.vue', () => {
 
   it('renders an episode', () => {
     const { html } = renderComponent(
-      h.factory('episode', {
+      h.factory('episode').make({
         title: 'Brahms Piano Concerto No. 1',
         podcast_title: 'The Sticky Notes podcast',
         podcast_author: 'Some random dudes',

--- a/resources/assets/js/services/QueuePlaybackService.spec.ts
+++ b/resources/assets/js/services/QueuePlaybackService.spec.ts
@@ -29,7 +29,7 @@ describe('playbackService', () => {
 
   const setCurrentSong = (song?: Playable) => {
     const playbackState = song?.playback_state ?? 'Playing'
-    const [synced] = playableStore.syncWithVault(song || h.factory('song'))
+    const [synced] = playableStore.syncWithVault(song || h.factory('song').make())
     synced.playback_state = playbackState
     queueStore.state.playables = reactive([synced])
     return synced
@@ -49,7 +49,7 @@ describe('playbackService', () => {
   ])(
     'when playCountRegistered is %s, current media time is %d, media duration is %d, then registerPlay() should be call %d times',
     (playCountRegistered, currentTime, duration, numberOfCalls) => {
-      const song = h.factory('song', {
+      const song = h.factory('song').make({
         play_count_registered: playCountRegistered,
         playback_state: 'Playing',
       })
@@ -127,7 +127,7 @@ describe('playbackService', () => {
     (preloaded, currentTime, duration, numberOfCalls) => {
       setCurrentSong()
       h.mock(playbackService, 'registerPlay')
-      h.setReadOnlyProperty(queueStore, 'next', h.factory('song', { preloaded }))
+      h.setReadOnlyProperty(queueStore, 'next', h.factory('song').make({ preloaded }))
 
       const mediaElement = playbackService.media
 
@@ -146,7 +146,7 @@ describe('playbackService', () => {
   it('registers play', () => {
     const recentlyPlayedStoreAddMock = h.mock(recentlyPlayedStore, 'add')
     const registerPlayMock = h.mock(playableStore, 'registerPlay')
-    const song = h.factory('song')
+    const song = h.factory('song').make()
 
     playbackService.registerPlay(song)
 
@@ -163,7 +163,7 @@ describe('playbackService', () => {
 
     const createElementMock = h.mock(document, 'createElement', audioElement)
     h.mock(playableStore, 'getSourceUrl').mockReturnValue('/foo?token=o5afd')
-    const song = h.factory('song')
+    const song = h.factory('song').make()
 
     playbackService.preload(song)
 
@@ -230,7 +230,7 @@ describe('playbackService', () => {
   })
 
   it('plays the previous playable', async () => {
-    const previousSong = h.factory('song')
+    const previousSong = h.factory('song').make()
     h.setReadOnlyProperty(playbackService.media, 'currentTime', 4)
     h.setReadOnlyProperty(playbackService, 'previous', previousSong)
     const playMock = h.mock(playbackService, 'play')
@@ -251,7 +251,7 @@ describe('playbackService', () => {
   })
 
   it('plays the next playable', async () => {
-    const nextSong = h.factory('song')
+    const nextSong = h.factory('song').make()
     h.setReadOnlyProperty(playbackService, 'next', nextSong)
     const playMock = h.mock(playbackService, 'play')
 
@@ -287,7 +287,7 @@ describe('playbackService', () => {
 
   it('resumes playback', async () => {
     const song = setCurrentSong(
-      h.factory('song', {
+      h.factory('song').make({
         playback_state: 'Paused',
       }),
     )
@@ -316,7 +316,7 @@ describe('playbackService', () => {
     ['resume', 'Paused'],
     ['pause', 'Playing'],
   ])('%ss playback if toggled when current playable playback state is %s', async (action, playbackState) => {
-    setCurrentSong(h.factory('song', { playback_state: playbackState }))
+    setCurrentSong(h.factory('song').make({ playback_state: playbackState }))
     const actionMock = h.mock(playbackService, action)
     await playbackService.toggle()
 
@@ -324,7 +324,7 @@ describe('playbackService', () => {
   })
 
   it('queues and plays songs without shuffling', async () => {
-    const songs = h.factory('song', 5)
+    const songs = h.factory('song').make(5)
     const replaceQueueMock = h.mock(queueStore, 'replaceQueueWith')
     const playMock = h.mock(playbackService, 'play')
     const firstSongInQueue = songs[0]
@@ -339,8 +339,8 @@ describe('playbackService', () => {
   })
 
   it('queues and plays songs with shuffling', async () => {
-    const songs = h.factory('song', 5)
-    const shuffledSongs = h.factory('song', 5)
+    const songs = h.factory('song').make(5)
+    const shuffledSongs = h.factory('song').make(5)
     const replaceQueueMock = h.mock(queueStore, 'replaceQueueWith')
     const playMock = h.mock(playbackService, 'play')
     const firstSongInQueue = songs[0]
@@ -356,7 +356,7 @@ describe('playbackService', () => {
   })
 
   it('plays first playable in queue', async () => {
-    const songs = h.factory('song', 5)
+    const songs = h.factory('song').make(5)
     queueStore.state.playables = songs
     h.setReadOnlyProperty(queueStore, 'first', songs[0])
     const playMock = h.mock(playbackService, 'play')

--- a/resources/assets/js/services/RadioPlaybackService.spec.ts
+++ b/resources/assets/js/services/RadioPlaybackService.spec.ts
@@ -19,9 +19,9 @@ describe('playbackService', () => {
   })
 
   it('plays a radio station', async () => {
-    const currentStation = h.factory('radio-station')
+    const currentStation = h.factory('radio-station').make()
     currentStation.playback_state = 'Playing'
-    const toBePlayedStation = h.factory('radio-station')
+    const toBePlayedStation = h.factory('radio-station').make()
     toBePlayedStation.playback_state = 'Stopped'
 
     radioStationStore.state.stations = [currentStation, toBePlayedStation]
@@ -43,7 +43,7 @@ describe('playbackService', () => {
   })
 
   it('pauses a radio station playback', async () => {
-    const currentStation = h.factory('radio-station')
+    const currentStation = h.factory('radio-station').make()
     currentStation.playback_state = 'Playing'
     radioStationStore.state.stations = [currentStation]
 

--- a/resources/assets/js/services/aiService.spec.ts
+++ b/resources/assets/js/services/aiService.spec.ts
@@ -50,7 +50,7 @@ describe('aiService', () => {
 
   describe('handleResponse', () => {
     it('handles play_songs action', () => {
-      const songs = h.factory('song', 3)
+      const songs = h.factory('song').make(3)
       const response: AiResponse = {
         message: 'Playing 3 songs.',
         action: 'play_songs',
@@ -70,7 +70,7 @@ describe('aiService', () => {
     })
 
     it('handles play_songs with queue flag', () => {
-      const songs = h.factory('song', 2)
+      const songs = h.factory('song').make(2)
       const response: AiResponse = {
         message: 'Added to queue.',
         action: 'play_songs',
@@ -86,7 +86,7 @@ describe('aiService', () => {
     })
 
     it('handles create_smart_playlist action', () => {
-      const playlist = h.factory('playlist')
+      const playlist = h.factory('playlist').make()
       h.mock(playlistStore, 'setupSmartPlaylist')
 
       const response: AiResponse = {
@@ -103,7 +103,7 @@ describe('aiService', () => {
     })
 
     it('handles add_radio_station action', () => {
-      const station = h.factory('radio-station')
+      const station = h.factory('radio-station').make()
       h.mock(radioStationStore, 'sync').mockReturnValue([station])
 
       const response: AiResponse = {
@@ -120,7 +120,7 @@ describe('aiService', () => {
     })
 
     it('handles add_to_favorites action', () => {
-      const songs = h.factory('song', 2)
+      const songs = h.factory('song').make(2)
       h.mock(playableStore, 'syncWithVault').mockReturnValue(songs)
 
       const response: AiResponse = {

--- a/resources/assets/js/services/authService.spec.ts
+++ b/resources/assets/js/services/authService.spec.ts
@@ -91,12 +91,12 @@ describe('authService', () => {
   })
 
   it('updates profile', async () => {
-    userStore.state.current = h.factory('user', {
+    userStore.state.current = h.factory('user').make({
       name: 'John Doe',
       email: 'john@doe.com',
     }) as CurrentUser
 
-    const updated = h.factory('user', {
+    const updated = h.factory('user').make({
       name: 'Jane Doe',
       email: 'jane@doe.com',
     })

--- a/resources/assets/js/services/downloadService.spec.ts
+++ b/resources/assets/js/services/downloadService.spec.ts
@@ -10,7 +10,7 @@ describe('downloadService', () => {
     const triggerMock = h.mock(downloadService, 'trigger')
     const checkMock = h.mock(downloadService, 'checkDownloadable')
 
-    await downloadService.fromPlayables([h.factory('song', { id: 'bar' })])
+    await downloadService.fromPlayables([h.factory('song').make({ id: 'bar' })])
 
     expect(checkMock).not.toHaveBeenCalled()
     expect(triggerMock).toHaveBeenCalledWith('songs?songs[]=bar')
@@ -20,7 +20,7 @@ describe('downloadService', () => {
     const triggerMock = h.mock(downloadService, 'trigger')
     h.mock(downloadService, 'checkDownloadable').mockResolvedValue(undefined)
 
-    const songs = [h.factory('song', { id: 'foo' }), h.factory('song', { id: 'bar' })]
+    const songs = [h.factory('song').make({ id: 'foo' }), h.factory('song').make({ id: 'bar' })]
     await downloadService.fromPlayables(songs)
 
     expect(triggerMock).toHaveBeenCalled()
@@ -30,7 +30,7 @@ describe('downloadService', () => {
     const triggerMock = h.mock(downloadService, 'trigger')
     h.mock(downloadService, 'checkDownloadable').mockRejectedValue(new DownloadLimitExceededError('Limit exceeded'))
 
-    const songs = [h.factory('song', { id: 'foo' }), h.factory('song', { id: 'bar' })]
+    const songs = [h.factory('song').make({ id: 'foo' }), h.factory('song').make({ id: 'bar' })]
 
     await expect(downloadService.fromPlayables(songs)).rejects.toThrow(DownloadLimitExceededError)
     expect(triggerMock).not.toHaveBeenCalled()
@@ -39,7 +39,7 @@ describe('downloadService', () => {
   it('downloads all by artist', async () => {
     const triggerMock = h.mock(downloadService, 'trigger')
     h.mock(downloadService, 'checkDownloadable').mockResolvedValue(undefined)
-    const artist = h.factory('artist')
+    const artist = h.factory('artist').make()
 
     await downloadService.fromArtist(artist)
 
@@ -49,7 +49,7 @@ describe('downloadService', () => {
   it('downloads all in album', async () => {
     const triggerMock = h.mock(downloadService, 'trigger')
     h.mock(downloadService, 'checkDownloadable').mockResolvedValue(undefined)
-    const album = h.factory('album')
+    const album = h.factory('album').make()
 
     await downloadService.fromAlbum(album)
 
@@ -59,7 +59,7 @@ describe('downloadService', () => {
   it('downloads a playlist', async () => {
     const triggerMock = h.mock(downloadService, 'trigger')
     h.mock(downloadService, 'checkDownloadable').mockResolvedValue(undefined)
-    const playlist = h.factory('playlist')
+    const playlist = h.factory('playlist').make()
 
     await downloadService.fromPlaylist(playlist)
 
@@ -69,7 +69,7 @@ describe('downloadService', () => {
   it('downloads favorites if available', async () => {
     const triggerMock = h.mock(downloadService, 'trigger')
     h.mock(downloadService, 'checkDownloadable').mockResolvedValue(undefined)
-    playableStore.state.favorites = h.factory('song', 5)
+    playableStore.state.favorites = h.factory('song').make(5)
 
     await downloadService.fromFavorites()
 
@@ -89,7 +89,7 @@ describe('downloadService', () => {
     const triggerMock = h.mock(downloadService, 'trigger')
     h.mock(downloadService, 'checkDownloadable').mockRejectedValue(new DownloadLimitExceededError('Limit exceeded'))
 
-    await expect(downloadService.fromAlbum(h.factory('album'))).rejects.toThrow(DownloadLimitExceededError)
+    await expect(downloadService.fromAlbum(h.factory('album').make())).rejects.toThrow(DownloadLimitExceededError)
     expect(triggerMock).not.toHaveBeenCalled()
   })
 })

--- a/resources/assets/js/services/encyclopediaService.spec.ts
+++ b/resources/assets/js/services/encyclopediaService.spec.ts
@@ -10,8 +10,8 @@ describe('encyclopediaService', () => {
   const h = createHarness()
 
   it('fetches the artist info', async () => {
-    const artist = artistStore.syncWithVault(h.factory('artist'))[0]
-    const artistInfo = h.factory('artist-info')
+    const artist = artistStore.syncWithVault(h.factory('artist').make())[0]
+    const artistInfo = h.factory('artist-info').make()
     const getMock = h.mock(http, 'get').mockResolvedValue(artistInfo)
     const hasCacheMock = h.mock(cache, 'has', false)
     const setCacheMock = h.mock(cache, 'set')
@@ -25,12 +25,12 @@ describe('encyclopediaService', () => {
   })
 
   it('gets the artist info from cache', async () => {
-    const artistInfo = h.factory('artist-info')
+    const artistInfo = h.factory('artist-info').make()
     const hasCacheMock = h.mock(cache, 'has', true)
     const getCacheMock = h.mock(cache, 'get', artistInfo)
     const getMock = h.mock(http, 'get')
 
-    const artist = artistStore.syncWithVault(h.factory('artist'))[0]
+    const artist = artistStore.syncWithVault(h.factory('artist').make())[0]
 
     expect(await encyclopediaService.fetchForArtist(artist)).toBe(artistInfo)
     expect(hasCacheMock).toHaveBeenCalledWith(['artist.info', artist.id])
@@ -39,8 +39,8 @@ describe('encyclopediaService', () => {
   })
 
   it('fetches the album info', async () => {
-    const album = albumStore.syncWithVault(h.factory('album'))[0]
-    const albumInfo = h.factory('album-info')
+    const album = albumStore.syncWithVault(h.factory('album').make())[0]
+    const albumInfo = h.factory('album-info').make()
     const getMock = h.mock(http, 'get').mockResolvedValue(albumInfo)
     const hasCacheMock = h.mock(cache, 'has', false)
     const setCacheMock = h.mock(cache, 'set')
@@ -54,8 +54,8 @@ describe('encyclopediaService', () => {
   })
 
   it('gets the album info from cache', async () => {
-    const album = albumStore.syncWithVault(h.factory('album'))[0]
-    const albumInfo = h.factory('album-info')
+    const album = albumStore.syncWithVault(h.factory('album').make())[0]
+    const albumInfo = h.factory('album-info').make()
     const hasCacheMock = h.mock(cache, 'has', true)
     const getCacheMock = h.mock(cache, 'get', albumInfo)
     const getMock = h.mock(http, 'get')

--- a/resources/assets/js/services/invitationService.spec.ts
+++ b/resources/assets/js/services/invitationService.spec.ts
@@ -31,7 +31,7 @@ describe('invitationService', () => {
   })
 
   it('invites users', async () => {
-    const prospects = factory.states('prospect')('user', 2)
+    const prospects = factory('user').state('prospect').make(2)
     const addMock = h.mock(userStore, 'add')
     const postMock = h.mock(http, 'post').mockResolvedValue(prospects)
 
@@ -46,7 +46,7 @@ describe('invitationService', () => {
   })
 
   it('revokes an invitation', async () => {
-    const user = factory.states('prospect')('user')
+    const user = factory('user').state('prospect').make()
     const removeMock = h.mock(userStore, 'remove')
     const deleteMock = h.mock(http, 'delete')
 

--- a/resources/assets/js/services/mediaBrowser.spec.ts
+++ b/resources/assets/js/services/mediaBrowser.spec.ts
@@ -11,8 +11,8 @@ describe('mediaBrowser', () => {
 
   it('browses a path', async () => {
     const path = 'foo/bar'
-    const folders = h.factory('folder', 2)
-    const songs = h.factory('song', 3)
+    const folders = h.factory('folder').make(2)
+    const songs = h.factory('song').make(3)
 
     const songPaginator: PaginatorResource<Song> = {
       data: songs,
@@ -44,8 +44,8 @@ describe('mediaBrowser', () => {
 
   it('get from cache when available', async () => {
     const path = 'foo/bar'
-    const folders = h.factory('folder', 2)
-    const songs = h.factory('song', 3)
+    const folders = h.factory('folder').make(2)
+    const songs = h.factory('song').make(3)
 
     const songPaginator: PaginatorResource<Song> = {
       data: songs,
@@ -80,8 +80,8 @@ describe('mediaBrowser', () => {
     const removeCacheMock = vi.spyOn(cache, 'remove')
 
     const path = 'foo/bar'
-    const folders = h.factory('folder', 2)
-    const songs = h.factory('song', 3)
+    const folders = h.factory('folder').make(2)
+    const songs = h.factory('song').make(3)
 
     const songPaginator: PaginatorResource<Song> = {
       data: songs,
@@ -154,7 +154,7 @@ describe('mediaBrowser', () => {
   })
 
   it('extracts media references', () => {
-    const items = [h.factory('song'), h.factory('folder', 1)]
+    const items = [h.factory('song').make(), h.factory('folder').make(1)]
 
     const references = mediaBrowser.extractMediaReferences(items)
 

--- a/resources/assets/js/services/playlistCollaborationService.spec.ts
+++ b/resources/assets/js/services/playlistCollaborationService.spec.ts
@@ -8,7 +8,7 @@ describe('playlistCollaborationService', () => {
   const h = createHarness()
 
   it('creates invite link', async () => {
-    const playlist = h.factory('playlist', { is_smart: false })
+    const playlist = h.factory('playlist').make({ is_smart: false })
     const postMock = h.mock(http, 'post').mockResolvedValue({ token: 'abc123' })
 
     const link = await service.createInviteLink(playlist)
@@ -18,7 +18,7 @@ describe('playlistCollaborationService', () => {
   })
 
   it('throws if trying to create invite link for smart playlist', async () => {
-    const playlist = h.factory('playlist', { is_smart: true })
+    const playlist = h.factory('playlist').make({ is_smart: true })
 
     await expect(service.createInviteLink(playlist)).rejects.toThrow('Smart playlists are not collaborative.')
   })
@@ -32,8 +32,8 @@ describe('playlistCollaborationService', () => {
   })
 
   it('fetches collaborators', async () => {
-    const playlist = h.factory('playlist')
-    const collaborators = h.factory('playlist-collaborator', 2)
+    const playlist = h.factory('playlist').make()
+    const collaborators = h.factory('playlist-collaborator').make(2)
     const getMock = h.mock(http, 'get').mockResolvedValue(collaborators)
 
     const received = await service.fetchCollaborators(playlist)
@@ -43,8 +43,8 @@ describe('playlistCollaborationService', () => {
   })
 
   it('removes collaborator', async () => {
-    const playlist = h.factory('playlist')
-    const collaborator = h.factory('playlist-collaborator')
+    const playlist = h.factory('playlist').make()
+    const collaborator = h.factory('playlist-collaborator').make()
     const deleteMock = h.mock(http, 'delete').mockResolvedValue({})
     const removeCacheMock = h.mock(cache, 'remove')
 

--- a/resources/assets/js/services/socketService.spec.ts
+++ b/resources/assets/js/services/socketService.spec.ts
@@ -49,7 +49,7 @@ describe('socketService', () => {
   })
 
   it('broadcasts events', () => {
-    const user = h.factory('user') as CurrentUser
+    const user = h.factory('user').make() as CurrentUser
     userStore.state.current = user
 
     socketService.broadcast('TEST_EVENT', { foo: 'bar' })
@@ -57,7 +57,7 @@ describe('socketService', () => {
   })
 
   it('listens to events', () => {
-    const user = h.factory('user') as CurrentUser
+    const user = h.factory('user').make() as CurrentUser
     userStore.state.current = user
 
     const cb = vi.fn()

--- a/resources/assets/js/services/uploadService.spec.ts
+++ b/resources/assets/js/services/uploadService.spec.ts
@@ -127,7 +127,7 @@ describe('uploadService', () => {
   })
 
   it('uploads a file successfully', async () => {
-    const result = { song: h.factory('song'), album: h.factory('album') }
+    const result = { song: h.factory('song').make(), album: h.factory('album').make() }
     mockPostWithProgress(result)
     const handleMock = h.mock(uploadService, 'handleUploadResult')
     const proceedMock = h.mock(uploadService, 'proceed')
@@ -154,7 +154,7 @@ describe('uploadService', () => {
   })
 
   it('sets progress during upload', async () => {
-    const result = { song: h.factory('song'), album: h.factory('album') }
+    const result = { song: h.factory('song').make(), album: h.factory('album').make() }
     postWithProgressMock.mockImplementation((_url: string, _data: FormData, onProgress: Function) => {
       onProgress({ loaded: 50, total: 100 })
       return { promise: Promise.resolve(result), abort: vi.fn() }
@@ -221,7 +221,7 @@ describe('uploadService', () => {
   })
 
   it('cleans up abort handle after successful upload', async () => {
-    const result = { song: h.factory('song'), album: h.factory('album') }
+    const result = { song: h.factory('song').make(), album: h.factory('album').make() }
     mockPostWithProgress(result)
     h.mock(uploadService, 'handleUploadResult')
     h.mock(uploadService, 'proceed')

--- a/resources/assets/js/services/youTubeService.spec.ts
+++ b/resources/assets/js/services/youTubeService.spec.ts
@@ -7,7 +7,7 @@ describe('youTubeService', () => {
   const h = createHarness()
 
   it('plays a video', () => {
-    const video = h.factory('you-tube-video', {
+    const video = h.factory('you-tube-video').make({
       id: {
         videoId: 'foo',
       },

--- a/resources/assets/js/stores/albumStore.spec.ts
+++ b/resources/assets/js/stores/albumStore.spec.ts
@@ -14,13 +14,13 @@ describe('albumStore', () => {
   })
 
   it('gets an album by ID', () => {
-    const album = h.factory('album')
+    const album = h.factory('album').make()
     albumStore.vault.set(album.id, album)
     expect(albumStore.byId(album.id)).toEqual(album)
   })
 
   it('removes albums by IDs', () => {
-    const albums = h.factory('album', 3)
+    const albums = h.factory('album').make(3)
     albums.forEach(album => albumStore.vault.set(album.id, album))
     albumStore.state.albums = albums
 
@@ -33,14 +33,14 @@ describe('albumStore', () => {
   })
 
   it('identifies an unknown album', () => {
-    const album = factory.states('unknown')('album')
+    const album = factory('album').state('unknown').make()
 
     expect(albumStore.isUnknown(album)).toBe(true)
-    expect(albumStore.isUnknown(h.factory('album'))).toBe(false)
+    expect(albumStore.isUnknown(h.factory('album').make())).toBe(false)
   })
 
   it('syncs albums with the vault', () => {
-    const album = h.factory('album', { name: 'IV' })
+    const album = h.factory('album').make({ name: 'IV' })
 
     albumStore.syncWithVault(album)
     expect(albumStore.vault.get(album.id)).toEqual(album)
@@ -54,7 +54,7 @@ describe('albumStore', () => {
 
   it('fetches an album thumbnail', async () => {
     const getMock = h.mock(http, 'get').mockResolvedValue({ thumbnailUrl: 'http://test/thumbnail.jpg' })
-    const album = h.factory('album')
+    const album = h.factory('album').make()
 
     const url = await albumStore.fetchThumbnail(album.id)
 
@@ -63,7 +63,7 @@ describe('albumStore', () => {
   })
 
   it('resolves an album', async () => {
-    const album = h.factory('album')
+    const album = h.factory('album').make()
     const getMock = h.mock(http, 'get').mockResolvedValueOnce(album)
 
     expect(await albumStore.resolve(album.id)).toEqual(album)
@@ -75,7 +75,7 @@ describe('albumStore', () => {
   })
 
   it('paginates', async () => {
-    const albums = h.factory('album', 3)
+    const albums = h.factory('album').make(3)
 
     h.mock(http, 'get').mockResolvedValueOnce({
       data: albums,
@@ -101,7 +101,7 @@ describe('albumStore', () => {
   })
 
   it('updates', async () => {
-    const album = h.factory('album', { name: 'IV' })
+    const album = h.factory('album').make({ name: 'IV' })
     albumStore.syncWithVault(album)
 
     const updateData = {
@@ -122,11 +122,11 @@ describe('albumStore', () => {
   })
 
   it('toggles favorite', async () => {
-    const album = h.factory('album', { favorite: false })
+    const album = h.factory('album').make({ favorite: false })
     albumStore.syncWithVault(album)
 
     const postMock = h.mock(http, 'post').mockResolvedValueOnce(
-      h.factory('favorite', {
+      h.factory('favorite').make({
         favoriteable_type: 'album',
         favoriteable_id: album.id,
       }),

--- a/resources/assets/js/stores/artistStore.spec.ts
+++ b/resources/assets/js/stores/artistStore.spec.ts
@@ -14,13 +14,13 @@ describe('artistStore', () => {
   })
 
   it('gets an artist by ID', () => {
-    const artist = h.factory('artist')
+    const artist = h.factory('artist').make()
     artistStore.vault.set(artist.id, artist)
     expect(artistStore.byId(artist.id)).toEqual(artist)
   })
 
   it('removes artists by IDs', () => {
-    const artists = h.factory('artist', 3)
+    const artists = h.factory('artist').make(3)
     artists.forEach(artist => artistStore.vault.set(artist.id, artist))
     artistStore.state.artists = artists
 
@@ -33,29 +33,29 @@ describe('artistStore', () => {
   })
 
   it('identifies an unknown artist', () => {
-    const artist = factory.states('unknown')('artist')
+    const artist = factory('artist').state('unknown').make()
 
     expect(artistStore.isUnknown(artist)).toBe(true)
     expect(artistStore.isUnknown(artist.name)).toBe(true)
-    expect(artistStore.isUnknown(h.factory('artist'))).toBe(false)
+    expect(artistStore.isUnknown(h.factory('artist').make())).toBe(false)
   })
 
   it('identifies the various artist', () => {
-    const artist = factory.states('various')('artist')
+    const artist = factory('artist').state('various').make()
 
     expect(artistStore.isVarious(artist)).toBe(true)
     expect(artistStore.isVarious(artist.name)).toBe(true)
-    expect(artistStore.isVarious(h.factory('artist'))).toBe(false)
+    expect(artistStore.isVarious(h.factory('artist').make())).toBe(false)
   })
 
   it('identifies a standard artist', () => {
-    expect(artistStore.isStandard(factory.states('unknown')('artist'))).toBe(false)
-    expect(artistStore.isStandard(factory.states('various')('artist'))).toBe(false)
-    expect(artistStore.isStandard(h.factory('artist'))).toBe(true)
+    expect(artistStore.isStandard(factory('artist').state('unknown').make())).toBe(false)
+    expect(artistStore.isStandard(factory('artist').state('various').make())).toBe(false)
+    expect(artistStore.isStandard(h.factory('artist').make())).toBe(true)
   })
 
   it('syncs artists with the vault', () => {
-    const artist = h.factory('artist', { name: 'Led Zeppelin' })
+    const artist = h.factory('artist').make({ name: 'Led Zeppelin' })
 
     artistStore.syncWithVault(artist)
     expect(artistStore.vault.get(artist.id)).toEqual(artist)
@@ -68,7 +68,7 @@ describe('artistStore', () => {
   })
 
   it('resolves an artist', async () => {
-    const artist = h.factory('artist')
+    const artist = h.factory('artist').make()
     const getMock = h.mock(http, 'get').mockResolvedValueOnce(artist)
 
     expect(await artistStore.resolve(artist.id)).toEqual(artist)
@@ -80,7 +80,7 @@ describe('artistStore', () => {
   })
 
   it('paginates', async () => {
-    const artists = h.factory('artist', 3)
+    const artists = h.factory('artist').make(3)
 
     h.mock(http, 'get').mockResolvedValueOnce({
       data: artists,
@@ -106,11 +106,11 @@ describe('artistStore', () => {
   })
 
   it('toggles favorite', async () => {
-    const artist = h.factory('artist', { favorite: false })
+    const artist = h.factory('artist').make({ favorite: false })
     artistStore.syncWithVault(artist)
 
     const postMock = h.mock(http, 'post').mockResolvedValueOnce(
-      h.factory('favorite', {
+      h.factory('favorite').make({
         favoriteable_type: 'artist',
         favoriteable_id: artist.id,
       }),
@@ -129,7 +129,7 @@ describe('artistStore', () => {
   })
 
   it('updates artist', async () => {
-    const artist = h.factory('artist', { name: 'Led Zeppelin' })
+    const artist = h.factory('artist').make({ name: 'Led Zeppelin' })
     artistStore.syncWithVault(artist)
 
     const updatedArtist = {

--- a/resources/assets/js/stores/commonStore.spec.ts
+++ b/resources/assets/js/stores/commonStore.spec.ts
@@ -15,7 +15,7 @@ describe('commonStore', () => {
   const h = createHarness()
 
   const createApiResponse = (overrides = {}) => ({
-    current_user: h.factory('user'),
+    current_user: h.factory('user').make(),
     playlists: [],
     playlist_folders: [],
     settings: {},

--- a/resources/assets/js/stores/embedService.spec.ts
+++ b/resources/assets/js/stores/embedService.spec.ts
@@ -1,21 +1,21 @@
 import { describe, expect, it } from 'vite-plus/test'
 import { createHarness } from '@/__tests__/TestHarness'
 import { http } from '@/services/http'
-import type { ModelToTypeMap } from '@/__tests__/factory'
+import type { Factoria } from 'factoria'
 import { embedService } from '@/stores/embedService'
 
 describe('embedService', async () => {
   const h = createHarness()
 
-  it.each<[keyof ModelToTypeMap, string]>([
+  it.each<[keyof Factoria.ModelRegistry, string]>([
     ['song', 'playable'],
     ['episode', 'playable'],
     ['album', 'album'],
     ['artist', 'artist'],
     ['playlist', 'playlist'],
   ])('resolves for %s', async (model, embeddableType) => {
-    const playable = h.factory(model) as Embeddable
-    const embed = h.factory('embed')
+    const playable = h.factory(model).make() as Embeddable
+    const embed = h.factory('embed').make()
     const postMock = h.mock(http, 'post').mockResolvedValue(embed)
 
     const resolved = await embedService.resolveForEmbeddable(playable)
@@ -42,7 +42,7 @@ describe('embedService', async () => {
   })
 
   it('get widget payload', async () => {
-    const embed = h.factory('embed')
+    const embed = h.factory('embed').make()
     const options: EmbedOptions = {
       theme: 'cat',
       layout: 'grid',
@@ -58,7 +58,7 @@ describe('embedService', async () => {
   })
 
   it('get widget payload with invalid theme', async () => {
-    const embed = h.factory('embed')
+    const embed = h.factory('embed').make()
     const options: EmbedOptions = {
       theme: 'invalid-theme',
       layout: 'full',

--- a/resources/assets/js/stores/genreStore.spec.ts
+++ b/resources/assets/js/stores/genreStore.spec.ts
@@ -7,14 +7,14 @@ describe('genreStore', () => {
   const h = createHarness()
 
   it('fetches all genres', async () => {
-    const genres = h.factory('genre', 3)
+    const genres = h.factory('genre').make(3)
     h.mock(http, 'get').mockResolvedValue(genres)
 
     expect(await genreStore.fetchAll()).toEqual(genres)
   })
 
   it('fetches a single genre', async () => {
-    const genre = h.factory('genre')
+    const genre = h.factory('genre').make()
     h.mock(http, 'get').mockResolvedValue(genre)
 
     expect(await genreStore.fetchOne(genre.id)).toEqual(genre)

--- a/resources/assets/js/stores/overviewStore.spec.ts
+++ b/resources/assets/js/stores/overviewStore.spec.ts
@@ -31,16 +31,16 @@ describe('overviewStore', () => {
     const artistSyncMock = h.mock(artistStore, 'syncWithVault')
     const refreshMock = h.mock(overviewStore, 'refreshPlayStats')
 
-    const mostPlayedSongs = h.factory('song', 6)
-    const mostPlayedAlbums = h.factory('album', 6)
-    const mostPlayedArtists = h.factory('artist', 6)
-    const recentlyAddedSongs = h.factory('song', 6)
-    const recentlyAddedAlbums = h.factory('album', 6)
-    const recentlyAddedArtists = h.factory('artist', 6)
-    const recentlyPlayedSongs = h.factory('song', 6)
-    const leastPlayedSongs = h.factory('song', 6)
-    const randomSongs = h.factory('song', 6)
-    const similarSongs = h.factory('song', 6)
+    const mostPlayedSongs = h.factory('song').make(6)
+    const mostPlayedAlbums = h.factory('album').make(6)
+    const mostPlayedArtists = h.factory('artist').make(6)
+    const recentlyAddedSongs = h.factory('song').make(6)
+    const recentlyAddedAlbums = h.factory('album').make(6)
+    const recentlyAddedArtists = h.factory('artist').make(6)
+    const recentlyPlayedSongs = h.factory('song').make(6)
+    const leastPlayedSongs = h.factory('song').make(6)
+    const randomSongs = h.factory('song').make(6)
+    const similarSongs = h.factory('song').make(6)
 
     const getMock = h.mock(http, 'get').mockResolvedValueOnce({
       most_played_songs: mostPlayedSongs,
@@ -72,8 +72,8 @@ describe('overviewStore', () => {
   })
 
   it('refreshes the store', () => {
-    const mostPlayedSongs = h.factory('song', 6)
-    const recentlyPlayedSongs = h.factory('song', 6)
+    const mostPlayedSongs = h.factory('song').make(6)
+    const recentlyPlayedSongs = h.factory('song').make(6)
 
     const mostPlayedSongsMock = h.mock(playableStore, 'getMostPlayedSongs', mostPlayedSongs)
     recentlyPlayedStore.excerptState.playables = recentlyPlayedSongs

--- a/resources/assets/js/stores/playableStore.spec.ts
+++ b/resources/assets/js/stores/playableStore.spec.ts
@@ -23,41 +23,44 @@ describe('playableStore', () => {
   })
 
   it('gets a song by ID', () => {
-    const song = reactive(h.factory('song', { id: 'foo' }))
+    const song = reactive(h.factory('song').make({ id: 'foo' }))
     playableStore.vault.set('foo', reactive(song))
-    playableStore.vault.set('bar', reactive(h.factory('song', { id: 'bar' })))
+    playableStore.vault.set('bar', reactive(h.factory('song').make({ id: 'bar' })))
 
     expect(playableStore.byId('foo')).toBe(song)
   })
 
   it('gets songs by IDs', () => {
-    const foo = reactive(h.factory('song', { id: 'foo' }))
-    const bar = reactive(h.factory('song', { id: 'bar' }))
+    const foo = reactive(h.factory('song').make({ id: 'foo' }))
+    const bar = reactive(h.factory('song').make({ id: 'bar' }))
     playableStore.vault.set('foo', foo)
     playableStore.vault.set('bar', bar)
-    playableStore.vault.set('baz', reactive(h.factory('song', { id: 'baz' })))
+    playableStore.vault.set('baz', reactive(h.factory('song').make({ id: 'baz' })))
 
     expect(playableStore.byIds(['foo', 'bar'])).toEqual([foo, bar])
   })
 
   it('gets formatted length', () => {
-    expect(playableStore.getFormattedLength(h.factory('song', { length: 123 }))).toBe('2 min 3 sec')
+    expect(playableStore.getFormattedLength(h.factory('song').make({ length: 123 }))).toBe('2 min 3 sec')
     expect(
-      playableStore.getFormattedLength([h.factory('song', { length: 122 }), h.factory('song', { length: 123 })]),
+      playableStore.getFormattedLength([
+        h.factory('song').make({ length: 122 }),
+        h.factory('song').make({ length: 123 }),
+      ]),
     ).toBe('4 min 5 sec')
   })
 
   it('gets songs by album', () => {
-    const songs = reactive(h.factory('song', 2, { album_id: 'iv' }))
+    const songs = reactive(h.factory('song').make({ album_id: 'iv' }, 2))
     playableStore.vault.set(songs[0].id, songs[0])
     playableStore.vault.set(songs[1].id, songs[1])
-    const album = h.factory('album', { id: 'iv' })
+    const album = h.factory('album').make({ id: 'iv' })
 
     expect(playableStore.byAlbum(album)).toEqual(songs)
   })
 
   it('resolves a song', async () => {
-    const song = h.factory('song')
+    const song = h.factory('song').make()
     const getMock = h.mock(http, 'get').mockResolvedValueOnce(song)
 
     expect(await playableStore.resolve(song.id)).toEqual(song)
@@ -69,8 +72,8 @@ describe('playableStore', () => {
   })
 
   it('matches a song by title', () => {
-    const song = h.factory('song', { title: 'An amazing song' })
-    const songs = [song, ...h.factory('song', 3)]
+    const song = h.factory('song').make({ title: 'An amazing song' })
+    const songs = [song, ...h.factory('song').make(3)]
 
     expect(playableStore.matchSongsByTitle('An amazing song', songs)).toEqual(song)
     expect(playableStore.matchSongsByTitle('An Amazing Song', songs)).toEqual(song)
@@ -78,10 +81,10 @@ describe('playableStore', () => {
   })
 
   it('registers a play', async () => {
-    const song = h.factory('song', { play_count: 42 })
+    const song = h.factory('song').make({ play_count: 42 })
 
     const postMock = h.mock(http, 'post').mockResolvedValueOnce(
-      h.factory('interaction', {
+      h.factory('interaction').make({
         song_id: song.id,
         play_count: 50,
       }),
@@ -93,7 +96,7 @@ describe('playableStore', () => {
   })
 
   it('scrobbles', async () => {
-    const song = h.factory('song')
+    const song = h.factory('song').make()
     song.play_start_time = 123456789
     const postMock = h.mock(http, 'post')
 
@@ -103,12 +106,12 @@ describe('playableStore', () => {
   })
 
   it('updates songs', async () => {
-    const songs = h.factory('song', 3)
+    const songs = h.factory('song').make(3)
 
     const result: SongUpdateResult = {
-      songs: h.factory('song', 3),
-      albums: h.factory('album', 2),
-      artists: h.factory('artist', 2),
+      songs: h.factory('song').make(3),
+      albums: h.factory('album').make(2),
+      artists: h.factory('artist').make(2),
       removed: {
         album_ids: ['iv'],
         artist_ids: ['led-zeppelin'],
@@ -144,7 +147,7 @@ describe('playableStore', () => {
 
   it('gets source URL', () => {
     commonStore.state.cdn_url = 'http://test/'
-    const song = h.factory('song')
+    const song = h.factory('song').make()
     h.mock(authService, 'getAudioToken', 'hadouken')
 
     expect(playableStore.getSourceUrl(song)).toBe(`http://test/play/${song.id}?t=hadouken`)
@@ -155,12 +158,12 @@ describe('playableStore', () => {
   })
 
   it('gets shareable URL', () => {
-    const song = h.factory('song')
+    const song = h.factory('song').make()
     expect(playableStore.getShareableUrl(song)).toBe(`http://test/#/songs/${song.id}`)
   })
 
   it('syncs new songs into the vault and applies playback state defaults', () => {
-    const song = h.factory('song', {
+    const song = h.factory('song').make({
       playback_state: null,
     })
 
@@ -177,7 +180,7 @@ describe('playableStore', () => {
   it('refreshes play stats when a vaulted song play count changes', async () => {
     const refreshMock = h.mock(overviewStore, 'refreshPlayStats')
 
-    const [synced] = playableStore.syncWithVault(h.factory('song', { play_count: 98 }))
+    const [synced] = playableStore.syncWithVault(h.factory('song').make({ play_count: 98 }))
     synced.play_count = 100
 
     await h.tick()
@@ -192,8 +195,8 @@ describe('playableStore', () => {
   })
 
   it('fetches for album', async () => {
-    const songs = h.factory('song', 3)
-    const album = h.factory('album')
+    const songs = h.factory('song').make(3)
+    const album = h.factory('album').make()
     const getMock = h.mock(http, 'get').mockResolvedValueOnce(songs)
     const syncMock = h.mock(playableStore, 'syncWithVault', songs)
 
@@ -204,8 +207,8 @@ describe('playableStore', () => {
   })
 
   it('fetches for artist', async () => {
-    const songs = h.factory('song', 3)
-    const artist = h.factory('artist')
+    const songs = h.factory('song').make(3)
+    const artist = h.factory('artist').make()
     const getMock = h.mock(http, 'get').mockResolvedValueOnce(songs)
     const syncMock = h.mock(playableStore, 'syncWithVault', songs)
 
@@ -216,8 +219,8 @@ describe('playableStore', () => {
   })
 
   it('fetches for playlist', async () => {
-    const songs = h.factory('song', 3)
-    const playlist = h.factory('playlist', { id: '966268ea-935d-4f63-a84e-180385376a78' })
+    const songs = h.factory('song').make(3)
+    const playlist = h.factory('playlist').make({ id: '966268ea-935d-4f63-a84e-180385376a78' })
     h.mock(playlistStore, 'byId').mockReturnValueOnce(playlist)
     const getMock = h.mock(http, 'get').mockResolvedValueOnce(songs)
     const syncMock = h.mock(playableStore, 'syncWithVault', songs)
@@ -231,8 +234,8 @@ describe('playableStore', () => {
   })
 
   it('fetches for playlist with cache', async () => {
-    const songs = h.factory('song', 3)
-    const playlist = h.factory('playlist')
+    const songs = h.factory('song').make(3)
+    const playlist = h.factory('playlist').make()
     h.mock(playlistStore, 'byId').mockReturnValueOnce(playlist)
     cache.set(['playlist.songs', playlist.id], songs)
 
@@ -246,8 +249,8 @@ describe('playableStore', () => {
   })
 
   it('fetches for playlist discarding cache', async () => {
-    const songs = h.factory('song', 3)
-    const playlist = h.factory('playlist')
+    const songs = h.factory('song').make(3)
+    const playlist = h.factory('playlist').make()
     h.mock(playlistStore, 'byId').mockReturnValueOnce(playlist)
     cache.set(['playlist.songs', playlist.id], songs)
 
@@ -261,7 +264,7 @@ describe('playableStore', () => {
   })
 
   it('paginates', async () => {
-    const songs = h.factory('song', 3)
+    const songs = h.factory('song').make(3)
 
     const getMock = h.mock(http, 'get').mockResolvedValueOnce({
       data: songs,
@@ -289,7 +292,7 @@ describe('playableStore', () => {
   })
 
   it('paginates for genre', async () => {
-    const songs = h.factory('song', 3)
+    const songs = h.factory('song').make(3)
     const reactiveSongs = reactive(songs)
 
     const getMock = h.mock(http, 'get').mockResolvedValueOnce({
@@ -320,7 +323,7 @@ describe('playableStore', () => {
   })
 
   it('fetches songs for genre to queue', async () => {
-    const songs = h.factory('song', 3)
+    const songs = h.factory('song').make(3)
     const reactiveSongs = reactive(songs)
 
     const getMock = h.mock(http, 'get').mockResolvedValueOnce(songs)
@@ -333,7 +336,7 @@ describe('playableStore', () => {
   })
 
   it('fetches random songs for genre to queue', async () => {
-    const songs = h.factory('song', 3)
+    const songs = h.factory('song').make(3)
     const reactiveSongs = reactive(songs)
 
     const getMock = h.mock(http, 'get').mockResolvedValueOnce(songs)
@@ -346,7 +349,7 @@ describe('playableStore', () => {
   })
 
   it('fetches favorites', async () => {
-    const songs = h.factory('song', 3)
+    const songs = h.factory('song').make(3)
     const getMock = h.mock(http, 'get').mockResolvedValue(songs)
 
     await playableStore.fetchFavorites()
@@ -356,12 +359,12 @@ describe('playableStore', () => {
   })
 
   it('toggles favorite to true', async () => {
-    playableStore.state.favorites = h.factory('song', 2, { favorite: true })
+    playableStore.state.favorites = h.factory('song').make({ favorite: true }, 2)
 
-    const song = h.factory('song', { favorite: false })
+    const song = h.factory('song').make({ favorite: false })
 
     const postMock = h.mock(http, 'post').mockResolvedValue(
-      h.factory('favorite', {
+      h.factory('favorite').make({
         favoriteable_type: 'playable',
         favoriteable_id: song.id,
       }),
@@ -379,7 +382,7 @@ describe('playableStore', () => {
   })
 
   it('toggles favorite to false', async () => {
-    playableStore.state.favorites = h.factory('song', 3, { favorite: true })
+    playableStore.state.favorites = h.factory('song').make({ favorite: true }, 3)
 
     const song = playableStore.state.favorites[0]
     const postMock = h.mock(http, 'post').mockResolvedValue(null)
@@ -397,7 +400,7 @@ describe('playableStore', () => {
   })
 
   it('adds to favorites', async () => {
-    const songs = h.factory('song', 3)
+    const songs = h.factory('song').make(3)
     const postMock = h.mock(http, 'post')
 
     await playableStore.favorite(songs)
@@ -409,7 +412,7 @@ describe('playableStore', () => {
   })
 
   it('removes from favorites', async () => {
-    const songs = h.factory('song', 3)
+    const songs = h.factory('song').make(3)
     const deleteMock = h.mock(http, 'delete')
 
     await playableStore.undoFavorite(songs)
@@ -421,10 +424,13 @@ describe('playableStore', () => {
   })
 
   it('syncs album properties', () => {
-    const album = h.factory('album')
-    const songs = h.factory('song', 3, {
-      album_id: album.id,
-    })
+    const album = h.factory('album').make()
+    const songs = h.factory('song').make(
+      {
+        album_id: album.id,
+      },
+      3,
+    )
 
     playableStore.syncWithVault(songs)
 
@@ -440,15 +446,21 @@ describe('playableStore', () => {
   })
 
   it('syncs artist properties', () => {
-    const artist = h.factory('artist')
+    const artist = h.factory('artist').make()
 
-    const songsFromArtist = h.factory('song', 3, {
-      artist_id: artist.id,
-    })
+    const songsFromArtist = h.factory('song').make(
+      {
+        artist_id: artist.id,
+      },
+      3,
+    )
 
-    const songsContributedByArtist = h.factory('song', 2, {
-      album_artist_id: artist.id,
-    })
+    const songsContributedByArtist = h.factory('song').make(
+      {
+        album_artist_id: artist.id,
+      },
+      2,
+    )
 
     playableStore.syncWithVault([...songsFromArtist, ...songsContributedByArtist])
 

--- a/resources/assets/js/stores/playlistFolderStore.spec.ts
+++ b/resources/assets/js/stores/playlistFolderStore.spec.ts
@@ -31,8 +31,8 @@ describe('playlistFolderStore', () => {
   })
 
   it('initializes with sorted folders', () => {
-    const zebra = h.factory('playlist-folder', { name: 'Zebra' })
-    const alpha = h.factory('playlist-folder', { name: 'Alpha' })
+    const zebra = h.factory('playlist-folder').make({ name: 'Zebra' })
+    const alpha = h.factory('playlist-folder').make({ name: 'Alpha' })
 
     playlistFolderStore.init([zebra, alpha])
 
@@ -41,8 +41,8 @@ describe('playlistFolderStore', () => {
   })
 
   it('finds folder by id', () => {
-    const rock = h.factory('playlist-folder', { name: 'Rock' })
-    const jazz = h.factory('playlist-folder', { name: 'Jazz' })
+    const rock = h.factory('playlist-folder').make({ name: 'Rock' })
+    const jazz = h.factory('playlist-folder').make({ name: 'Jazz' })
 
     playlistFolderStore.init([rock, jazz])
 
@@ -55,10 +55,10 @@ describe('playlistFolderStore', () => {
   })
 
   it('stores a new folder via API and adds sorted', async () => {
-    const alpha = h.factory('playlist-folder', { name: 'Alpha' })
+    const alpha = h.factory('playlist-folder').make({ name: 'Alpha' })
     playlistFolderStore.init([alpha])
 
-    const beta = h.factory('playlist-folder', { name: 'Beta' })
+    const beta = h.factory('playlist-folder').make({ name: 'Beta' })
     vi.mocked(http.post).mockResolvedValue(beta)
 
     const folder = await playlistFolderStore.store('Beta')
@@ -71,10 +71,10 @@ describe('playlistFolderStore', () => {
   })
 
   it('deletes a folder and unlinks playlists', async () => {
-    const folder = h.factory('playlist-folder', { name: 'Rock' })
+    const folder = h.factory('playlist-folder').make({ name: 'Rock' })
     playlistFolderStore.init([folder])
 
-    const playlist = h.factory('playlist', { folder_id: folder.id })
+    const playlist = h.factory('playlist').make({ folder_id: folder.id })
     vi.mocked(playlistStore.byFolder).mockReturnValue([playlist])
     vi.mocked(http.delete).mockResolvedValue({})
 
@@ -86,7 +86,7 @@ describe('playlistFolderStore', () => {
   })
 
   it('renames a folder', async () => {
-    const folder = h.factory('playlist-folder', { name: 'Old' })
+    const folder = h.factory('playlist-folder').make({ name: 'Old' })
     playlistFolderStore.init([folder])
     vi.mocked(http.put).mockResolvedValue({})
 
@@ -97,8 +97,8 @@ describe('playlistFolderStore', () => {
   })
 
   it('adds a playlist to folder', async () => {
-    const folder = h.factory('playlist-folder')
-    const playlist = h.factory('playlist', { folder_id: null })
+    const folder = h.factory('playlist-folder').make()
+    const playlist = h.factory('playlist').make({ folder_id: null })
     vi.mocked(http.post).mockResolvedValue({})
 
     await playlistFolderStore.addPlaylistToFolder(folder, playlist)
@@ -108,8 +108,8 @@ describe('playlistFolderStore', () => {
   })
 
   it('removes a playlist from folder', async () => {
-    const folder = h.factory('playlist-folder')
-    const playlist = h.factory('playlist', { folder_id: folder.id })
+    const folder = h.factory('playlist-folder').make()
+    const playlist = h.factory('playlist').make({ folder_id: folder.id })
     vi.mocked(http.delete).mockResolvedValue({})
 
     await playlistFolderStore.removePlaylistFromFolder(folder, playlist)
@@ -120,9 +120,9 @@ describe('playlistFolderStore', () => {
 
   it('sorts folders alphabetically', () => {
     const sorted = playlistFolderStore.sort([
-      h.factory('playlist-folder', { name: 'Zebra' }),
-      h.factory('playlist-folder', { name: 'Alpha' }),
-      h.factory('playlist-folder', { name: 'Middle' }),
+      h.factory('playlist-folder').make({ name: 'Zebra' }),
+      h.factory('playlist-folder').make({ name: 'Alpha' }),
+      h.factory('playlist-folder').make({ name: 'Middle' }),
     ])
 
     expect(sorted.map(f => f.name)).toEqual(['Alpha', 'Middle', 'Zebra'])

--- a/resources/assets/js/stores/playlistStore.spec.ts
+++ b/resources/assets/js/stores/playlistStore.spec.ts
@@ -71,7 +71,7 @@ describe('playlistStore', () => {
   })
 
   it('sets up a smart playlist with properly unserialized rules', () => {
-    const playlist = h.factory('playlist', {
+    const playlist = h.factory('playlist').make({
       is_smart: true,
       rules: serializedRuleGroups as unknown as SmartPlaylistRuleGroup[],
     })
@@ -82,9 +82,9 @@ describe('playlistStore', () => {
   })
 
   it('stores a playlist', async () => {
-    const songs = h.factory('song', 3)
-    const playlist = h.factory('playlist')
-    const folder = h.factory('playlist-folder')
+    const songs = h.factory('song').make(3)
+    const playlist = h.factory('playlist').make()
+    const folder = h.factory('playlist-folder').make()
     const postMock = h.mock(http, 'post').mockResolvedValue(playlist)
     h.mock(playlistStore, 'serializeSmartPlaylistRulesForStorage', null)
 
@@ -111,9 +111,9 @@ describe('playlistStore', () => {
   })
 
   it('deletes a playlist', async () => {
-    const playlist = h.factory('playlist')
+    const playlist = h.factory('playlist').make()
     const deleteMock = h.mock(http, 'delete')
-    playlistStore.state.playlists = [h.factory('playlist'), playlist]
+    playlistStore.state.playlists = [h.factory('playlist').make(), playlist]
 
     await playlistStore.delete(playlist)
 
@@ -123,8 +123,8 @@ describe('playlistStore', () => {
   })
 
   it('adds songs to a playlist', async () => {
-    const playlist = h.factory('playlist')
-    const songs = h.factory('song', 3)
+    const playlist = h.factory('playlist').make()
+    const songs = h.factory('song').make(3)
     const postMock = h.mock(http, 'post').mockResolvedValue(playlist)
     const removeMock = h.mock(cache, 'remove')
 
@@ -138,8 +138,8 @@ describe('playlistStore', () => {
   })
 
   it('removes songs from a playlist', async () => {
-    const playlist = h.factory('playlist')
-    const songs = h.factory('song', 3)
+    const playlist = h.factory('playlist').make()
+    const songs = h.factory('song').make(3)
     const deleteMock = h.mock(http, 'delete').mockResolvedValue(playlist)
     const removeMock = h.mock(cache, 'remove')
 
@@ -153,20 +153,20 @@ describe('playlistStore', () => {
   })
 
   it('does not modify a smart playlist content', async () => {
-    const playlist = factory.states('smart')('playlist')
+    const playlist = factory('playlist').state('smart').make()
     const postMock = h.mock(http, 'post')
 
-    await playlistStore.addContent(playlist, h.factory('song', 3))
+    await playlistStore.addContent(playlist, h.factory('song').make(3))
     expect(postMock).not.toHaveBeenCalled()
 
-    await playlistStore.removeContent(playlist, h.factory('song', 3))
+    await playlistStore.removeContent(playlist, h.factory('song').make(3))
     expect(postMock).not.toHaveBeenCalled()
   })
 
   it('updates a standard playlist', async () => {
-    const playlist = h.factory('playlist')
+    const playlist = h.factory('playlist').make()
     playlistStore.state.playlists = [playlist]
-    const folder = h.factory('playlist-folder')
+    const folder = h.factory('playlist-folder').make()
 
     const putMock = h.mock(http, 'put').mockResolvedValue(playlist)
 
@@ -187,9 +187,9 @@ describe('playlistStore', () => {
   })
 
   it('updates a smart playlist', async () => {
-    const playlist = factory.states('smart')('playlist')
+    const playlist = factory('playlist').state('smart').make()
     playlistStore.state.playlists = [playlist]
-    const rules = h.factory('smart-playlist-rule-group', 2)
+    const rules = h.factory('smart-playlist-rule-group').make(2)
     const serializeMock = h.mock(playlistStore, 'serializeSmartPlaylistRulesForStorage', ['Whatever'])
     const putMock = h.mock(http, 'put').mockResolvedValue(playlist)
     const removeMock = h.mock(cache, 'remove')

--- a/resources/assets/js/stores/podcastStore.spec.ts
+++ b/resources/assets/js/stores/podcastStore.spec.ts
@@ -11,7 +11,7 @@ describe('podcastStore', () => {
   })
 
   it('gets a podcast by id', () => {
-    const podcast = h.factory('podcast')
+    const podcast = h.factory('podcast').make()
     podcastStore.state.podcasts.push(podcast)
 
     const foundPodcast = podcastStore.byId(podcast.id)
@@ -19,7 +19,7 @@ describe('podcastStore', () => {
   })
 
   it('resolves to a local podcast if available', async () => {
-    const podcast = h.factory('podcast')
+    const podcast = h.factory('podcast').make()
     podcastStore.state.podcasts.push(podcast)
 
     const resolvedPodcast = await podcastStore.resolve(podcast.id)
@@ -27,7 +27,7 @@ describe('podcastStore', () => {
   })
 
   it('fetches a podcast by id if not found locally', async () => {
-    const podcast = h.factory('podcast')
+    const podcast = h.factory('podcast').make()
     const getMock = h.mock(podcastStore, 'fetchOne').mockResolvedValue(podcast)
 
     const resolvedPodcast = await podcastStore.resolve(podcast.id)
@@ -36,7 +36,7 @@ describe('podcastStore', () => {
   })
 
   it('stores a new podcast', async () => {
-    const podcast = h.factory('podcast')
+    const podcast = h.factory('podcast').make()
     const postMock = h.mock(http, 'post').mockResolvedValue(podcast)
 
     const storedPodcast = await podcastStore.store('https://example.com/podcast')
@@ -46,7 +46,7 @@ describe('podcastStore', () => {
   })
 
   it('fetches all podcasts', async () => {
-    const podcasts = h.factory('podcast', 3)
+    const podcasts = h.factory('podcast').make(3)
     const getMock = h.mock(http, 'get').mockResolvedValue(podcasts)
 
     await podcastStore.fetchAll()
@@ -56,7 +56,7 @@ describe('podcastStore', () => {
   })
 
   it('fetches favorite podcasts only', async () => {
-    const podcasts = h.factory('podcast', 3)
+    const podcasts = h.factory('podcast').make(3)
     const getMock = h.mock(http, 'get').mockResolvedValue(podcasts)
 
     await podcastStore.fetchAll(true)
@@ -66,7 +66,7 @@ describe('podcastStore', () => {
   })
 
   it('fetches a single podcast', async () => {
-    const podcast = h.factory('podcast')
+    const podcast = h.factory('podcast').make()
     const getMock = h.mock(http, 'get').mockResolvedValue(podcast)
 
     const fetchedPodcast = await podcastStore.fetchOne(podcast.id)
@@ -76,7 +76,7 @@ describe('podcastStore', () => {
   })
 
   it('unsubscribes from a podcast', async () => {
-    const podcast = h.factory('podcast')
+    const podcast = h.factory('podcast').make()
     podcastStore.state.podcasts.push(podcast)
     const deleteMock = h.mock(http, 'delete').mockResolvedValue({})
 
@@ -87,7 +87,7 @@ describe('podcastStore', () => {
   })
 
   it('resets the podcast store', () => {
-    podcastStore.state.podcasts.push(...h.factory('podcast', 3))
+    podcastStore.state.podcasts.push(...h.factory('podcast').make(3))
 
     podcastStore.reset()
 
@@ -95,11 +95,11 @@ describe('podcastStore', () => {
   })
 
   it('toggles a podcast favorite status', async () => {
-    const podcast = h.factory('podcast', { favorite: false })
+    const podcast = h.factory('podcast').make({ favorite: false })
     podcastStore.state.podcasts.push(podcast)
 
     const postMock = h.mock(http, 'post').mockResolvedValueOnce(
-      h.factory('favorite', {
+      h.factory('favorite').make({
         favoriteable_type: 'podcast',
         favoriteable_id: podcast.id,
       }),

--- a/resources/assets/js/stores/preferenceStore.spec.ts
+++ b/resources/assets/js/stores/preferenceStore.spec.ts
@@ -9,7 +9,7 @@ describe('preferenceStore', () => {
   })
 
   it('sets preferences and saves the state', () => {
-    const user = h.factory('user')
+    const user = h.factory('user').make()
     user.preferences = defaultPreferences
     const mock = h.mock(http, 'patch')
     preferenceStore.set('volume', 5)

--- a/resources/assets/js/stores/queueStore.spec.ts
+++ b/resources/assets/js/stores/queueStore.spec.ts
@@ -11,7 +11,7 @@ describe('queueStore', () => {
   const h = createHarness({
     beforeEach: () => {
       playableStore.vault.clear()
-      songs = playableStore.syncWithVault(h.factory('song', 3)) as Song[]
+      songs = playableStore.syncWithVault(h.factory('song').make(3)) as Song[]
       queueStore.state.playables = reactive(songs)
     },
   })
@@ -23,7 +23,7 @@ describe('queueStore', () => {
   it('returns the last queued song', () => expect(queueStore.last).toEqual(songs[2]))
 
   it('queues to bottom', () => {
-    const song = h.factory('song')
+    const song = h.factory('song').make()
     const putMock = h.mock(http, 'put')
     queueStore.queue(song)
 
@@ -33,7 +33,7 @@ describe('queueStore', () => {
   })
 
   it('queues to top', () => {
-    const song = h.factory('song')
+    const song = h.factory('song').make()
     const putMock = h.mock(http, 'put')
     queueStore.queueToTop(song)
 
@@ -43,7 +43,7 @@ describe('queueStore', () => {
   })
 
   it('replaces the whole queue', () => {
-    const newSongs = h.factory('song', 2)
+    const newSongs = h.factory('song').make(2)
     const putMock = h.mock(http, 'put')
     queueStore.replaceQueueWith(newSongs)
 
@@ -101,7 +101,7 @@ describe('queueStore', () => {
   })
 
   it('fetches random songs to queue', async () => {
-    const songs = h.factory('song', 3)
+    const songs = h.factory('song').make(3)
     const getMock = h.mock(http, 'get').mockResolvedValue(songs)
     const syncMock = h.mock(playableStore, 'syncWithVault', songs)
     const putMock = h.mock(http, 'put')
@@ -115,7 +115,7 @@ describe('queueStore', () => {
   })
 
   it('fetches random songs to queue with a custom order', async () => {
-    const songs = h.factory('song', 3)
+    const songs = h.factory('song').make(3)
     const getMock = h.mock(http, 'get').mockResolvedValue(songs)
     const syncMock = h.mock(playableStore, 'syncWithVault', songs)
     const putMock = h.mock(http, 'put')

--- a/resources/assets/js/stores/radioStationStore.spec.ts
+++ b/resources/assets/js/stores/radioStationStore.spec.ts
@@ -15,20 +15,20 @@ describe('radioStationStore', () => {
   })
 
   it('gets a station by ID', () => {
-    store.state.stations = h.factory('radio-station', 3)
+    store.state.stations = h.factory('radio-station').make(3)
     const station = store.byId(store.state.stations[1].id)
     expect(station).toEqual(store.state.stations[1])
   })
 
   it('syncs stations', () => {
-    const stations = h.factory('radio-station', 3)
+    const stations = h.factory('radio-station').make(3)
     const synced = store.sync(stations)
 
     expect(synced).toHaveLength(3)
     expect(store.state.stations).toHaveLength(3)
     expect(store.state.stations[0]).toEqual(synced[0])
 
-    const updatedStation = h.factory('radio-station', { id: stations[0].id, name: 'Updated Station' })
+    const updatedStation = h.factory('radio-station').make({ id: stations[0].id, name: 'Updated Station' })
     const updatedSynced = store.sync(updatedStation)
     expect(updatedSynced).toHaveLength(1)
     expect(store.state.stations).toHaveLength(3)
@@ -37,14 +37,14 @@ describe('radioStationStore', () => {
 
   it('gets source URL', () => {
     commonStore.state.cdn_url = 'http://test/'
-    const station = h.factory('radio-station')
+    const station = h.factory('radio-station').make()
     h.mock(authService, 'getAudioToken', 'hadouken')
 
     expect(store.getSourceUrl(station)).toBe(`http://test/radio/stream/${station.id}?t=hadouken`)
   })
 
   it('gets the currently playing station', () => {
-    store.state.stations = h.factory('radio-station', 3)
+    store.state.stations = h.factory('radio-station').make(3)
     expect(store.current).toBeNull()
 
     store.state.stations[1].playback_state = 'Playing'
@@ -55,7 +55,7 @@ describe('radioStationStore', () => {
   })
 
   it('stores a new station', async () => {
-    const createdStation = h.factory('radio-station')
+    const createdStation = h.factory('radio-station').make()
     const postMock = h.mock(http, 'post').mockResolvedValue(createdStation)
     const syncMock = h.mock(store, 'sync').mockReturnValue([createdStation])
 
@@ -74,7 +74,7 @@ describe('radioStationStore', () => {
   })
 
   it.each([[true], [false]])('fetches all stations with favorites only set to %s', async favoritesOnly => {
-    const fetchedStations = h.factory('radio-station', 5)
+    const fetchedStations = h.factory('radio-station').make(5)
     const getMock = h.mock(http, 'get').mockResolvedValue(fetchedStations)
     const syncMock = h.mock(store, 'sync').mockReturnValue(fetchedStations)
 
@@ -86,7 +86,7 @@ describe('radioStationStore', () => {
   })
 
   it('updates a station', async () => {
-    const station = h.factory('radio-station')
+    const station = h.factory('radio-station').make()
 
     const updatedData = {
       url: 'https://test.com/new-stream',
@@ -107,7 +107,7 @@ describe('radioStationStore', () => {
   })
 
   it('deletes a station', async () => {
-    const station = h.factory('radio-station')
+    const station = h.factory('radio-station').make()
     store.state.stations.push(station)
 
     const deleteMock = h.mock(http, 'delete').mockResolvedValue(null)
@@ -119,7 +119,7 @@ describe('radioStationStore', () => {
   })
 
   it('fetches now-playing metadata', async () => {
-    const station = h.factory('radio-station')
+    const station = h.factory('radio-station').make()
     const getMock = h.mock(http, 'get').mockResolvedValue({
       stream_title: 'Artist - Song Title',
       updated_at: '2026-03-08T00:00:00.000Z',
@@ -134,7 +134,7 @@ describe('radioStationStore', () => {
   it('starts and stops polling', () => {
     vi.useFakeTimers()
 
-    const station = h.factory('radio-station')
+    const station = h.factory('radio-station').make()
     const fetchMock = h.mock(store, 'fetchNowPlaying').mockResolvedValue(undefined)
 
     store.startPolling(station)
@@ -158,7 +158,7 @@ describe('radioStationStore', () => {
   })
 
   it('toggles favorite status of a station', async () => {
-    const station = h.factory('radio-station', { favorite: false })
+    const station = h.factory('radio-station').make({ favorite: false })
     store.state.stations.push(station)
 
     const postMock = h.mock(http, 'post').mockResolvedValue({ id: station.id, type: 'radio-station' })

--- a/resources/assets/js/stores/recentlyPlayedStore.spec.ts
+++ b/resources/assets/js/stores/recentlyPlayedStore.spec.ts
@@ -8,7 +8,7 @@ describe('recentlyPlayedStore', () => {
   const h = createHarness()
 
   it('fetches the recently played songs', async () => {
-    const songs = h.factory('song', 3)
+    const songs = h.factory('song').make(3)
     const getMock = h.mock(http, 'get').mockResolvedValue(songs)
     const syncMock = h.mock(playableStore, 'syncWithVault', songs)
 
@@ -21,17 +21,17 @@ describe('recentlyPlayedStore', () => {
 
   it('fetches when attempting to add a new song and the state is empty', async () => {
     recentlyPlayedStore.state.playables = []
-    const songs = h.factory('song', 3)
+    const songs = h.factory('song').make(3)
     const fetchMock = h.mock(recentlyPlayedStore, 'fetch').mockResolvedValue(songs)
 
-    await recentlyPlayedStore.add(h.factory('song'))
+    await recentlyPlayedStore.add(h.factory('song').make())
 
     expect(fetchMock).toHaveBeenCalled()
   })
 
   it('adds a song to the state', async () => {
-    const newSong = h.factory('song')
-    const songs = h.factory('song', 10)
+    const newSong = h.factory('song').make()
+    const songs = h.factory('song').make(10)
     const exceptSongs = songs.slice(0, 6)
 
     // We don't want to keep the reference to the original songs
@@ -45,7 +45,7 @@ describe('recentlyPlayedStore', () => {
   })
 
   it('deduplicates when adding a song to the state', async () => {
-    const songs = h.factory('song', 10)
+    const songs = h.factory('song').make(10)
     const newSong = songs[1]
     const exceptSongs = songs.slice(0, 6)
 

--- a/resources/assets/js/stores/searchStore.spec.ts
+++ b/resources/assets/js/stores/searchStore.spec.ts
@@ -29,11 +29,11 @@ describe('searchStore', () => {
 
   it('performs an excerpt search', async () => {
     const result: ExcerptSearchResult = {
-      songs: h.factory('song', 3),
-      albums: h.factory('album', 3),
-      artists: h.factory('artist', 3),
-      podcasts: h.factory('podcast', 3),
-      radio_stations: h.factory('radio-station', 3),
+      songs: h.factory('song').make(3),
+      albums: h.factory('album').make(3),
+      artists: h.factory('artist').make(3),
+      podcasts: h.factory('podcast').make(3),
+      radio_stations: h.factory('radio-station').make(3),
     }
 
     const getMock = h.mock(http, 'get').mockResolvedValue(result)
@@ -54,7 +54,7 @@ describe('searchStore', () => {
   })
 
   it('performs a song search', async () => {
-    const songs = h.factory('song', 3)
+    const songs = h.factory('song').make(3)
 
     const getMock = h.mock(http, 'get').mockResolvedValue(songs)
     const syncMock = h.mock(playableStore, 'syncWithVault', songs)
@@ -68,7 +68,7 @@ describe('searchStore', () => {
   })
 
   it('resets the song result state', () => {
-    searchStore.state.playables = h.factory('song', 3)
+    searchStore.state.playables = h.factory('song').make(3)
     searchStore.resetPlayableResultState()
     expect(searchStore.state.playables).toEqual([])
   })

--- a/resources/assets/js/stores/themeStore.spec.ts
+++ b/resources/assets/js/stores/themeStore.spec.ts
@@ -49,7 +49,7 @@ describe('themeStore', () => {
   it('initializes the store with a custom theme', () => {
     const setThemeMock = h.mock(themeStore, 'setTheme')
 
-    const theme = h.factory('theme', {
+    const theme = h.factory('theme').make({
       properties: {
         '--color-fg': '#00ff00',
         '--color-bg': '#111111',
@@ -67,7 +67,7 @@ describe('themeStore', () => {
   })
 
   it('sets a theme', () => {
-    const theme = h.factory('theme', {
+    const theme = h.factory('theme').make({
       properties: {
         '--color-fg': '#ffffff',
         '--color-bg': '#000000',
@@ -87,7 +87,7 @@ describe('themeStore', () => {
   })
 
   it('gets a theme by id', () => {
-    const theme = h.factory('theme')
+    const theme = h.factory('theme').make()
     themeStore.all.push(theme)
     expect(themeStore.getThemeById(theme.id)).toEqual(theme)
   })
@@ -97,7 +97,7 @@ describe('themeStore', () => {
   })
 
   it('creates a custom theme', async () => {
-    const createdTheme = h.factory('theme')
+    const createdTheme = h.factory('theme').make()
     const postMock = h.mock(http, 'post').mockResolvedValueOnce(createdTheme)
 
     const data: ThemeData = {
@@ -117,7 +117,7 @@ describe('themeStore', () => {
   })
 
   it('fetches custom themes', async () => {
-    const customThemes = h.factory('theme', 5)
+    const customThemes = h.factory('theme').make(5)
     const getMock = h.mock(http, 'get').mockResolvedValueOnce(customThemes)
 
     await themeStore.fetchCustomThemes()
@@ -129,7 +129,7 @@ describe('themeStore', () => {
   })
 
   it('deletes a custom theme', async () => {
-    const customTheme = h.factory('theme')
+    const customTheme = h.factory('theme').make()
     themeStore.all.push(customTheme)
     const deleteMock = h.mock(http, 'delete')
     await themeStore.destroy(customTheme)

--- a/resources/assets/js/stores/userStore.spec.ts
+++ b/resources/assets/js/stores/userStore.spec.ts
@@ -14,7 +14,7 @@ describe('userStore', () => {
     },
   })
 
-  currentUser = h.factory.states('current')('user') as CurrentUser
+  currentUser = h.factory('user').state('current').make() as CurrentUser
 
   it('initializes with current user', () => {
     expect(userStore.current).toEqual(currentUser)
@@ -22,7 +22,7 @@ describe('userStore', () => {
   })
 
   it('syncs with vault', () => {
-    const user = h.factory('user')
+    const user = h.factory('user').make()
 
     expect(userStore.syncWithVault(user)).toEqual([user])
     expect(userStore.vault.size).toBe(2)
@@ -30,7 +30,7 @@ describe('userStore', () => {
   })
 
   it('fetches users', async () => {
-    const users = h.factory('user', 3)
+    const users = h.factory('user').make(3)
     const getMock = h.mock(http, 'get').mockResolvedValue(users)
 
     await userStore.fetch()
@@ -40,7 +40,7 @@ describe('userStore', () => {
   })
 
   it('gets user by id', () => {
-    const user = h.factory('user')
+    const user = h.factory('user').make()
     userStore.syncWithVault(user)
 
     expect(userStore.byId(user.id)).toEqual(user)
@@ -54,7 +54,7 @@ describe('userStore', () => {
       email: 'jane@doe.com',
     }
 
-    const user = h.factory('user', data)
+    const user = h.factory('user').make(data)
     const postMock = h.mock(http, 'post').mockResolvedValue(user)
 
     expect(await userStore.store(data)).toEqual(user)
@@ -64,7 +64,7 @@ describe('userStore', () => {
   })
 
   it('updates a user', async () => {
-    const user = h.factory('user')
+    const user = h.factory('user').make()
     userStore.state.users.push(...userStore.syncWithVault(user))
 
     const data: UpdateUserData = {
@@ -86,7 +86,7 @@ describe('userStore', () => {
   it('deletes a user', async () => {
     const deleteMock = h.mock(http, 'delete')
 
-    const user = h.factory('user')
+    const user = h.factory('user').make()
     userStore.state.users.push(...userStore.syncWithVault(user))
     expect(userStore.vault.has(user.id)).toBe(true)
 


### PR DESCRIPTION
## Summary

Migrates the spec suite to factoria's [v5 builder API](https://github.com/phanan/factoria/pull/20). Codemod-driven; 1474/1474 specs still pass.

## What changed

- `package.json` — `factoria ^4.0.1 → ^5.0.0`.
- `__tests__/factory/index.ts` — drops the v4-shape adapter wrapper. Now augments `Factoria.ModelRegistry` natively so `factory('user').make()` returns `User` without an explicit generic. Exposes `ModelFieldPair` for `it.each` parametric tests that need a `[model, field]` tuple narrowed to actual fields of the model.
- All `*.spec.ts` files (and `TestHarness.ts`, plus the factory definition files): call shapes rewritten via codemod —
  - `factory('m')` → `factory('m').make()`
  - `factory('m', N)` → `factory('m').make(N)`
  - `factory('m', { ... })` → `factory('m').make({ ... })`
  - `factory('m', N, { ... })` → `factory('m').make({ ... }, N)`
  - `factory.states('a', 'b')('m', ...)` → `factory('m').state('a', 'b').make(...)`
- Two hand-fixes for `factory(variableName)` patterns in `it.each` (codemod requires string-literal first arg).

## Why v5

- Per-builder state ends the v4 module-level state leak (`factory.states(...)` no longer bleeds across calls).
- Native `Factoria.ModelRegistry` augmentation replaces the local type-map shim.
- ESM-only, modern toolchain (TS 5, vitest 2, vite 5).

## Test plan

- [x] `pnpm test` — 1474/1474 pass against `factoria@5.0.0` from the npm registry