### PR TITLE
fix: redirect guests to / and log proxy-auth failure modes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -267,7 +267,7 @@ protected function isAccessible(User $user, ?string $path = null): bool
 ## Git Commits
 - Use [Conventional Commits](https://www.conventionalcommits.org/) for all commit messages (e.g. `fix:`, `feat:`, `chore:`, `test:`, `refactor:`, `docs:`, `ci:`, etc.).
 - Focus on the feature/purpose, not implementation details. For example, prefer "feat: show current playing song during radio stream" over "feat: radio station ICY metadata now-playing". Same applies to PR titles.
-- Never mention Claude Code in commits, PR descriptions, or any generated content. No "Generated with Claude Code" footers, no Co-Authored-By lines referencing Claude.
+- Never attribute work to AI in any artifact: no "Generated with Claude Code", "Assisted by AI", "Co-Authored-By: Claude/ChatGPT/Copilot/AI" lines, no AI-tool mentions in commits, PR titles, PR descriptions, issue comments, code comments, or doc pages. The author is the human running the tool.
 - When the implementation of a PR changes (e.g. during code review), always update the PR title and description to reflect the current state of the changes.
 
 ## Releasing

--- a/app/Exceptions/ProxyAuthException.php
+++ b/app/Exceptions/ProxyAuthException.php
@@ -7,5 +7,5 @@ use RuntimeException;
 abstract class ProxyAuthException extends RuntimeException
 {
     /** @return array<string, mixed> */
-    abstract public function context(): array;
+    abstract public function getContext(): array;
 }

--- a/app/Exceptions/ProxyAuthException.php
+++ b/app/Exceptions/ProxyAuthException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Exceptions;
+
+use RuntimeException;
+
+abstract class ProxyAuthException extends RuntimeException
+{
+    /** @return array<string, mixed> */
+    abstract public function context(): array;
+}

--- a/app/Exceptions/ProxyAuthIpNotAllowedException.php
+++ b/app/Exceptions/ProxyAuthIpNotAllowedException.php
@@ -13,7 +13,7 @@ class ProxyAuthIpNotAllowedException extends ProxyAuthException
     }
 
     /** @inheritDoc */
-    public function context(): array
+    public function getContext(): array
     {
         return [
             'remote_addr' => $this->remoteAddr,

--- a/app/Exceptions/ProxyAuthIpNotAllowedException.php
+++ b/app/Exceptions/ProxyAuthIpNotAllowedException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Exceptions;
+
+class ProxyAuthIpNotAllowedException extends ProxyAuthException
+{
+    /** @param array<int, string> $allowList */
+    public function __construct(
+        public readonly ?string $remoteAddr,
+        public readonly array $allowList,
+    ) {
+        parent::__construct('Remote address not in allow list');
+    }
+
+    /** @inheritDoc */
+    public function context(): array
+    {
+        return [
+            'remote_addr' => $this->remoteAddr,
+            'allow_list' => $this->allowList,
+        ];
+    }
+}

--- a/app/Exceptions/ProxyAuthUserHeaderMissingException.php
+++ b/app/Exceptions/ProxyAuthUserHeaderMissingException.php
@@ -12,7 +12,7 @@ class ProxyAuthUserHeaderMissingException extends ProxyAuthException
     }
 
     /** @inheritDoc */
-    public function context(): array
+    public function getContext(): array
     {
         return [
             'expected_header' => $this->expectedHeader,

--- a/app/Exceptions/ProxyAuthUserHeaderMissingException.php
+++ b/app/Exceptions/ProxyAuthUserHeaderMissingException.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Exceptions;
+
+class ProxyAuthUserHeaderMissingException extends ProxyAuthException
+{
+    public function __construct(
+        public readonly string $expectedHeader,
+        public readonly ?string $remoteAddr,
+    ) {
+        parent::__construct('User header not present on request');
+    }
+
+    /** @inheritDoc */
+    public function context(): array
+    {
+        return [
+            'expected_header' => $this->expectedHeader,
+            'remote_addr' => $this->remoteAddr,
+        ];
+    }
+}

--- a/app/Services/ProxyAuthService.php
+++ b/app/Services/ProxyAuthService.php
@@ -36,7 +36,7 @@ class ProxyAuthService
 
             return $this->userService->createOrUpdateUserFromSso(SsoUser::fromProxyAuthRequest($request));
         } catch (ProxyAuthException $e) {
-            Log::warning(sprintf('[ProxyAuth] %s', $e->getMessage()), $e->context());
+            Log::warning(sprintf('[ProxyAuth] %s', $e->getMessage()), $e->getContext());
         } catch (Throwable $e) {
             Log::error('[ProxyAuth] Failed to create or update user from SSO headers', [
                 'exception' => $e,

--- a/app/Services/ProxyAuthService.php
+++ b/app/Services/ProxyAuthService.php
@@ -19,14 +19,36 @@ class ProxyAuthService
 
     public function tryGetProxyAuthenticatedUserFromRequest(Request $request): ?User
     {
+        $remoteAddr = $request->server->get('REMOTE_ADDR');
+
         if (!self::validateProxyIp($request)) {
+            Log::warning('[ProxyAuth] Remote address not in allow list', [
+                'remote_addr' => $remoteAddr,
+                'allow_list' => config('koel.proxy_auth.allow_list'),
+            ]);
+
+            return null;
+        }
+
+        $userHeader = config('koel.proxy_auth.user_header');
+
+        if (!$request->header($userHeader)) {
+            Log::warning('[ProxyAuth] User header not present on request', [
+                'expected_header' => $userHeader,
+                'remote_addr' => $remoteAddr,
+            ]);
+
             return null;
         }
 
         try {
             return $this->userService->createOrUpdateUserFromSso(SsoUser::fromProxyAuthRequest($request));
         } catch (Throwable $e) {
-            Log::error($e->getMessage(), ['exception' => $e]);
+            Log::error('[ProxyAuth] Failed to create or update user from SSO headers', [
+                'exception' => $e,
+                'expected_header' => $userHeader,
+                'remote_addr' => $remoteAddr,
+            ]);
         }
 
         return null;

--- a/app/Services/ProxyAuthService.php
+++ b/app/Services/ProxyAuthService.php
@@ -50,15 +50,17 @@ class ProxyAuthService
 
     private function assertProxyIpAllowed(?string $remoteAddr): void
     {
-        if (!IpUtils::checkIp($remoteAddr, $this->allowList)) {
-            throw new ProxyAuthIpNotAllowedException($remoteAddr, $this->allowList);
-        }
+        throw_unless(
+            IpUtils::checkIp($remoteAddr, $this->allowList),
+            new ProxyAuthIpNotAllowedException($remoteAddr, $this->allowList),
+        );
     }
 
     private function assertUserHeaderPresent(Request $request, ?string $remoteAddr): void
     {
-        if (!$request->header($this->userHeader)) {
-            throw new ProxyAuthUserHeaderMissingException($this->userHeader, $remoteAddr);
-        }
+        throw_unless(
+            $request->header($this->userHeader),
+            new ProxyAuthUserHeaderMissingException($this->userHeader, $remoteAddr),
+        );
     }
 }

--- a/app/Services/ProxyAuthService.php
+++ b/app/Services/ProxyAuthService.php
@@ -3,6 +3,9 @@
 namespace App\Services;
 
 use App\Attributes\RequiresPlus;
+use App\Exceptions\ProxyAuthException;
+use App\Exceptions\ProxyAuthIpNotAllowedException;
+use App\Exceptions\ProxyAuthUserHeaderMissingException;
 use App\Models\User;
 use App\Values\User\SsoUser;
 use Illuminate\Container\Attributes\Config;
@@ -27,26 +30,18 @@ class ProxyAuthService
     {
         $remoteAddr = $request->server->get('REMOTE_ADDR');
 
-        if (!IpUtils::checkIp($remoteAddr, $this->allowList)) {
-            Log::warning('[ProxyAuth] Remote address not in allow list', [
-                'remote_addr' => $remoteAddr,
-                'allow_list' => $this->allowList,
-            ]);
-
-            return null;
-        }
-
-        if (!$request->header($this->userHeader)) {
-            Log::warning('[ProxyAuth] User header not present on request', [
-                'expected_header' => $this->userHeader,
-                'remote_addr' => $remoteAddr,
-            ]);
-
-            return null;
-        }
-
         try {
+            if (!IpUtils::checkIp($remoteAddr, $this->allowList)) {
+                throw new ProxyAuthIpNotAllowedException($remoteAddr, $this->allowList);
+            }
+
+            if (!$request->header($this->userHeader)) {
+                throw new ProxyAuthUserHeaderMissingException($this->userHeader, $remoteAddr);
+            }
+
             return $this->userService->createOrUpdateUserFromSso(SsoUser::fromProxyAuthRequest($request));
+        } catch (ProxyAuthException $e) {
+            Log::warning(sprintf('[ProxyAuth] %s', $e->getMessage()), $e->context());
         } catch (Throwable $e) {
             Log::error('[ProxyAuth] Failed to create or update user from SSO headers', [
                 'exception' => $e,

--- a/app/Services/ProxyAuthService.php
+++ b/app/Services/ProxyAuthService.php
@@ -31,13 +31,8 @@ class ProxyAuthService
         $remoteAddr = $request->server->get('REMOTE_ADDR');
 
         try {
-            if (!IpUtils::checkIp($remoteAddr, $this->allowList)) {
-                throw new ProxyAuthIpNotAllowedException($remoteAddr, $this->allowList);
-            }
-
-            if (!$request->header($this->userHeader)) {
-                throw new ProxyAuthUserHeaderMissingException($this->userHeader, $remoteAddr);
-            }
+            $this->assertProxyIpAllowed($remoteAddr);
+            $this->assertUserHeaderPresent($request, $remoteAddr);
 
             return $this->userService->createOrUpdateUserFromSso(SsoUser::fromProxyAuthRequest($request));
         } catch (ProxyAuthException $e) {
@@ -51,5 +46,19 @@ class ProxyAuthService
         }
 
         return null;
+    }
+
+    private function assertProxyIpAllowed(?string $remoteAddr): void
+    {
+        if (!IpUtils::checkIp($remoteAddr, $this->allowList)) {
+            throw new ProxyAuthIpNotAllowedException($remoteAddr, $this->allowList);
+        }
+    }
+
+    private function assertUserHeaderPresent(Request $request, ?string $remoteAddr): void
+    {
+        if (!$request->header($this->userHeader)) {
+            throw new ProxyAuthUserHeaderMissingException($this->userHeader, $remoteAddr);
+        }
     }
 }

--- a/app/Services/ProxyAuthService.php
+++ b/app/Services/ProxyAuthService.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use App\Attributes\RequiresPlus;
 use App\Models\User;
 use App\Values\User\SsoUser;
+use Illuminate\Container\Attributes\Config;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
 use Symfony\Component\HttpFoundation\IpUtils;
@@ -13,28 +14,31 @@ use Throwable;
 #[RequiresPlus]
 class ProxyAuthService
 {
+    /** @param array<int, string> $allowList */
     public function __construct(
         private readonly UserService $userService,
+        #[Config('koel.proxy_auth.allow_list')]
+        private readonly array $allowList,
+        #[Config('koel.proxy_auth.user_header')]
+        private readonly string $userHeader,
     ) {}
 
     public function tryGetProxyAuthenticatedUserFromRequest(Request $request): ?User
     {
         $remoteAddr = $request->server->get('REMOTE_ADDR');
 
-        if (!self::validateProxyIp($request)) {
+        if (!IpUtils::checkIp($remoteAddr, $this->allowList)) {
             Log::warning('[ProxyAuth] Remote address not in allow list', [
                 'remote_addr' => $remoteAddr,
-                'allow_list' => config('koel.proxy_auth.allow_list'),
+                'allow_list' => $this->allowList,
             ]);
 
             return null;
         }
 
-        $userHeader = config('koel.proxy_auth.user_header');
-
-        if (!$request->header($userHeader)) {
+        if (!$request->header($this->userHeader)) {
             Log::warning('[ProxyAuth] User header not present on request', [
-                'expected_header' => $userHeader,
+                'expected_header' => $this->userHeader,
                 'remote_addr' => $remoteAddr,
             ]);
 
@@ -46,16 +50,11 @@ class ProxyAuthService
         } catch (Throwable $e) {
             Log::error('[ProxyAuth] Failed to create or update user from SSO headers', [
                 'exception' => $e,
-                'expected_header' => $userHeader,
+                'expected_header' => $this->userHeader,
                 'remote_addr' => $remoteAddr,
             ]);
         }
 
         return null;
-    }
-
-    private static function validateProxyIp(Request $request): bool
-    {
-        return IpUtils::checkIp($request->server->get('REMOTE_ADDR'), config('koel.proxy_auth.allow_list'));
     }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -41,15 +41,21 @@ return Application::configure(basePath: dirname(__DIR__))
             'audio.auth' => AudioAuthenticate::class,
             'os.auth' => ObjectStorageAuthenticate::class,
         ]);
+
+        // Koel is an SPA without a `login` route, so the Authenticate middleware would otherwise
+        // throw RouteNotFoundException when it tries to resolve route('login') on guest requests.
+        $middleware->redirectGuestsTo('/');
     })
     ->withExceptions(static function (Exceptions $exceptions): void {
-        $exceptions->render(
-            static function (AuthenticationException $e, Request $request): JsonResponse|RedirectResponse {
-                if ($request->expectsJson()) {
-                    return response()->json(['error' => 'Unauthenticated.'], 401);
-                }
-
-                return redirect()->guest('/');
+        $exceptions->render(static function (
+            AuthenticationException $e,
+            Request $request,
+        ): JsonResponse|RedirectResponse {
+            if ($request->expectsJson()) {
+                return response()->json(['error' => 'Unauthenticated.'], 401);
             }
-        );
-    })->create();
+
+            return redirect()->guest('/');
+        });
+    })
+    ->create();

--- a/docs/plus/proxy-auth.md
+++ b/docs/plus/proxy-auth.md
@@ -26,6 +26,14 @@ Now when a request comes in, Koel will look for specific headers to determine th
 If the headers are found, Koel will attempt to log the user in automatically using the unique identifier.
 If the user is not found, Koel will create a new user with the unique identifier and the preferred name.
 
+## Troubleshooting
+
+If proxy authentication isn't logging users in (you keep landing on Koel's password login screen despite a successful upstream auth handshake), check `storage/logs/laravel.log` for `[ProxyAuth]` entries. Koel logs a structured warning for each of the three failure modes:
+
+* **`Remote address not in allow list`** — the request reached Koel from an IP not covered by `PROXY_AUTH_ALLOW_LIST`. The log line includes both the observed `remote_addr` and the configured allow list. If your proxy runs in a Docker network or behind another layer, the address Koel sees may not be the one you expect — adjust the allow list or your `TrustProxies` config accordingly.
+* **`User header not present on request`** — Koel got the request but the configured `PROXY_AUTH_USER_HEADER` was missing. This usually means the proxy isn't propagating the header to the upstream request. Caddy users: double-check the `copy_headers` directive in your `forward_auth` block. Traefik / nginx users: confirm the header is in the forward-auth response and isn't being stripped before the upstream call.
+* **`Failed to create or update user from SSO headers`** — Koel received the header but failed to provision the user. The log entry includes the full exception; common causes are organization-membership constraints or invalid email derivation from the identifier.
+
 <style>
 sup {
   font-size: 0.8rem;

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -38,6 +38,9 @@ parameters:
         -
           message: '#expects .*, Mockery\\MockInterface given#'
           path: tests/*
+        -
+          message: '#Call to an undefined static method Illuminate\\Support\\Facades\\Log::shouldHaveReceived\(\)#'
+          path: tests/*
 
     excludePaths:
         - ./routes/console.php

--- a/tests/Feature/AuthTest.php
+++ b/tests/Feature/AuthTest.php
@@ -53,6 +53,21 @@ class AuthTest extends TestCase
     }
 
     #[Test]
+    public function unauthenticatedNavigateRequestRedirectsToRootInsteadOfThrowing(): void
+    {
+        // Without redirectGuestsTo configured, Laravel 12's Authenticate middleware would try
+        // to resolve route('login') and blow up with RouteNotFoundException because koel has
+        // no login route. See issue #2164.
+        $this->get('api/data', ['Accept' => 'text/html'])->assertRedirect('/');
+    }
+
+    #[Test]
+    public function unauthenticatedJsonRequestReturnsCleanUnauthorized(): void
+    {
+        $this->getJson('api/data')->assertUnauthorized()->assertJson(['error' => 'Unauthenticated.']);
+    }
+
+    #[Test]
     public function logOut(): void
     {
         $user = create_user([

--- a/tests/Feature/KoelPlus/ProxyAuthTest.php
+++ b/tests/Feature/KoelPlus/ProxyAuthTest.php
@@ -102,7 +102,7 @@ class ProxyAuthTest extends PlusTestCase
         self::assertNull($response->viewData('token'));
 
         Log::shouldHaveReceived('warning')
-            ->withArgs( // @phpstan-ignore-line
+            ->withArgs(
                 static fn (string $message, array $context) => (
                     str_contains($message, 'Remote address not in allow list')
                     && $context['remote_addr'] === '255.168.1.127'
@@ -125,7 +125,7 @@ class ProxyAuthTest extends PlusTestCase
         self::assertNull($response->viewData('token'));
 
         Log::shouldHaveReceived('warning')
-            ->withArgs( // @phpstan-ignore-line
+            ->withArgs(
                 static fn (string $message, array $context) => (
                     str_contains($message, 'User header not present')
                     && $context['expected_header'] === 'remote-user'

--- a/tests/Feature/KoelPlus/ProxyAuthTest.php
+++ b/tests/Feature/KoelPlus/ProxyAuthTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\KoelPlus;
 
 use App\Models\User;
+use Illuminate\Support\Facades\Log;
 use Laravel\Sanctum\PersonalAccessToken;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\PlusTestCase;
@@ -89,6 +90,8 @@ class ProxyAuthTest extends PlusTestCase
     #[Test]
     public function proxyAuthenticateWithDisallowedIp(): void
     {
+        Log::spy();
+
         $response = $this->get('/', [
             'REMOTE_ADDR' => '255.168.1.127',
             'remote-user' => '123456',
@@ -96,7 +99,38 @@ class ProxyAuthTest extends PlusTestCase
         ]);
 
         $response->assertOk();
-
         self::assertNull($response->viewData('token'));
+
+        Log::shouldHaveReceived('warning')
+            ->withArgs( // @phpstan-ignore-line
+                static fn (string $message, array $context) => (
+                    str_contains($message, 'Remote address not in allow list')
+                    && $context['remote_addr'] === '255.168.1.127'
+                ),
+            )
+            ->once();
+    }
+
+    #[Test]
+    public function proxyAuthenticateWithMissingUserHeader(): void
+    {
+        Log::spy();
+
+        $response = $this->get('/', [
+            'REMOTE_ADDR' => '192.168.1.127',
+            'remote-preferred-name' => 'Bruce Dickinson',
+        ]);
+
+        $response->assertOk();
+        self::assertNull($response->viewData('token'));
+
+        Log::shouldHaveReceived('warning')
+            ->withArgs( // @phpstan-ignore-line
+                static fn (string $message, array $context) => (
+                    str_contains($message, 'User header not present')
+                    && $context['expected_header'] === 'remote-user'
+                ),
+            )
+            ->once();
     }
 }


### PR DESCRIPTION
## Summary

Closes #2164. Reporters using Koel behind a Forward-Auth proxy (Authentik/Caddy in this case) hit two stacked problems when something on the proxy side mis-propagates the auth headers:

1. **Guest API requests crash with `Route [login] not defined`.** Laravel 12's `Authenticate` middleware tries to resolve `route('login')` to redirect unauthenticated navigate-style requests. Koel is an SPA without a `login` route, so the resolver throws `RouteNotFoundException` *before* the existing `AuthenticationException` exception handler at `bootstrap/app.php:45-54` ever runs — and a "you're not logged in" condition surfaces as a 500 page that reads as "koel is broken".
2. **`ProxyAuthService` returns `null` silently in three failure modes** — IP not in allow list, user header missing, user creation throws. With no log output, operators have no signal why their forward-auth setup isn't logging users in. The reporter's request trace shows their `X-Authentik-Uid` / `X-Authentik-Username` headers never reaching koel — almost certainly a Caddy `copy_headers` quirk on their side, but they had no way to know that.

## Changes

**`bootstrap/app.php`** — register `redirectGuestsTo('/')` on the middleware. The Authenticate middleware now redirects to `/` for guest navigate requests; the existing `AuthenticationException` render closure handles both JSON (returns 401) and navigate (already redirects to `/`) cases cleanly. No more 500 from the missing login route.

**`app/Services/ProxyAuthService.php`** — promote each `return null` branch to a structured `[ProxyAuth]` log line:

| Branch | Log line | Context fields |
|---|---|---|
| IP not in allow list | `Remote address not in allow list` | `remote_addr`, `allow_list` |
| User header missing | `User header not present on request` | `expected_header`, `remote_addr` |
| User creation throws | `Failed to create or update user from SSO headers` | `exception`, `expected_header`, `remote_addr` |

A `tail -f storage/logs/laravel.log` now tells the operator exactly which step failed.

**`docs/plus/proxy-auth.md`** — adds a troubleshooting section that names each log line and points at the most common operator-side root cause (Caddy `copy_headers`, Traefik forward-auth config, Trust Proxies misalignment).

## What this PR does *not* try to fix

The reporter's own header-propagation issue is almost certainly a Caddy config bug (`copy_headers` not propagating `X-Authentik-*` to the upstream). Without reproducing their exact stack, I can't be sure where the headers are being lost. The diagnostic logging makes that failure self-debuggable, which is the highest-leverage thing koel can do here.

## Test plan

- [x] `php artisan test --compact --filter='Auth|ProxyAuth'` — 26 passed (incl. 4 new: navigate-redirect, JSON-401, IP log, missing-header log)
- [x] `composer run lint` — clean
- [x] `composer run analyze` — clean
- [x] `bash docs/.vitepress/check-frontmatter.sh` — clean
- [ ] Manual: hit `/api/data` from a fresh browser navigate (no token) — should 302 to `/`, not 500
- [ ] Manual: enable proxy auth with a wrong header name, hit `/`, confirm log line names the missing header


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Extended proxy-auth troubleshooting guidance and updated contribution rules to forbid attributing work to AI tools by name.

* **Improvements**
  * More detailed, structured diagnostic warnings for proxy authentication failures.
  * Safer handling of unauthenticated requests: HTML navigation redirects to root and API requests return clean 401 JSON responses.

* **Tests**
  * Added feature tests for unauthenticated request behavior and proxy-auth failure logging.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2454)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->