### PR TITLE
feat: list only album artists on the Artists screen

### DIFF
--- a/app/Builders/ArtistBuilder.php
+++ b/app/Builders/ArtistBuilder.php
@@ -35,6 +35,11 @@ class ArtistBuilder extends FavoriteableBuilder
         return $this->whereNotIn('artists.name', [Artist::UNKNOWN_NAME, Artist::VARIOUS_NAME]);
     }
 
+    public function onlyAlbumArtists(): self
+    {
+        return $this->whereHas('albums');
+    }
+
     private function accessible(): self
     {
         if (License::isCommunity()) {

--- a/app/Repositories/ArtistRepository.php
+++ b/app/Repositories/ArtistRepository.php
@@ -26,6 +26,7 @@ class ArtistRepository extends Repository implements ScoutableRepository
     {
         return Artist::query()
             ->onlyStandard()
+            ->onlyAlbumArtists()
             ->withUserContext(user: $user ?? $this->auth->user())
             ->latest()
             ->limit($count)
@@ -37,6 +38,7 @@ class ArtistRepository extends Repository implements ScoutableRepository
         return Artist::query()
             ->withUserContext(user: $user ?? $this->auth->user(), includePlayCount: true)
             ->onlyStandard()
+            ->onlyAlbumArtists()
             ->orderByDesc('play_count')
             ->limit($count)
             ->get();
@@ -62,6 +64,7 @@ class ArtistRepository extends Repository implements ScoutableRepository
         return Artist::query()
             ->withUserContext(user: $user ?? $this->auth->user(), favoritesOnly: $favoritesOnly)
             ->onlyStandard()
+            ->onlyAlbumArtists()
             ->sort($sortColumn, $sortDirection)
             ->simplePaginate(21);
     }

--- a/docs/usage/web-interface.md
+++ b/docs/usage/web-interface.md
@@ -20,8 +20,6 @@ artists…
 
 ![Artists screen](../assets/img/interface/artists.avif)
 
-The Artists screen lists artists who appear as the album artist of at least one album in your library. Per-track collaborators (featured artists, remixers) aren't shown as separate entries — they're still reachable via global search and via the artist link on individual songs. This matches how iTunes/Apple Music and similar apps present an artists view, and prevents one-off "Artist A feat. Artist B" tags from cluttering the list.
-
 albums…
 
 ![Albums screen](../assets/img/interface/albums.avif)

--- a/docs/usage/web-interface.md
+++ b/docs/usage/web-interface.md
@@ -20,6 +20,8 @@ artists…
 
 ![Artists screen](../assets/img/interface/artists.avif)
 
+The Artists screen lists artists who appear as the album artist of at least one album in your library. Per-track collaborators (featured artists, remixers) aren't shown as separate entries — they're still reachable via global search and via the artist link on individual songs. This matches how iTunes/Apple Music and similar apps present an artists view, and prevents one-off "Artist A feat. Artist B" tags from cluttering the list.
+
 albums…
 
 ![Albums screen](../assets/img/interface/albums.avif)

--- a/resources/assets/js/components/ui/VirtualGridScroller.vue
+++ b/resources/assets/js/components/ui/VirtualGridScroller.vue
@@ -156,6 +156,21 @@ const scrollToTop = () => scroller.value?.scrollTo({ top: 0, behavior: 'smooth' 
 watch(minItemWidth, () => measure())
 
 watch(
+  [() => items.value.length, scrollerHeight, measuring],
+  () => {
+    if (
+      !measuring.value &&
+      items.value.length > 0 &&
+      measuredItemHeight.value > 0 &&
+      totalHeight.value <= scrollerHeight.value
+    ) {
+      emit('scrolled-to-end')
+    }
+  },
+  { flush: 'post' },
+)
+
+watch(
   () => items.value.length,
   async (newLen: number, oldLen: number) => {
     if (newLen < oldLen) {

--- a/tests/Feature/ArtistTest.php
+++ b/tests/Feature/ArtistTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Helpers\Ulid;
 use App\Http\Resources\ArtistResource;
+use App\Models\Album;
 use App\Models\Artist;
 use App\Models\Embed;
 use App\Values\EmbedOptions;
@@ -28,6 +29,20 @@ class ArtistTest extends TestCase
         $this->getAs(
             'api/artists?sort=created_at&order=desc&page=2',
         )->assertJsonStructure(ArtistResource::PAGINATION_JSON_STRUCTURE);
+    }
+
+    #[Test]
+    public function indexExcludesArtistsWithoutAlbums(): void
+    {
+        $albumArtist = Artist::factory()->createOne();
+        Album::factory()->for($albumArtist)->createOne();
+
+        $perTrackOnly = Artist::factory()->createOne();
+
+        $ids = collect($this->getAs('api/artists')->json('data'))->pluck('id')->all();
+
+        self::assertContains($albumArtist->id, $ids);
+        self::assertNotContains($perTrackOnly->id, $ids);
     }
 
     #[Test]

--- a/tests/Feature/ArtistTest.php
+++ b/tests/Feature/ArtistTest.php
@@ -89,23 +89,6 @@ class ArtistTest extends TestCase
     }
 
     #[Test]
-    public function indexReturnsArtistOnceEvenWithMultipleAlbums(): void
-    {
-        // Regression guard: a future refactor that swaps whereHas('albums') for a
-        // JOIN without DISTINCT would produce one row per album. Three albums under
-        // one artist is the simplest data shape that surfaces that bug.
-        $artist = Artist::factory()->createOne();
-        Album::factory()
-            ->count(3)
-            ->for($artist)
-            ->create();
-
-        $ids = collect($this->getAs('api/artists')->json('data'))->pluck('id')->all();
-
-        self::assertSame(1, collect($ids)->filter(static fn ($id) => $id === $artist->id)->count());
-    }
-
-    #[Test]
     public function show(): void
     {
         $this->getAs('api/artists/'

--- a/tests/Feature/ArtistTest.php
+++ b/tests/Feature/ArtistTest.php
@@ -89,24 +89,20 @@ class ArtistTest extends TestCase
     }
 
     #[Test]
-    public function indexIncludesArtistWhoBothOwnsAlbumAndAppearsAsFeaturedElsewhere(): void
+    public function indexReturnsArtistOnceEvenWithMultipleAlbums(): void
     {
-        // An artist with their own album AND a feat. credit on someone else's album
-        // should still appear once. Sanity check that the filter doesn't mis-handle
-        // the dual-role case.
-        $hostOfOwnAlbum = Artist::factory()->createOne();
-        Album::factory()->for($hostOfOwnAlbum)->createOne();
-
-        $otherArtist = Artist::factory()->createOne();
-        $otherAlbum = Album::factory()->for($otherArtist)->createOne();
-        Song::factory()
-            ->for($otherAlbum)
-            ->for($hostOfOwnAlbum)
-            ->createOne();
+        // Regression guard: a future refactor that swaps whereHas('albums') for a
+        // JOIN without DISTINCT would produce one row per album. Three albums under
+        // one artist is the simplest data shape that surfaces that bug.
+        $artist = Artist::factory()->createOne();
+        Album::factory()
+            ->count(3)
+            ->for($artist)
+            ->create();
 
         $ids = collect($this->getAs('api/artists')->json('data'))->pluck('id')->all();
 
-        self::assertSame(1, collect($ids)->filter(static fn ($id) => $id === $hostOfOwnAlbum->id)->count());
+        self::assertSame(1, collect($ids)->filter(static fn ($id) => $id === $artist->id)->count());
     }
 
     #[Test]

--- a/tests/Feature/ArtistTest.php
+++ b/tests/Feature/ArtistTest.php
@@ -7,6 +7,7 @@ use App\Http\Resources\ArtistResource;
 use App\Models\Album;
 use App\Models\Artist;
 use App\Models\Embed;
+use App\Models\Song;
 use App\Values\EmbedOptions;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
@@ -43,6 +44,69 @@ class ArtistTest extends TestCase
 
         self::assertContains($albumArtist->id, $ids);
         self::assertNotContains($perTrackOnly->id, $ids);
+    }
+
+    #[Test]
+    public function indexExcludesFeaturedArtistsOnSomeoneElsesAlbum(): void
+    {
+        // Album owned by `albumOwner`, with a track credited to `featuredArtist`.
+        // featuredArtist has no album of their own → must be excluded.
+        $albumOwner = Artist::factory()->createOne();
+        $album = Album::factory()->for($albumOwner)->createOne();
+
+        $featuredArtist = Artist::factory()->createOne();
+        Song::factory()
+            ->for($album)
+            ->for($featuredArtist)
+            ->createOne();
+
+        $ids = collect($this->getAs('api/artists')->json('data'))->pluck('id')->all();
+
+        self::assertContains($albumOwner->id, $ids);
+        self::assertNotContains($featuredArtist->id, $ids);
+    }
+
+    #[Test]
+    public function indexIncludesCompilationCuratorEvenWithoutOwnTracks(): void
+    {
+        // The curator owns a compilation album but contributes no tracks themselves;
+        // every song on the comp is credited to a different track artist. Curator
+        // is still the album_artist → must be included. Track artist with no album
+        // of their own → excluded.
+        $curator = Artist::factory()->createOne();
+        $compilation = Album::factory()->for($curator)->createOne();
+
+        $trackArtist = Artist::factory()->createOne();
+        Song::factory()
+            ->for($compilation)
+            ->for($trackArtist)
+            ->createOne();
+
+        $ids = collect($this->getAs('api/artists')->json('data'))->pluck('id')->all();
+
+        self::assertContains($curator->id, $ids);
+        self::assertNotContains($trackArtist->id, $ids);
+    }
+
+    #[Test]
+    public function indexIncludesArtistWhoBothOwnsAlbumAndAppearsAsFeaturedElsewhere(): void
+    {
+        // An artist with their own album AND a feat. credit on someone else's album
+        // should still appear once. Sanity check that the filter doesn't mis-handle
+        // the dual-role case.
+        $hostOfOwnAlbum = Artist::factory()->createOne();
+        Album::factory()->for($hostOfOwnAlbum)->createOne();
+
+        $otherArtist = Artist::factory()->createOne();
+        $otherAlbum = Album::factory()->for($otherArtist)->createOne();
+        Song::factory()
+            ->for($otherAlbum)
+            ->for($hostOfOwnAlbum)
+            ->createOne();
+
+        $ids = collect($this->getAs('api/artists')->json('data'))->pluck('id')->all();
+
+        self::assertSame(1, collect($ids)->filter(static fn ($id) => $id === $hostOfOwnAlbum->id)->count());
     }
 
     #[Test]

--- a/tests/Feature/KoelPlus/Ai/PlayMostPlayedArtistToolTest.php
+++ b/tests/Feature/KoelPlus/Ai/PlayMostPlayedArtistToolTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\KoelPlus\Ai;
 use App\Ai\AiAssistantResult;
 use App\Ai\AiRequestContext;
 use App\Ai\Tools\PlayMostPlayedArtist;
+use App\Models\Album;
 use App\Models\Artist;
 use App\Models\Interaction;
 use App\Models\Song;
@@ -37,9 +38,11 @@ class PlayMostPlayedArtistToolTest extends PlusTestCase
     public function playsMostPlayedArtist(): void
     {
         $artist = Artist::factory()->for($this->user)->createOne();
+        $album = Album::factory()->for($artist)->createOne();
         $songs = Song::factory()
             ->count(3)
             ->for($artist)
+            ->for($album)
             ->for($this->user, 'owner')
             ->create();
 
@@ -70,9 +73,11 @@ class PlayMostPlayedArtistToolTest extends PlusTestCase
     public function queuesInsteadOfPlaying(): void
     {
         $artist = Artist::factory()->for($this->user)->createOne();
+        $album = Album::factory()->for($artist)->createOne();
         $songs = Song::factory()
             ->count(2)
             ->for($artist)
+            ->for($album)
             ->for($this->user, 'owner')
             ->create();
 


### PR DESCRIPTION
## Summary

Closes #2210. Two related changes:

1. **Filter the Artists list to album artists only** — match how iTunes / Apple Music, Navidrome, Roon, and Beets present an artists view. Per-track collaborators (featured artists, remixers, one-off contributors) no longer fragment the list; they remain reachable via global search and via the artist link on individual songs.

2. **Auto-fetch additional pages when the grid content underflows the viewport** — pre-existing pagination bug surfaced by the new filter. With a result set that fits the screen, `VirtualGridScroller`'s `scrolled-to-end` event never fires (no scrollbar to scroll on), and the consumer stops at page 1.

## Why filter by album artist

The reporter framed the FR as "group by album artist" with the underlying motivation that featured-artist clutter makes their library hard to navigate. The data model already separates `songs.artist_id` (per-track) from `albums.artist_id` (album owner) cleanly, so the filter is a single `whereHas('albums')` scope on `ArtistBuilder`, applied in the three listing/ranking repository methods.

Defaulting to album-artist filtering is the dominant pattern across mature library apps. The "noisy" view koel currently has is the outlier — common in basic players (Rhythmbox, naive MPD clients), uncommon among apps with curated metadata workflows.

## Why bundle the pagination fix

The pagination bug exists in master today — it's just usually masked by the unfiltered Artists list having enough rows to overflow even a 4K monitor. The new filter shrinks results into the "fits the viewport" range, exposing the latent issue. Fixing one without the other would ship a known-degraded UX.

The fix is in `VirtualGridScroller` rather than the consumers, so both `ArtistListScreen` and `AlbumListScreen` (and any future screen using the component) benefit automatically.

## Changes

- **`ArtistBuilder::onlyAlbumArtists()`** — new scope, `whereHas('albums')`. Sibling to existing `onlyStandard()`.
- **`ArtistRepository`** — chains `->onlyAlbumArtists()` in `getForListing` (Artists screen), `getRecentlyAdded` (home), and `getMostPlayed` (home). Caller-driven paths (`getOne`, `getMany`, `search`) unchanged so direct lookup by ID or name still resolves any artist.
- **`VirtualGridScroller.vue`** — new watcher emits `scrolled-to-end` when measured content height ≤ scroller height with non-empty items, complementing the existing scroll-event-driven emit.

## Tests

- `ArtistTest::indexExcludesArtistsWithoutAlbums` — basic exclusion.
- `ArtistTest::indexExcludesFeaturedArtistsOnSomeoneElsesAlbum` — featured-only artist excluded.
- `ArtistTest::indexIncludesCompilationCuratorEvenWithoutOwnTracks` — album_artist of a compilation included even without their own track contribution.

Each new test fails on master (no filter) and passes with the fix — verified by checking out `master` for just `ArtistRepository` and `ArtistBuilder` and re-running.

The pagination fix isn't unit-tested at the scroller level — jsdom's layout primitives return zero, making the underflow predicate unobservable without invasive mocking. Manual verification on a real browser covers it.

## Test plan

- [x] `php artisan test --compact tests/Feature/ArtistTest.php` — 15 passed
- [x] `npx vp test run … VirtualGridScroller, ArtistListScreen, AlbumListScreen` — 18 passed
- [x] `composer run lint`, `composer run analyze`, `npx vp check`, `npx vp build` — all clean
- [x] Each new ArtistTest case fails when reverted to master (verified)
- [x] Manual: with a library of <21 album-artists on a big screen, confirm the Artists list paginates through all available pages instead of stopping at the first.
- [x] Manual: with a normal library, confirm the Artists list still paginates correctly on user scroll (existing behavior preserved).
- [x] Manual: search for a per-track-only artist by name, confirm they appear in search results.

## Behavioral note for release notes

Users with featured-artist tags will see fewer entries in their Artists screen, recently-added rail, and most-played rail. Featured artists remain reachable via search and via track-row artist links.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Artists without associated albums are now excluded from artist listings, search results, and most-played views.
  * Improved scroll detection for grid layouts to better handle content that fits within the viewport.

* **Tests**
  * Added test coverage for artist filtering behavior and edge cases in artist display logic.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2455)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->