### PR TITLE
fix: properly move playlist between folders / out to root on update

### DIFF
--- a/app/Services/PlaylistService.php
+++ b/app/Services/PlaylistService.php
@@ -79,11 +79,15 @@ class PlaylistService
             // Detach from any folder owned by this user, then attach
             // to the target if one was provided. Covers move-in,
             // move-between, and move-to-root.
-            PlaylistFolder::query()
+            $existingFolderIds = PlaylistFolder::query()
                 ->where('user_id', $playlist->owner->id)
                 ->whereHas('playlists', static fn (Builder $query) => $query->where('id', $playlist->id))
-                ->get()
-                ->each(static fn (PlaylistFolder $folder) => $folder->playlists()->detach($playlist->id));
+                ->pluck('id')
+                ->all();
+
+            if ($existingFolderIds) {
+                $playlist->folders()->detach($existingFolderIds);
+            }
 
             if ($folderId) {
                 $playlist->folders()->attach($folderId);

--- a/app/Services/PlaylistService.php
+++ b/app/Services/PlaylistService.php
@@ -6,11 +6,13 @@ use App\Enums\Placement;
 use App\Exceptions\OperationNotApplicableForSmartPlaylistException;
 use App\Facades\License as LicenseFacade;
 use App\Models\Playlist;
+use App\Models\PlaylistFolder;
 use App\Models\Song as Playable;
 use App\Models\User;
 use App\Repositories\SongRepository;
 use App\Values\Playlist\PlaylistCreateData;
 use App\Values\Playlist\PlaylistUpdateData;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
@@ -73,9 +75,20 @@ class PlaylistService
 
         $folderId = $this->resolveFolderId($dto->folderId, $dto->folderName, $playlist->owner);
 
-        if ($folderId) {
-            $playlist->folders()->syncWithoutDetaching([$folderId]);
-        }
+        DB::transaction(static function () use ($playlist, $folderId): void {
+            // Detach from any folder owned by this user, then attach
+            // to the target if one was provided. Covers move-in,
+            // move-between, and move-to-root.
+            PlaylistFolder::query()
+                ->where('user_id', $playlist->owner->id)
+                ->whereHas('playlists', static fn (Builder $query) => $query->where('id', $playlist->id))
+                ->get()
+                ->each(static fn (PlaylistFolder $folder) => $folder->playlists()->detach($playlist->id));
+
+            if ($folderId) {
+                $playlist->folders()->attach($folderId);
+            }
+        });
 
         return $playlist->refresh();
     }

--- a/tests/Feature/PlaylistTest.php
+++ b/tests/Feature/PlaylistTest.php
@@ -152,6 +152,50 @@ class PlaylistTest extends TestCase
     }
 
     #[Test]
+    public function updatingPlaylistMovesItBetweenFolders(): void
+    {
+        $playlist = create_playlist();
+        $folderA = $playlist->owner->playlistFolders()->create(['name' => 'A']);
+        $folderB = $playlist->owner->playlistFolders()->create(['name' => 'B']);
+        $playlist->folders()->attach($folderA->id);
+
+        $this->putAs(
+            "api/playlists/{$playlist->id}",
+            [
+                'name' => $playlist->name,
+                'description' => '',
+                'folder_id' => $folderB->id,
+            ],
+            $playlist->owner,
+        )->assertJsonStructure(PlaylistResource::JSON_STRUCTURE);
+
+        $folder = app(PlaylistFolderService::class)->getFolderForPlaylist($playlist->refresh());
+        self::assertNotNull($folder);
+        self::assertSame($folderB->id, $folder->id);
+        self::assertCount(1, $playlist->folders()->where('user_id', $playlist->owner->id)->get());
+    }
+
+    #[Test]
+    public function updatingPlaylistWithNullFolderIdRemovesFromFolder(): void
+    {
+        $playlist = create_playlist();
+        $folder = $playlist->owner->playlistFolders()->create(['name' => 'A']);
+        $playlist->folders()->attach($folder->id);
+
+        $this->putAs(
+            "api/playlists/{$playlist->id}",
+            [
+                'name' => $playlist->name,
+                'description' => '',
+                'folder_id' => null,
+            ],
+            $playlist->owner,
+        )->assertJsonStructure(PlaylistResource::JSON_STRUCTURE);
+
+        self::assertNull(app(PlaylistFolderService::class)->getFolderForPlaylist($playlist->refresh()));
+    }
+
+    #[Test]
     public function createPlaylistWithoutCover(): void
     {
         /** @var PlaylistFolderService $playlistFolderService */


### PR DESCRIPTION
## Problem

`PlaylistService::updatePlaylist`'s folder block was:

```php
if ($folderId) {
    $playlist->folders()->syncWithoutDetaching([$folderId]);
}
```

Two issues with that:

- **Move between folders is broken.** `syncWithoutDetaching` only adds; the old folder relationship stays. A playlist moved from A to B ends up in both, and `getFolderForPlaylist` returns whichever the relationship query returns first — so the user sees inconsistent behavior.
- **Move to root is silently ignored.** A null/empty `folder_id` falls through the `if`, so the client can't remove a playlist from a folder via `PUT /api/playlists/:id`.

## Fix

Replace the block with a transactional detach-then-attach (mirroring the constraint `addPlaylistsToFolder` already enforces):

```php
DB::transaction(static function () use ($playlist, $folderId): void {
    PlaylistFolder::query()
        ->where('user_id', $playlist->owner->id)
        ->whereHas('playlists', static fn (Builder $q) => $q->where('id', $playlist->id))
        ->get()
        ->each(static fn (PlaylistFolder $f) => $f->playlists()->detach($playlist->id));

    if ($folderId) {
        $playlist->folders()->attach($folderId);
    }
});
```

Detach from any folder owned by the playlist's owner, then attach the new target if one was provided. Covers move-in, move-between, and move-to-root in one path.

## Tests

Two regression tests added to `tests/Feature/PlaylistTest.php`:

- `updatingPlaylistMovesItBetweenFolders` — playlist in folder A, PUT with `folder_id: B`, asserts it ends up only in B.
- `updatingPlaylistWithNullFolderIdRemovesFromFolder` — playlist in folder A, PUT with `folder_id: null`, asserts no folder.

Both fail against `master`; both pass after the fix. Full `PlaylistTest` class still green (23 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved playlist folder management: reliable moves between folders and explicit removal from folders.
  * Seamless transfer of playlists to another folder or back to root (no folder).
* **Tests**
  * Added feature tests verifying playlist moves between folders and removal from folders, plus API response structure checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->