### PR TITLE
chore: clarify radio-station public toggle label

### DIFF
--- a/resources/assets/js/components/radio/AddRadioStationForm.spec.ts
+++ b/resources/assets/js/components/radio/AddRadioStationForm.spec.ts
@@ -41,7 +41,7 @@ describe('addRadioStationForm.vue', () => {
 
     await waitFor(() => screen.getByRole('img'))
 
-    await h.user.click(screen.getByLabelText('Make this station public'))
+    await h.user.click(screen.getByLabelText('Accessible to all users'))
     await h.user.click(screen.getByRole('button', { name: 'Save' }))
 
     expect(storeMock).toHaveBeenCalledWith({

--- a/resources/assets/js/components/radio/AddRadioStationForm.vue
+++ b/resources/assets/js/components/radio/AddRadioStationForm.vue
@@ -26,7 +26,7 @@
       <FormRow>
         <label>
           <CheckBox v-model="data.is_public" name="is_public" />
-          <span class="ml-2">Make this station public</span>
+          <span class="ml-2">Accessible to all users</span>
         </label>
       </FormRow>
     </main>

--- a/resources/assets/js/components/radio/EditRadioStationForm.vue
+++ b/resources/assets/js/components/radio/EditRadioStationForm.vue
@@ -26,7 +26,7 @@
       <FormRow>
         <label>
           <CheckBox v-model="data.is_public" name="is_public" />
-          <span class="ml-2">Make this station public</span>
+          <span class="ml-2">Accessible to all users</span>
         </label>
       </FormRow>
     </main>


### PR DESCRIPTION
Replaces **Make this station public** on the Add/Edit Radio Station forms with **Accessible to all users**.

The previous wording was ambiguous (public to whom — the internet, the koel instance, anonymous users?). The new copy is unambiguous and matches the equivalent toggle in the mobile client (koel/player).

Updated:
- `AddRadioStationForm.vue`
- `EditRadioStationForm.vue`
- `AddRadioStationForm.spec.ts` (the test that grabs the label by text)

`pnpm test resources/assets/js/components/radio/AddRadioStationForm.spec.ts` is green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the wording of the radio station accessibility setting label from "Make this station public" to "Accessible to all users" across creation and editing forms for improved clarity.

* **Tests**
  * Updated test assertions to align with the new label text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->