### PR TITLE
fix: don't blank-page the app when GitHub is unreachable

### DIFF
--- a/app/Services/ApplicationInformationService.php
+++ b/app/Services/ApplicationInformationService.php
@@ -11,17 +11,22 @@ class ApplicationInformationService
         private readonly Client $client,
     ) {}
 
-    /**
-     * Get the latest version number of Koel from GitHub.
-     */
     public function getLatestVersionNumber(): string
     {
-        return rescue(function () {
-            return Cache::remember(cache_key('latest version number'), now()->addDay(), function (): string {
-                return json_decode(
-                    $this->client->get('https://api.github.com/repos/koel/koel/tags')->getBody(),
-                )[0]->name;
-            });
-        }) ?? koel_version();
+        return Cache::remember(
+            cache_key('latest version number'),
+            now()->addDay(),
+            fn (): string => (
+                rescue(
+                    fn () => json_decode(
+                        $this->client->get('https://api.github.com/repos/koel/koel/tags', [
+                            'connect_timeout' => 3,
+                            'timeout' => 5,
+                        ])->getBody(),
+                    )[0]->name,
+                    report: false,
+                ) ?? koel_version()
+            ),
+        );
     }
 }

--- a/resources/assets/js/components/utils/AppInitializer.vue
+++ b/resources/assets/js/components/utils/AppInitializer.vue
@@ -19,6 +19,7 @@ const emits = defineEmits<{
 
 const { showOverlay, hideOverlay } = useOverlay()
 const { currentUser } = useAuthorization()
+const { handleHttpError } = useErrorHandler()
 
 /**
  * Request for notification permission if it's not provided and the user is OK with notifications.
@@ -64,7 +65,7 @@ onMounted(async () => {
 
     emits('success')
   } catch (error: unknown) {
-    useErrorHandler().handleHttpError(error)
+    handleHttpError(error)
     emits('error', error)
   } finally {
     hideOverlay()

--- a/tests/Integration/Services/ApplicationInformationServiceTest.php
+++ b/tests/Integration/Services/ApplicationInformationServiceTest.php
@@ -4,8 +4,10 @@ namespace Tests\Integration\Services;
 
 use App\Services\ApplicationInformationService;
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Illuminate\Support\Facades\File;
 use PHPUnit\Framework\Attributes\Test;
@@ -29,5 +31,19 @@ class ApplicationInformationServiceTest extends TestCase
 
         self::assertSame($latestVersion, $service->getLatestVersionNumber());
         self::assertSame($latestVersion, cache()->get(cache_key('latest version number')));
+    }
+
+    #[Test]
+    public function fallsBackToCurrentVersionWhenGitHubIsUnreachable(): void
+    {
+        $mock = new MockHandler([
+            new ConnectException('cURL error 7: Failed to connect', new Request('GET', 'tags')),
+        ]);
+
+        $client = new Client(['handler' => HandlerStack::create($mock)]);
+        $service = new ApplicationInformationService($client);
+
+        self::assertSame(koel_version(), $service->getLatestVersionNumber());
+        self::assertSame(koel_version(), cache()->get(cache_key('latest version number')));
     }
 }


### PR DESCRIPTION
Closes #2439.

## Summary

When the host's outbound traffic is blocked (e.g. `ufw default deny outgoing`), Koel's startup hangs and then errors to a blank page. Two stacked bugs caused it.

## Bug 1: GitHub call without a timeout (backend)

`ApplicationInformationService::getLatestVersionNumber()` wraps the GitHub tags call in `rescue()`, but the Guzzle client had no timeout. With UFW silently dropping packets, no `RST` comes back; the kernel retries SYN packets for ~60-120s before giving up. `rescue()` does eventually catch the `ConnectException` and fall back to `koel_version()` — but by then an upstream layer (reverse proxy, or the browser's network stack) has already timed out the slow PHP request and surfaced it as an error to the frontend.

`rescue()` was correct in *intent* but can only catch what gets thrown — it can't make a hanging call fail fast.

**Fix:**
- Add explicit Guzzle `connect_timeout` (3s) and `timeout` (5s).
- Move the `rescue()` *inside* `Cache::remember`, so the fallback (current koel version) is cached for a day. Subsequent requests don't retry the failed call.
- Pass `report: false` to `rescue()` — failed reachability checks are routine cleanup noise, not log-worthy signal.

## Bug 2: useErrorHandler() called outside setup context (frontend)

`AppInitializer.vue` called `useErrorHandler()` *inside* an async `onMounted` catch block. Vue's `inject()` only works during a component's synchronous setup phase; calling it from a callback throws `Missing injection: Symbol(MessageToaster)` — exactly what the user saw in `browser.log` right before the blank page.

Other call sites of `useErrorHandler()` in catch blocks happen to work because `useMessageToaster` has a module-level cache that gets populated by some other component's setup before they fire. `AppInitializer` is the first place to run during boot, so the cache is empty when its catch fires — and the inject explodes.

**Fix:** hoist `useErrorHandler()` to script-setup time. Capture `handleHttpError` once, use it from any callback. Even if the error path never fires (the common case), the inject runs in setup context and populates the cache.

## Test plan

- [x] Existing `ApplicationInformationServiceTest` still passes with the moved `rescue()`.
- [x] New test exercises the `ConnectException` fallback path and asserts the `koel_version()` fallback is cached so subsequent calls don't hit the network.
- [x] Existing `AppInitializer.spec.ts` still passes.
- [x] `composer cs` and `vp check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced version checking resilience with connection timeouts and improved fallback handling when external services are unavailable.

* **Tests**
  * Added integration test to verify graceful fallback behavior when version check services are unreachable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->