### PR TITLE
fix: skip native draggable on touch devices so context menu fires reliably

### DIFF
--- a/resources/assets/js/components/layout/app-footer/FooterPlayableInfo.vue
+++ b/resources/assets/js/components/layout/app-footer/FooterPlayableInfo.vue
@@ -24,6 +24,7 @@
 </template>
 
 <script lang="ts" setup>
+import isMobile from 'ismobilejs'
 import type { Ref } from 'vue'
 import { computed, ref } from 'vue'
 import { getPlayableProp, requireInjection, use } from '@/utils/helpers'
@@ -61,7 +62,7 @@ const artistOrPodcastName = computed(() =>
 )
 
 const coverBackgroundImage = computed(() => `url(${cover.value ?? defaultCover})`)
-const draggable = computed(() => Boolean(playable.value))
+const draggable = computed(() => Boolean(playable.value) && !isMobile.any)
 
 const onDragStart = (event: DragEvent) => use(playable.value, p => startDragging(event, [p]))
 

--- a/resources/assets/js/components/layout/main-wrapper/sidebar/PlaylistFolderSidebarItem.vue
+++ b/resources/assets/js/components/layout/main-wrapper/sidebar/PlaylistFolderSidebarItem.vue
@@ -2,7 +2,7 @@
   <li
     :class="{ droppable }"
     class="playlist-folder relative"
-    draggable="true"
+    :draggable="!isMobile.any"
     tabindex="0"
     @dragleave="onDragLeave"
     @dragover="onDragOver"
@@ -42,6 +42,7 @@
 
 <script lang="ts" setup>
 import { faFolder, faFolderOpen } from '@fortawesome/free-solid-svg-icons'
+import isMobile from 'ismobilejs'
 import { computed, ref, toRefs } from 'vue'
 import { defineAsyncComponent } from '@/utils/helpers'
 import { playlistFolderStore } from '@/stores/playlistFolderStore'

--- a/resources/assets/js/components/layout/main-wrapper/sidebar/PlaylistSidebarItem.vue
+++ b/resources/assets/js/components/layout/main-wrapper/sidebar/PlaylistSidebarItem.vue
@@ -4,7 +4,7 @@
     :class="{ droppable }"
     :href="href"
     class="playlist select-none"
-    draggable="true"
+    :draggable="!isMobile.any"
     :active
     @dblclick="onDblClick"
     @contextmenu="onContextMenu"
@@ -26,6 +26,7 @@
 
 <script lang="ts" setup>
 import { faClockRotateLeft, faStar, faUsers, faWandMagicSparkles } from '@fortawesome/free-solid-svg-icons'
+import isMobile from 'ismobilejs'
 import { ListMusicIcon } from 'lucide-vue-next'
 import { computed, ref, toRefs } from 'vue'
 import { defineAsyncComponent } from '@/utils/helpers'

--- a/resources/assets/js/components/playable/playable-list/PlayableList.vue
+++ b/resources/assets/js/components/playable/playable-list/PlayableList.vue
@@ -20,7 +20,7 @@
         :key="item.playable.id"
         :item="item"
         :show-disc="showDiscLabel(item.playable)"
-        draggable="true"
+        :draggable="!isMobile.any"
         @click="onClick(item, $event)"
         @dragleave="onDragLeave"
         @dragstart="onDragStart(item, $event)"

--- a/resources/assets/js/components/ui/album-artist/AlbumOrArtistCard.vue
+++ b/resources/assets/js/components/ui/album-artist/AlbumOrArtistCard.vue
@@ -10,7 +10,7 @@
       :class="layout"
       class="relative group flex p-5 rounded-[inherit] flex-col gap-5"
       data-testid="artist-album-card"
-      draggable="true"
+      :draggable="!isMobile.any"
       tabindex="0"
       @dblclick="onDblClick"
       @dragstart="onDragStart"
@@ -35,6 +35,7 @@
 </template>
 
 <script lang="ts" setup>
+import isMobile from 'ismobilejs'
 import { computed, toRefs } from 'vue'
 import { textToHsl } from '@/utils/formatters'
 


### PR DESCRIPTION
## Summary

Closes #1885. On Android Chrome and Firefox Mobile, an element with `draggable="true"` captures the long-press gesture for HTML5 drag and either suppresses or delays the `contextmenu` event that should follow. Every list / card / sidebar entry that sets `draggable="true"` unconditionally was hitting this — so long-pressing a song, album, artist, or playlist on mobile produced the partial / no-menu state the reporter screenshotted.

The reporter [self-diagnosed this](https://github.com/koel/koel/issues/1885#issuecomment-2528555015) and proved it by removing all drag wiring in their fork. Their fix is a hammer (loses desktop drag entirely); the right shape is to make `draggable` device-conditional.

## Changes

`:draggable="!isMobile.any"` (or computed equivalent) on the five affected templates:

- `resources/assets/js/components/playable/playable-list/PlayableList.vue` — song / podcast / radio rows
- `resources/assets/js/components/ui/album-artist/AlbumOrArtistCard.vue` — album / artist cards
- `resources/assets/js/components/layout/main-wrapper/sidebar/PlaylistSidebarItem.vue`
- `resources/assets/js/components/layout/main-wrapper/sidebar/PlaylistFolderSidebarItem.vue`
- `resources/assets/js/components/layout/app-footer/FooterPlayableInfo.vue` — already had a computed `draggable`, extended it with the mobile guard

Drag event handlers are left untouched — they're inert when `draggable=false`, no events fire. Desktop drag continues to work unchanged.

The `#2421` popover migration changed how the menu DOM is rendered but not how it's *triggered* — the `@contextmenu` event was always the trigger, and `draggable=true` was always suppressing it. So this bug survived that work; this PR fixes the trigger side.

## Test plan

- [x] `npx vp check resources/assets/js` — clean
- [x] `npx vp test` — 1509 passed
- [x] `npx vp build` — clean
- [ ] Manual on a real Android device (both Chrome and Firefox): long-press a song, an album card, an artist card, a sidebar playlist — context menu should appear reliably each time. Tap-to-select still works.
- [ ] Manual on desktop: drag-to-queue, drag-to-playlist, drag-to-folder all keep working as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Drag-and-drop functionality is now disabled on mobile devices across multiple components: sidebar playlist folders and items, the playable list, footer playback information, and album/artist cards.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2453)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->