### PR TITLE
fix: arrowleft hotkey now seeks backward, not forward

### DIFF
--- a/resources/assets/js/components/utils/HotkeyListener.spec.ts
+++ b/resources/assets/js/components/utils/HotkeyListener.spec.ts
@@ -5,6 +5,8 @@ import Component from './HotkeyListener.vue'
 
 const goMock = vi.fn()
 const isCurrentScreenMock = vi.fn().mockReturnValue(false)
+const forwardMock = vi.fn()
+const rewindMock = vi.fn()
 
 vi.mock('@/composables/useRouter', () => ({
   useRouter: () => ({
@@ -12,6 +14,10 @@ vi.mock('@/composables/useRouter', () => ({
     url: (name: string) => `/#/${name}`,
     isCurrentScreen: isCurrentScreenMock,
   }),
+}))
+
+vi.mock('@/services/playbackManager', () => ({
+  playback: () => ({ forward: forwardMock, rewind: rewindMock }),
 }))
 
 const pressKey = (key: string) => {
@@ -36,5 +42,19 @@ describe('hotkeyListener.vue', () => {
     pressKey('h')
 
     expect(goMock).toHaveBeenCalledWith('/#/home')
+  })
+
+  it('seeks forward on ArrowRight', () => {
+    h.render(Component)
+    pressKey('ArrowRight')
+
+    expect(forwardMock).toHaveBeenCalledWith(10)
+  })
+
+  it('seeks backward on ArrowLeft', () => {
+    h.render(Component)
+    pressKey('ArrowLeft')
+
+    expect(rewindMock).toHaveBeenCalledWith(10)
   })
 })

--- a/resources/assets/js/components/utils/HotkeyListener.vue
+++ b/resources/assets/js/components/utils/HotkeyListener.vue
@@ -46,7 +46,7 @@ onKeyStroke('q', () => go(isCurrentScreen('Queue') ? -1 : url('queue')))
 onKeyStroke('h', () => go(url('home')))
 
 onKeyStroke('ArrowRight', () => playback('current')?.forward(10))
-onKeyStroke('ArrowLeft', () => playback('current')?.rewind(-10))
+onKeyStroke('ArrowLeft', () => playback('current')?.rewind(10))
 onKeyStroke('ArrowUp', () => volumeManager.increase())
 onKeyStroke('ArrowDown', () => volumeManager.decrease())
 onKeyStroke('m', () => volumeManager.toggleMute())


### PR DESCRIPTION
Closes #2441.

## Bug

The Left arrow key on desktop seeks *forward* instead of backward. Both Left and Right arrows advance playback by ~10s.

## Cause

`HotkeyListener.vue` wired Left arrow to `playback('current')?.rewind(-10)`. `QueuePlaybackService::rewind(seconds)` is implemented as `this.media.currentTime -= seconds`, so passing `-10` becomes `currentTime -= -10` → adds 10s to the playback position. Same direction as Right arrow.

The other caller (`BasePlaybackService.ts:41`, the mediaSession `seekbackward` handler) correctly passes a positive number, which is why this bug never surfaced via OS media keys — only via keyboard arrows.

## Fix

Pass `10` (positive) to `rewind()`, matching the method's contract and the other caller.

## Test plan

- [x] New tests pin both arrow-key seek directions in `HotkeyListener.spec.ts`.
- [x] `vp test` passes (4 tests for `HotkeyListener`).
- [x] `vp check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the ArrowLeft hotkey to correctly perform playback rewind operations with appropriate values.

* **Tests**
  * Expanded test coverage for hotkey controls with new test cases verifying arrow key functionality for playback operations, including forward and rewind controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->