### PR TITLE
feat: introduce a Guest role that can play but not upload

### DIFF
--- a/app/Enums/Acl/Role.php
+++ b/app/Enums/Acl/Role.php
@@ -12,6 +12,7 @@ enum Role: string implements Arrayable
     case ADMIN = 'admin';
     case MANAGER = 'manager';
     case USER = 'user';
+    case GUEST = 'guest';
 
     public function label(): string
     {
@@ -19,6 +20,7 @@ enum Role: string implements Arrayable
             self::ADMIN => 'Admin',
             self::MANAGER => 'Manager',
             self::USER => 'User',
+            self::GUEST => 'Guest',
         };
     }
 
@@ -33,6 +35,7 @@ enum Role: string implements Arrayable
             self::ADMIN => 3,
             self::MANAGER => 2,
             self::USER => 1,
+            self::GUEST => 0,
         };
     }
 
@@ -56,7 +59,7 @@ enum Role: string implements Arrayable
         return match ($this) {
             self::ADMIN, self::USER => true,
             // @mago-ignore lint:prefer-first-class-callable
-            self::MANAGER => once(static fn () => License::isPlus()),
+            self::MANAGER, self::GUEST => once(static fn () => License::isPlus()),
         };
     }
 
@@ -84,6 +87,8 @@ enum Role: string implements Arrayable
             self::USER => $isCommunity
                 ? 'Users can play music and manage their own playlists.'
                 : 'Users can upload and manage their own music.',
+            self::GUEST
+                => 'Guests can only play music shared by others; they cannot upload or manage their own library.',
         };
     }
 

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -3,6 +3,7 @@
 namespace App\Policies;
 
 use App\Enums\Acl\Permission;
+use App\Enums\Acl\Role;
 use App\Facades\License;
 use App\Models\User;
 
@@ -32,6 +33,12 @@ class UserPolicy
 
     public function upload(User $currentUser): bool
     {
-        return License::isCommunity() ? $currentUser->hasPermissionTo(Permission::MANAGE_SONGS) : true; // For Plus Edition, any user can upload songs (to their own library).
+        if (License::isCommunity()) {
+            return $currentUser->hasPermissionTo(Permission::MANAGE_SONGS);
+        }
+
+        // On Plus, every authenticated user can upload to their own library — except Guests,
+        // who have no library by design.
+        return $currentUser->role !== Role::GUEST;
     }
 }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -37,6 +37,11 @@ class UserFactory extends Factory
         return $this->afterCreating(static fn (User $user) => $user->syncRoles(Role::MANAGER)); // @phpstan-ignore-line
     }
 
+    public function guest(): self
+    {
+        return $this->afterCreating(static fn (User $user) => $user->syncRoles(Role::GUEST)); // @phpstan-ignore-line
+    }
+
     public function prospect(): self
     {
         // @mago-ignore lint:prefer-static-closure

--- a/database/migrations/2026_05_08_212314_add_guest_role.php
+++ b/database/migrations/2026_05_08_212314_add_guest_role.php
@@ -1,0 +1,12 @@
+<?php
+
+use App\Enums\Acl\Role;
+use Illuminate\Database\Migrations\Migration;
+use Spatie\Permission\Models\Role as RoleModel;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        RoleModel::findOrCreate(Role::GUEST->value);
+    }
+};

--- a/docs/usage/user-management.md
+++ b/docs/usage/user-management.md
@@ -1,5 +1,5 @@
 ---
-description: User roles (admin, user, manager), creating and inviting users, and managing permissions in Koel.
+description: User roles (admin, user, manager, guest), creating and inviting users, and managing permissions in Koel.
 ---
 
 # User Management
@@ -9,6 +9,7 @@ Koel supports multiple users with different roles and permissions.
 * **Admins** can do basically anything: manage settings, users, and the shared music library
 * **Users** can access the shared library and manage their own profile and preferences.
 * <PlusBadge /> **Managers** can manage users and the shared library, but not settings.
+* <PlusBadge /> **Guests** can only play music shared by others — they have no library of their own and cannot upload, edit, or delete songs. Useful when you want to share a Koel Plus instance with friends or family without giving them a personal library.
 
 :::tip Multi-library support
 In the Community edition, all users share a common library (though playlists, favorites, and other stats are private).

--- a/resources/assets/js/composables/usePolicies.spec.ts
+++ b/resources/assets/js/composables/usePolicies.spec.ts
@@ -130,6 +130,16 @@ describe('usePolicies', () => {
     expect(currentUserCan.uploadSongs()).toBe(true)
   })
 
+  it('forbids upload for Plus guests', async () => {
+    const guest = h.factory('user').make({ abilities: [], role: 'guest' }) as CurrentUser
+    h.actingAsUser(guest)
+
+    await h.withPlusEdition(async () => {
+      const { currentUserCan } = usePolicies()
+      expect(currentUserCan.uploadSongs()).toBe(false)
+    })
+  })
+
   it('reads the edit permission embedded in the user', () => {
     const { currentUserCan } = usePolicies()
     const editable = h.factory('user').make({ permissions: { edit: true, delete: false } })

--- a/resources/assets/js/composables/usePolicies.ts
+++ b/resources/assets/js/composables/usePolicies.ts
@@ -34,7 +34,14 @@ export const usePolicies = () => {
 
     manageSettings: () => currentUser.value.abilities.includes('manage settings'),
     manageUsers: () => currentUser.value.abilities.includes('manage users'),
-    uploadSongs: () => isPlus.value || currentUser.value.abilities.includes('manage songs'),
+    uploadSongs: () => {
+      if (currentUser.value.abilities.includes('manage songs')) {
+        return true
+      }
+
+      // On Plus, every user has their own library to upload to — except Guests, who don't.
+      return isPlus.value && currentUser.value.role !== 'guest'
+    },
   }
 
   return {

--- a/resources/assets/js/types.d.ts
+++ b/resources/assets/js/types.d.ts
@@ -416,7 +416,7 @@ interface UserPreferences extends Record<string, any> {
 }
 
 type Ability = 'manage settings' | 'manage users' | 'manage songs' | 'manage podcasts' | 'manage radio stations'
-type Role = ('admin' | 'manager' | 'user') & string
+type Role = ('admin' | 'manager' | 'user' | 'guest') & string
 
 interface User {
   type: 'users'

--- a/tests/Feature/KoelPlus/UploadTest.php
+++ b/tests/Feature/KoelPlus/UploadTest.php
@@ -8,6 +8,7 @@ use Illuminate\Http\UploadedFile;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\PlusTestCase;
 
+use function Tests\create_guest;
 use function Tests\create_user;
 use function Tests\test_path;
 
@@ -36,5 +37,11 @@ class UploadTest extends PlusTestCase
         $song = Song::query()->latest()->first();
         self::assertSame($song->owner_id, $user->id);
         self::assertFalse($song->is_public);
+    }
+
+    #[Test]
+    public function guestsCannotUpload(): void
+    {
+        $this->postAs('api/upload', ['file' => $this->file], create_guest())->assertForbidden();
     }
 }

--- a/tests/Feature/KoelPlus/UploadTest.php
+++ b/tests/Feature/KoelPlus/UploadTest.php
@@ -42,6 +42,10 @@ class UploadTest extends PlusTestCase
     #[Test]
     public function guestsCannotUpload(): void
     {
-        $this->postAs('api/upload', ['file' => $this->file], create_guest())->assertForbidden();
+        $guest = create_guest();
+
+        $this->postAs('api/upload', ['file' => $this->file], $guest)->assertForbidden();
+
+        $this->assertDatabaseMissing(Song::class, ['owner_id' => $guest->id]);
     }
 }

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -22,6 +22,11 @@ function create_manager(array $attributes = []): User
     return User::factory()->manager()->createOne($attributes);
 }
 
+function create_guest(array $attributes = []): User
+{
+    return User::factory()->guest()->createOne($attributes);
+}
+
 function create_user_prospect(array $attributes = []): User
 {
     return User::factory()->prospect()->createOne($attributes);

--- a/tests/Unit/KoelPlus/Models/UserTest.php
+++ b/tests/Unit/KoelPlus/Models/UserTest.php
@@ -12,27 +12,27 @@ use function Tests\create_manager;
 class UserTest extends PlusTestCase
 {
     /**
-     * In Plus, Role::available() admits MANAGER. The admin's canManage() permits every role,
-     * so getAssignableRoles() returns all three ordered by level() ascending.
+     * In Plus, Role::available() admits MANAGER and GUEST. The admin's canManage() permits every
+     * role, so getAssignableRoles() returns all four ordered by level() ascending.
      */
     #[Test]
     public function adminCanAssignAllRolesOrderedByLevel(): void
     {
         $admin = create_admin();
 
-        self::assertSame([Role::USER, Role::MANAGER, Role::ADMIN], $admin->getAssignableRoles()->all());
+        self::assertSame([Role::GUEST, Role::USER, Role::MANAGER, Role::ADMIN], $admin->getAssignableRoles()->all());
     }
 
     /**
      * In Plus, MANAGER passes Role::available() and the manager satisfies canManage(MANAGER)
      * since 2 >= 2; only ADMIN is filtered out by canManage() (level 3 > manager's 2). Net
-     * result of getAssignableRoles() is [USER, MANAGER].
+     * result of getAssignableRoles() is [GUEST, USER, MANAGER].
      */
     #[Test]
     public function managerCannotAssignAdminRole(): void
     {
         $manager = create_manager();
 
-        self::assertSame([Role::USER, Role::MANAGER], $manager->getAssignableRoles()->all());
+        self::assertSame([Role::GUEST, Role::USER, Role::MANAGER], $manager->getAssignableRoles()->all());
     }
 }


### PR DESCRIPTION
## Summary

Closes #2182. Introduces a new `Role::GUEST` (Plus-only) for users who should only be able to play music shared by others — no individual library, no uploads.

The implementation is deliberately small because koel's existing ACL already does most of the work for free:

- **`Role::GUEST`** added to `App\Enums\Acl\Role` at `level()` 0 (below USER), `available()` only on Plus, with a description for the role-management UI.
- **`UserPolicy::upload`** short-circuits Guest on Plus. The Community path (community user → `MANAGE_SONGS` permission check) is unchanged.
- **`SongBuilder::accessible()` is untouched.** A Guest owns nothing, so the existing ownership predicate (`whereBelongsTo($user, 'owner')`) naturally returns nothing, and the public-songs branch in the same query handles their "only see public songs" experience automatically.
- **Frontend gate is single-source-of-truth.** `usePolicies.uploadSongs()` mirrors the backend rule, which transitively hides:
  - the upload-screen route (`config/routes.ts` guard)
  - the upload nav item (`SidebarManageSection.vue`)
  - the drop-zone overlay (`useUpload.allowsUpload` → `DropZone.vue`)

  No per-component visibility tweaks needed.
- **Migration** `2026_05_08_212314_add_guest_role.php` registers the role with Spatie's `roles` table for existing installs (fresh installs pick it up via the same migration during initial sequence).

The `getAssignableRoles()` machinery already filters by `role->canManage()` and `role->available()`, so admin and manager dropdowns automatically include Guest with no controller change. The two unit tests asserting the assignable-roles list are updated to include `Role::GUEST`.

## Decisions taken (open to revisit if you'd rather differ)

- **Plus-only role.** On Community, `USER` already lacks `MANAGE_SONGS`, so a "Guest" wouldn't add anything beyond the existing role — `Role::available()` returns `false` on Community to keep the role list tidy. If you'd rather expose Guest universally for completeness, flip the case in `available()` to `true`.
- **Default role stays `USER`.** The reporter's "server-wide disable libraries" use case isn't part of this PR — it would be a one-liner follow-up (switch `Role::default()` to `GUEST`, optionally gated by an env var) once the role exists.
- **Guests can have their own playlists.** Playlists are user-scoped, not song-scoped — a Guest can curate public songs into private lists. No data-model change.
- **`UserPolicy::upload`** uses a direct role check (`role !== Role::GUEST`) rather than `hasPermissionTo(MANAGE_SONGS)`. The permission-based form would require granting `USER` the permission, which on Community would broaden their power to managing the entire shared library — a larger semantic shift. Out of scope; documented decision.

## Test plan

- [x] `php artisan test --compact` — 888 backend tests pass
- [x] `npx vp test` — 1509 frontend tests pass (incl. new `usePolicies` Guest case)
- [x] `composer run lint` — clean
- [x] `npx vp check resources/assets/js` — clean
- [x] `npx vp build` — clean
- [ ] Manual (Plus): create a Guest user via the admin UI, log in as them, confirm:
  - "Songs" sidebar section shows only public songs (none uploaded by them)
  - No "Upload" entry in the manage section
  - Drag-and-drop overlay does not appear
  - Direct navigation to `/upload` route is blocked
  - `POST /api/upload` returns 403
- [ ] Manual: confirm admin/manager dropdowns include "Guest" when assigning a role to a user


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Guest user role (Plus edition): can play shared music but has restricted library and upload/edit/delete privileges

* **Documentation**
  * Updated user management docs to describe Guest role and its restrictions

* **Migrations**
  * Database migration added to ensure Guest role exists

* **Tests**
  * New tests and test helpers verifying Guests cannot upload songs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->