### PR TITLE
fix: keep search index in sync with post-scan mass-deletes

### DIFF
--- a/app/Models/Concerns/SupportsDeleteWhereValueNotIn.php
+++ b/app/Models/Concerns/SupportsDeleteWhereValueNotIn.php
@@ -5,6 +5,7 @@ namespace App\Models\Concerns;
 use Closure;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\DB;
+use Laravel\Scout\Searchable;
 
 /**
  * With reference to GitHub issue #463.
@@ -29,7 +30,7 @@ trait SupportsDeleteWhereValueNotIn
         $maxChunkSize = DB::getDriverName() === 'sqlite' ? 999 : 65_535;
 
         if (count($values) <= $maxChunkSize) {
-            $queryModifier(static::query())->whereNotIn($field, $values)->delete();
+            self::deleteAndUnsearch($queryModifier(static::query())->whereNotIn($field, $values));
 
             return;
         }
@@ -42,7 +43,7 @@ trait SupportsDeleteWhereValueNotIn
         $deletableIds = array_diff($allIds, $values);
 
         if (count($deletableIds) < $maxChunkSize) {
-            $queryModifier(static::query())->whereIn($field, $deletableIds)->delete();
+            self::deleteAndUnsearch($queryModifier(static::query())->whereIn($field, $deletableIds));
 
             return;
         }
@@ -56,8 +57,22 @@ trait SupportsDeleteWhereValueNotIn
 
         DB::transaction(static function () use ($values, $field, $chunkSize): void {
             foreach (array_chunk($values, $chunkSize) as $chunk) {
-                static::query()->whereIn($field, $chunk)->delete();
+                self::deleteAndUnsearch(static::query()->whereIn($field, $chunk));
             }
         });
+    }
+
+    /**
+     * Mass-delete bypasses per-model events, which means Scout's `deleted` listener
+     * never fires and orphan rows linger in the search index. Flush the matching rows
+     * from Scout first when the model is searchable, then delete via the same query.
+     */
+    private static function deleteAndUnsearch(Builder $query): void
+    {
+        if (in_array(Searchable::class, class_uses_recursive(static::class), true)) {
+            (clone $query)->unsearchable();
+        }
+
+        $query->delete();
     }
 }

--- a/app/Models/Concerns/SupportsDeleteWhereValueNotIn.php
+++ b/app/Models/Concerns/SupportsDeleteWhereValueNotIn.php
@@ -62,15 +62,10 @@ trait SupportsDeleteWhereValueNotIn
         });
     }
 
-    /**
-     * Mass-delete bypasses per-model events, which means Scout's `deleted` listener
-     * never fires and orphan rows linger in the search index. Flush the matching rows
-     * from Scout first when the model is searchable, then delete via the same query.
-     */
     private static function deleteAndUnsearch(Builder $query): void
     {
         if (in_array(Searchable::class, class_uses_recursive(static::class), true)) {
-            (clone $query)->unsearchable(); // @phpstan-ignore-line — Scout's Searchable trait macros unsearchable() onto the Eloquent Builder.
+            $query->unsearchable(); // @phpstan-ignore-line
         }
 
         $query->delete();

--- a/app/Models/Concerns/SupportsDeleteWhereValueNotIn.php
+++ b/app/Models/Concerns/SupportsDeleteWhereValueNotIn.php
@@ -70,7 +70,7 @@ trait SupportsDeleteWhereValueNotIn
     private static function deleteAndUnsearch(Builder $query): void
     {
         if (in_array(Searchable::class, class_uses_recursive(static::class), true)) {
-            (clone $query)->unsearchable();
+            (clone $query)->unsearchable(); // @phpstan-ignore-line — Scout's Searchable trait macros unsearchable() onto the Eloquent Builder.
         }
 
         $query->delete();

--- a/app/Services/LibraryManager.php
+++ b/app/Services/LibraryManager.php
@@ -35,8 +35,8 @@ class LibraryManager
                 // Flush the search index before mass-delete: the query-builder ->delete()
                 // bypasses per-model events, so Scout's `deleted` listener never fires
                 // and orphan rows would otherwise linger in the index.
-                $results['albums']->unsearchable();
-                $results['artists']->unsearchable();
+                $results['albums']->unsearchable(); // @phpstan-ignore-line — Scout adds unsearchable() to Eloquent collections.
+                $results['artists']->unsearchable(); // @phpstan-ignore-line — Scout adds unsearchable() to Eloquent collections.
 
                 $albumQuery->delete();
                 $artistQuery->delete();

--- a/app/Services/LibraryManager.php
+++ b/app/Services/LibraryManager.php
@@ -32,6 +32,12 @@ class LibraryManager
             ];
 
             if (!$dryRun) {
+                // Flush the search index before mass-delete: the query-builder ->delete()
+                // bypasses per-model events, so Scout's `deleted` listener never fires
+                // and orphan rows would otherwise linger in the index.
+                $results['albums']->unsearchable();
+                $results['artists']->unsearchable();
+
                 $albumQuery->delete();
                 $artistQuery->delete();
             }

--- a/app/Services/LibraryManager.php
+++ b/app/Services/LibraryManager.php
@@ -32,12 +32,8 @@ class LibraryManager
             ];
 
             if (!$dryRun) {
-                // Flush the search index before mass-delete: the query-builder ->delete()
-                // bypasses per-model events, so Scout's `deleted` listener never fires
-                // and orphan rows would otherwise linger in the index.
-                $results['albums']->unsearchable(); // @phpstan-ignore-line — Scout adds unsearchable() to Eloquent collections.
-                $results['artists']->unsearchable(); // @phpstan-ignore-line — Scout adds unsearchable() to Eloquent collections.
-
+                $results['albums']->unsearchable(); // @phpstan-ignore-line
+                $results['artists']->unsearchable(); // @phpstan-ignore-line
                 $albumQuery->delete();
                 $artistQuery->delete();
             }

--- a/tests/Integration/Listeners/DeleteNonExistingRecordsPostSyncTest.php
+++ b/tests/Integration/Listeners/DeleteNonExistingRecordsPostSyncTest.php
@@ -84,6 +84,6 @@ class DeleteNonExistingRecordsPostSyncTest extends TestCase
         $this->listener->handle(new MediaScanCompleted(ScanResultCollection::create()));
 
         self::assertModelMissing($orphan);
-        $engine->shouldHaveReceived('delete')->atLeast()->once();
+        $engine->shouldHaveReceived('delete')->atLeast()->once(); // @phpstan-ignore-line — Mockery chained expectations
     }
 }

--- a/tests/Integration/Listeners/DeleteNonExistingRecordsPostSyncTest.php
+++ b/tests/Integration/Listeners/DeleteNonExistingRecordsPostSyncTest.php
@@ -70,11 +70,7 @@ class DeleteNonExistingRecordsPostSyncTest extends TestCase
     #[Test]
     public function flushesOrphanedSongsFromSearchIndex(): void
     {
-        // Replace Scout's engine with a spy so we can assert that `delete()` is called
-        // when orphan songs are pruned. Without the trait fix, the mass-delete bypasses
-        // Scout's per-model `deleted` event and orphans linger in the search index.
         $engine = Mockery::spy(Engine::class);
-
         $manager = Mockery::mock(EngineManager::class);
         $manager->shouldReceive('engine')->andReturn($engine);
         $this->app->instance(EngineManager::class, $manager);
@@ -84,6 +80,6 @@ class DeleteNonExistingRecordsPostSyncTest extends TestCase
         $this->listener->handle(new MediaScanCompleted(ScanResultCollection::create()));
 
         self::assertModelMissing($orphan);
-        $engine->shouldHaveReceived('delete')->atLeast()->once(); // @phpstan-ignore-line — Mockery chained expectations
+        $engine->shouldHaveReceived('delete')->atLeast()->once(); // @phpstan-ignore-line
     }
 }

--- a/tests/Integration/Listeners/DeleteNonExistingRecordsPostSyncTest.php
+++ b/tests/Integration/Listeners/DeleteNonExistingRecordsPostSyncTest.php
@@ -9,6 +9,9 @@ use App\Models\Song;
 use App\Values\Scanning\ScanResult;
 use App\Values\Scanning\ScanResultCollection;
 use Illuminate\Database\Eloquent\Collection;
+use Laravel\Scout\EngineManager;
+use Laravel\Scout\Engines\Engine;
+use Mockery;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -62,5 +65,25 @@ class DeleteNonExistingRecordsPostSyncTest extends TestCase
         $this->assertModelExists($songs[3]);
         $this->assertModelMissing($songs[1]);
         $this->assertModelMissing($songs[2]);
+    }
+
+    #[Test]
+    public function flushesOrphanedSongsFromSearchIndex(): void
+    {
+        // Replace Scout's engine with a spy so we can assert that `delete()` is called
+        // when orphan songs are pruned. Without the trait fix, the mass-delete bypasses
+        // Scout's per-model `deleted` event and orphans linger in the search index.
+        $engine = Mockery::spy(Engine::class);
+
+        $manager = Mockery::mock(EngineManager::class);
+        $manager->shouldReceive('engine')->andReturn($engine);
+        $this->app->instance(EngineManager::class, $manager);
+
+        $orphan = Song::factory()->createOne();
+
+        $this->listener->handle(new MediaScanCompleted(ScanResultCollection::create()));
+
+        self::assertModelMissing($orphan);
+        $engine->shouldHaveReceived('delete')->atLeast()->once();
     }
 }

--- a/tests/Integration/Services/LibraryManagerTest.php
+++ b/tests/Integration/Services/LibraryManagerTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tests\Integration\Services;
+
+use App\Models\Album;
+use App\Models\Artist;
+use App\Models\Song;
+use App\Services\LibraryManager;
+use Laravel\Scout\EngineManager;
+use Laravel\Scout\Engines\Engine;
+use Mockery;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class LibraryManagerTest extends TestCase
+{
+    private LibraryManager $libraryManager;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->libraryManager = app(LibraryManager::class);
+    }
+
+    #[Test]
+    public function prunesEmptyAlbumsAndArtists(): void
+    {
+        $emptyAlbum = Album::factory()->createOne();
+        $emptyArtist = Artist::factory()->createOne();
+
+        $albumWithSongs = Album::factory()->createOne();
+        Song::factory()->for($albumWithSongs)->createOne();
+
+        $this->libraryManager->prune();
+
+        self::assertModelMissing($emptyAlbum);
+        self::assertModelMissing($emptyArtist);
+        self::assertModelExists($albumWithSongs);
+    }
+
+    #[Test]
+    public function dryRunDoesNotDelete(): void
+    {
+        $emptyAlbum = Album::factory()->createOne();
+        $emptyArtist = Artist::factory()->createOne();
+
+        $this->libraryManager->prune(dryRun: true);
+
+        self::assertModelExists($emptyAlbum);
+        self::assertModelExists($emptyArtist);
+    }
+
+    #[Test]
+    public function flushesEmptyAlbumsAndArtistsFromSearchIndex(): void
+    {
+        // Replace Scout's engine with a spy. The mass-delete in prune() bypasses Scout's
+        // per-model `deleted` event, so the explicit `unsearchable()` calls are the only
+        // way orphan rows leave the search index.
+        $engine = Mockery::spy(Engine::class);
+
+        $manager = Mockery::mock(EngineManager::class);
+        $manager->shouldReceive('engine')->andReturn($engine);
+        $this->app->instance(EngineManager::class, $manager);
+
+        Album::factory()->createOne();
+        Artist::factory()->createOne();
+
+        $this->libraryManager->prune();
+
+        // One Engine::delete() call per searchable type flushed (album + artist).
+        $engine->shouldHaveReceived('delete')->twice();
+    }
+
+    #[Test]
+    public function dryRunDoesNotTouchSearchIndex(): void
+    {
+        $engine = Mockery::spy(Engine::class);
+
+        $manager = Mockery::mock(EngineManager::class);
+        $manager->shouldReceive('engine')->andReturn($engine);
+        $this->app->instance(EngineManager::class, $manager);
+
+        Album::factory()->createOne();
+
+        $this->libraryManager->prune(dryRun: true);
+
+        $engine->shouldNotHaveReceived('delete');
+    }
+}

--- a/tests/Integration/Services/LibraryManagerTest.php
+++ b/tests/Integration/Services/LibraryManagerTest.php
@@ -69,7 +69,7 @@ class LibraryManagerTest extends TestCase
         $this->libraryManager->prune();
 
         // One Engine::delete() call per searchable type flushed (album + artist).
-        $engine->shouldHaveReceived('delete')->twice();
+        $engine->shouldHaveReceived('delete')->twice(); // @phpstan-ignore-line — Mockery chained expectations
     }
 
     #[Test]

--- a/tests/Integration/Services/LibraryManagerTest.php
+++ b/tests/Integration/Services/LibraryManagerTest.php
@@ -54,11 +54,7 @@ class LibraryManagerTest extends TestCase
     #[Test]
     public function flushesEmptyAlbumsAndArtistsFromSearchIndex(): void
     {
-        // Replace Scout's engine with a spy. The mass-delete in prune() bypasses Scout's
-        // per-model `deleted` event, so the explicit `unsearchable()` calls are the only
-        // way orphan rows leave the search index.
         $engine = Mockery::spy(Engine::class);
-
         $manager = Mockery::mock(EngineManager::class);
         $manager->shouldReceive('engine')->andReturn($engine);
         $this->app->instance(EngineManager::class, $manager);
@@ -68,15 +64,13 @@ class LibraryManagerTest extends TestCase
 
         $this->libraryManager->prune();
 
-        // One Engine::delete() call per searchable type flushed (album + artist).
-        $engine->shouldHaveReceived('delete')->twice(); // @phpstan-ignore-line — Mockery chained expectations
+        $engine->shouldHaveReceived('delete')->twice(); // @phpstan-ignore-line
     }
 
     #[Test]
     public function dryRunDoesNotTouchSearchIndex(): void
     {
         $engine = Mockery::spy(Engine::class);
-
         $manager = Mockery::mock(EngineManager::class);
         $manager->shouldReceive('engine')->andReturn($engine);
         $this->app->instance(EngineManager::class, $manager);


### PR DESCRIPTION
## Summary

Fixes a latent stale-search-index bug surfaced while triaging #2170. After `koel:scan`, two cleanup paths mass-delete via the query builder:

- `SupportsDeleteWhereValueNotIn::deleteWhereValueNotIn` — drops orphan songs whose paths are no longer in the scan result.
- `LibraryManager::prune()` — drops albums/artists left without any songs.

Both go through `Builder::delete()`, which **bypasses per-model `deleted` events**. That's the hook Scout's `Searchable` trait listens on to remove rows from the search index automatically. Net effect: orphan rows get removed from the database but linger in the index, producing "ghost" hits when users search.

This isn't the full fix for #2170's "no entries after scan" symptom (which is likely a TNTSearch index corruption / concurrency issue under Docker), but it's a real adjacent bug worth fixing on its own merits.

## Changes

- **`SupportsDeleteWhereValueNotIn`** — new private `deleteAndUnsearch()` step that, when the consuming model uses `Searchable`, calls `unsearchable()` on the matching query before issuing the mass-delete. The trait detects the trait via `class_uses_recursive`, so it's a no-op for non-searchable models and any future caller gets the sync for free.

- **`LibraryManager::prune()`** — calls `unsearchable()` on the album and artist collections it already fetches (for the return value) before the mass-delete. The dry-run path is left untouched so the index is never modified unless rows actually go away.

## Test plan

- [x] `php artisan test tests/Integration/Listeners/DeleteNonExistingRecordsPostSyncTest.php` — 4 passed (incl. new `flushesOrphanedSongsFromSearchIndex` asserting Scout's engine receives `delete()`)
- [x] `php artisan test tests/Integration/Services/LibraryManagerTest.php` — 4 passed (incl. flush-on-prune and dry-run-no-flush coverage)
- [x] `php artisan test --compact --filter='Scan|Prune|Library|DeleteWhere'` — 41 passed
- [x] `composer run lint` — clean
- [ ] Manual: import a fresh library, then delete some files on disk and re-run `koel:scan`. Search for the deleted song's title — should return zero hits (today: returns hits but clicking them errors).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure search-index entries are cleared before mass deletions so removed albums/artists/songs no longer appear.
  * Respect dry-run: pruning with dry-run does not touch the search index.

* **Tests**
  * Added integration tests verifying pruning deletes records, flushes them from the search index, and that dry-run preserves index state.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2452)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->