### PR TITLE
fix: cast favorite attribute to boolean across favoriteable models

### DIFF
--- a/app/Http/Controllers/API/Upload/KeepAllDuplicateUploadsController.php
+++ b/app/Http/Controllers/API/Upload/KeepAllDuplicateUploadsController.php
@@ -22,7 +22,7 @@ class KeepAllDuplicateUploadsController extends Controller
         AlbumRepository $albumRepository,
         Authenticatable $user,
     ) {
-        return $service->keep($repository->getAllForUser($user))->map(function (Song $song) use (
+        return $service->keep($repository->getAllForUser($user))->map(static function (Song $song) use (
             $songRepository,
             $albumRepository,
         ): SongUploadResponse {

--- a/app/Models/Album.php
+++ b/app/Models/Album.php
@@ -65,6 +65,14 @@ class Album extends Model implements AuditableContract, Embeddable, Favoriteable
     /** @deprecated */
     protected $appends = ['is_compilation'];
 
+    /** @inheritDoc */
+    protected function casts(): array
+    {
+        return [
+            'favorite' => 'boolean',
+        ];
+    }
+
     public static function query(): AlbumBuilder
     {
         /** @var AlbumBuilder */

--- a/app/Models/Artist.php
+++ b/app/Models/Artist.php
@@ -59,6 +59,14 @@ class Artist extends Model implements AuditableContract, Embeddable, Favoriteabl
     protected $guarded = ['id'];
     protected $hidden = ['created_at', 'updated_at'];
 
+    /** @inheritDoc */
+    protected function casts(): array
+    {
+        return [
+            'favorite' => 'boolean',
+        ];
+    }
+
     public static function query(): ArtistBuilder
     {
         /** @var ArtistBuilder */

--- a/app/Models/Podcast.php
+++ b/app/Models/Podcast.php
@@ -56,6 +56,7 @@ class Podcast extends Model implements Favoriteable
             'metadata' => PodcastMetadataCast::class,
             'last_synced_at' => 'datetime',
             'explicit' => 'boolean',
+            'favorite' => 'boolean',
         ];
     }
 

--- a/app/Models/Song.php
+++ b/app/Models/Song.php
@@ -108,10 +108,10 @@ class Song extends Model implements AuditableContract, Favoriteable, Embeddable
             'track' => 'int',
             'disc' => 'int',
             'year' => 'int',
-            'is_public' => 'bool',
+            'is_public' => 'boolean',
             'storage' => SongStorageCast::class,
             'episode_metadata' => EpisodeMetadataCast::class,
-            'favorite' => 'bool',
+            'favorite' => 'boolean',
         ];
     }
 

--- a/app/Observers/RadioStationObserver.php
+++ b/app/Observers/RadioStationObserver.php
@@ -4,7 +4,6 @@ namespace App\Observers;
 
 use App\Models\RadioStation;
 use App\Services\ModelImageObserver;
-use Illuminate\Support\Facades\File;
 
 class RadioStationObserver
 {

--- a/app/Rules/HasAudioContentType.php
+++ b/app/Rules/HasAudioContentType.php
@@ -47,8 +47,7 @@ class HasAudioContentType implements ValidationRule
             if ($response->successful()) {
                 return $response->header('Content-Type');
             }
-        } catch (Throwable) {
-            // HEAD may time out or fail on streaming servers — fall through to GET
+        } catch (Throwable) { // @mago-expect lint:no-empty-catch-clause -- HEAD may time out or fail on streaming servers; fall through to GET below.
         }
 
         // Fall back to GET with ICY headers — streaming servers often only respond to GET

--- a/tests/Feature/FavoriteTest.php
+++ b/tests/Feature/FavoriteTest.php
@@ -6,10 +6,14 @@ use App\Events\MultipleSongsLiked;
 use App\Events\MultipleSongsUnliked;
 use App\Events\SongFavoriteToggled;
 use App\Http\Resources\FavoriteResource;
+use App\Models\Album;
+use App\Models\Artist;
 use App\Models\Favorite;
+use App\Models\Podcast;
 use App\Models\Song;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Event;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -122,6 +126,43 @@ class FavoriteTest extends TestCase
         }
 
         Event::assertDispatched(MultipleSongsUnliked::class);
+    }
+
+    /** @return array<string, array{class-string<Song|Album|Artist|Podcast>}> */
+    public static function favoriteableModelProvider(): array
+    {
+        return [
+            'song' => [Song::class],
+            'album' => [Album::class],
+            'artist' => [Artist::class],
+            'podcast' => [Podcast::class],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('favoriteableModelProvider')]
+    public function favoriteAttributeIsCastToBoolean(string $modelClass): void
+    {
+        $user = create_user();
+        $favorited = $modelClass::factory()->createOne();
+        $unfavorited = $modelClass::factory()->createOne();
+
+        $favorited->favorites()->create(['user_id' => $user->id]);
+
+        $loadedFavorited = $modelClass::query()
+            ->setScopedUser($user)
+            ->withFavoriteStatus()
+            ->whereKey($favorited->getKey())
+            ->firstOrFail();
+
+        $loadedUnfavorited = $modelClass::query()
+            ->setScopedUser($user)
+            ->withFavoriteStatus()
+            ->whereKey($unfavorited->getKey())
+            ->firstOrFail();
+
+        self::assertSame(true, $loadedFavorited->favorite);
+        self::assertSame(false, $loadedUnfavorited->favorite);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

Fix a cross-database inconsistency where the `favorite` virtual column on Favoriteable models leaked driver-dependent types (int 0/1 on MySQL/SQLite vs. bool false/true on PostgreSQL) into the API response.

`FavoriteableBuilder::withFavoriteStatus()` adds `addSelect(DB::raw('CASE WHEN ... THEN false ELSE true END AS favorite'))`. The result of the CASE expression is typed by the driver; without an explicit model cast, the attribute reaches the frontend as `0`/`1` on MySQL/SQLite. With the cast, it always serializes as `true`/`false`.

- Added `'favorite' => 'boolean'` cast on `Album`, `Artist`, `Podcast` — these had no cast at all.
- Normalized `Song`'s existing `'bool'` aliases (for both `is_public` and `favorite`) to `'boolean'` for consistency. Functionally identical, since `bool` is a Laravel alias of `boolean`.
- `RadioStation` already had the cast — no change needed there.
- New data-provider test in `FavoriteTest::favoriteAttributeIsCastToBoolean` asserts strict `=== true` / `=== false` for all four models, which would have caught the issue on MySQL/SQLite.

This PR also cleans up three pre-existing Mago lint warnings surfaced while running `composer run lint` (separate commit):

- Unused `Illuminate\Support\Facades\File` import in `RadioStationObserver`.
- Empty `Throwable` catch in `HasAudioContentType::resolveContentType` annotated with `@mago-expect` (the silent fallback to GET is intentional for streaming servers; the explanatory comment is now on the catch line itself).
- Closure in `KeepAllDuplicateUploadsController` marked `static` (doesn't use `$this`).

## Test plan

- [x] `php artisan test --compact --filter=favoriteAttributeIsCastToBoolean` — 4 passed
- [x] `php artisan test --compact tests/Feature/FavoriteTest.php` — full suite passes
- [x] `php artisan test --compact --filter='Upload|RadioStation|HasAudioContentType|FavoriteTest'` — 86 passed
- [x] `composer run lint` — `No issues found.`
- [ ] Manual: with MySQL or SQLite, fetch `/api/songs/favorites` and confirm each entry's `favorite` field is `true` (boolean), not `1` (int).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved audio content type validation with better error handling for streaming servers.

* **Refactor**
  * Updated favorite attribute handling to use consistent boolean casting across albums, artists, podcasts, and songs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->