### PR TITLE
refactor: collapse UserPreferences into a polymorphic Preference hierarchy

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"cec59d0c-b51a-495b-a69a-46e6cf9780d1","pid":62405,"procStart":"Tue Apr 28 19:58:00 2026","acquiredAt":1778447885071}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"cec59d0c-b51a-495b-a69a-46e6cf9780d1","pid":62405,"procStart":"Tue Apr 28 19:58:00 2026","acquiredAt":1778447885071}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,6 +245,7 @@ protected function isAccessible(User $user, ?string $path = null): bool
 ## Self-Explanatory Code
 - Code should read on its own. If a piece of code needs a comment to be understood, that's a signal the code is wrong, not that the comment is needed — refactor it: extract a named helper, rename a variable to encode intent, lift a condition into a named flag, pull a block into a small function. Use a comment only when refactoring genuinely can't carry the intent (a hidden invariant, a workaround tied to a specific external bug, behaviour a reader would otherwise misjudge). Never write comments that narrate the next line, summarise the surrounding block, or restate what well-named identifiers already say.
 - Don't use single-letter variable names. The only allowed ones are `i` / `j` for loop counters and `h` for the test harness. For everything else (callback params, destructured fields, lambda args, etc.) pick a name that says what it is.
+- Never combine assignment with return. Always `$x = expr;` then `return $x;` on a separate line — `return $x = expr;` cramming two effects into one statement is forbidden in PHP, TS, and JS.
 
 ## PHP Conventions
 - Always prefer Laravel's built-in helpers over custom implementations (e.g. `str()->plural()`, `Str::slug()`, `Arr::flatten()`, etc.). Do not reimplement what Laravel already provides.

--- a/app/Values/User/Preferences/ActiveExtraPanelTabPreference.php
+++ b/app/Values/User/Preferences/ActiveExtraPanelTabPreference.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Values\User\Preferences;
+
+use Webmozart\Assert\Assert;
+
+class ActiveExtraPanelTabPreference extends Preference
+{
+    public function assert(): void
+    {
+        Assert::oneOf($this->value, [null, 'Lyrics', 'Artist', 'Album', 'YouTube']);
+    }
+}

--- a/app/Values/User/Preferences/AlbumsFavoritesOnlyPreference.php
+++ b/app/Values/User/Preferences/AlbumsFavoritesOnlyPreference.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Values\User\Preferences;
+
+class AlbumsFavoritesOnlyPreference extends Preference
+{
+    public function getDefaultValue(): false
+    {
+        return false;
+    }
+
+    protected function cast(mixed $value): bool
+    {
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+    }
+}

--- a/app/Values/User/Preferences/AlbumsFavoritesOnlyPreference.php
+++ b/app/Values/User/Preferences/AlbumsFavoritesOnlyPreference.php
@@ -2,15 +2,10 @@
 
 namespace App\Values\User\Preferences;
 
-class AlbumsFavoritesOnlyPreference extends Preference
+class AlbumsFavoritesOnlyPreference extends BooleanPreference
 {
     public function getDefaultValue(): false
     {
         return false;
-    }
-
-    protected function cast(mixed $value): bool
-    {
-        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
     }
 }

--- a/app/Values/User/Preferences/AlbumsSortFieldPreference.php
+++ b/app/Values/User/Preferences/AlbumsSortFieldPreference.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Values\User\Preferences;
+
+use Webmozart\Assert\Assert;
+
+class AlbumsSortFieldPreference extends Preference
+{
+    public function getDefaultValue(): string
+    {
+        return 'name';
+    }
+
+    public function assert(): void
+    {
+        Assert::oneOf($this->value, ['name', 'artist_name', 'year', 'created_at']);
+    }
+}

--- a/app/Values/User/Preferences/AlbumsSortOrderPreference.php
+++ b/app/Values/User/Preferences/AlbumsSortOrderPreference.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Values\User\Preferences;
+
+use Webmozart\Assert\Assert;
+
+class AlbumsSortOrderPreference extends Preference
+{
+    public function getDefaultValue(): string
+    {
+        return 'asc';
+    }
+
+    public function assert(): void
+    {
+        Assert::oneOf(strtolower((string) $this->value), ['asc', 'desc']);
+    }
+}

--- a/app/Values/User/Preferences/AlbumsSortOrderPreference.php
+++ b/app/Values/User/Preferences/AlbumsSortOrderPreference.php
@@ -2,17 +2,4 @@
 
 namespace App\Values\User\Preferences;
 
-use Webmozart\Assert\Assert;
-
-class AlbumsSortOrderPreference extends Preference
-{
-    public function getDefaultValue(): string
-    {
-        return 'asc';
-    }
-
-    public function assert(): void
-    {
-        Assert::oneOf(strtolower((string) $this->value), ['asc', 'desc']);
-    }
-}
+class AlbumsSortOrderPreference extends SortOrderPreference {}

--- a/app/Values/User/Preferences/AlbumsViewModePreference.php
+++ b/app/Values/User/Preferences/AlbumsViewModePreference.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Values\User\Preferences;
+
+use Webmozart\Assert\Assert;
+
+class AlbumsViewModePreference extends Preference
+{
+    public function getDefaultValue(): string
+    {
+        return 'thumbnails';
+    }
+
+    public function assert(): void
+    {
+        Assert::oneOf($this->value, ['list', 'thumbnails']);
+    }
+}

--- a/app/Values/User/Preferences/ArtistsFavoritesOnlyPreference.php
+++ b/app/Values/User/Preferences/ArtistsFavoritesOnlyPreference.php
@@ -2,15 +2,10 @@
 
 namespace App\Values\User\Preferences;
 
-class ArtistsFavoritesOnlyPreference extends Preference
+class ArtistsFavoritesOnlyPreference extends BooleanPreference
 {
     public function getDefaultValue(): false
     {
         return false;
-    }
-
-    protected function cast(mixed $value): bool
-    {
-        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
     }
 }

--- a/app/Values/User/Preferences/ArtistsFavoritesOnlyPreference.php
+++ b/app/Values/User/Preferences/ArtistsFavoritesOnlyPreference.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Values\User\Preferences;
+
+class ArtistsFavoritesOnlyPreference extends Preference
+{
+    public function getDefaultValue(): false
+    {
+        return false;
+    }
+
+    protected function cast(mixed $value): bool
+    {
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+    }
+}

--- a/app/Values/User/Preferences/ArtistsSortFieldPreference.php
+++ b/app/Values/User/Preferences/ArtistsSortFieldPreference.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Values\User\Preferences;
+
+use Webmozart\Assert\Assert;
+
+class ArtistsSortFieldPreference extends Preference
+{
+    public function getDefaultValue(): string
+    {
+        return 'name';
+    }
+
+    public function assert(): void
+    {
+        Assert::oneOf($this->value, ['name', 'created_at']);
+    }
+}

--- a/app/Values/User/Preferences/ArtistsSortOrderPreference.php
+++ b/app/Values/User/Preferences/ArtistsSortOrderPreference.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Values\User\Preferences;
+
+use Webmozart\Assert\Assert;
+
+class ArtistsSortOrderPreference extends Preference
+{
+    public function getDefaultValue(): string
+    {
+        return 'asc';
+    }
+
+    public function assert(): void
+    {
+        Assert::oneOf(strtolower((string) $this->value), ['asc', 'desc']);
+    }
+}

--- a/app/Values/User/Preferences/ArtistsSortOrderPreference.php
+++ b/app/Values/User/Preferences/ArtistsSortOrderPreference.php
@@ -2,17 +2,4 @@
 
 namespace App\Values\User\Preferences;
 
-use Webmozart\Assert\Assert;
-
-class ArtistsSortOrderPreference extends Preference
-{
-    public function getDefaultValue(): string
-    {
-        return 'asc';
-    }
-
-    public function assert(): void
-    {
-        Assert::oneOf(strtolower((string) $this->value), ['asc', 'desc']);
-    }
-}
+class ArtistsSortOrderPreference extends SortOrderPreference {}

--- a/app/Values/User/Preferences/ArtistsViewModePreference.php
+++ b/app/Values/User/Preferences/ArtistsViewModePreference.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Values\User\Preferences;
+
+use Webmozart\Assert\Assert;
+
+class ArtistsViewModePreference extends Preference
+{
+    public function getDefaultValue(): string
+    {
+        return 'thumbnails';
+    }
+
+    public function assert(): void
+    {
+        Assert::oneOf($this->value, ['list', 'thumbnails']);
+    }
+}

--- a/app/Values/User/Preferences/BooleanPreference.php
+++ b/app/Values/User/Preferences/BooleanPreference.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Values\User\Preferences;
+
+abstract class BooleanPreference extends Preference
+{
+    protected function cast(mixed $value): bool
+    {
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+    }
+}

--- a/app/Values/User/Preferences/ConfirmBeforeClosingPreference.php
+++ b/app/Values/User/Preferences/ConfirmBeforeClosingPreference.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Values\User\Preferences;
+
+class ConfirmBeforeClosingPreference extends Preference
+{
+    public function getDefaultValue(): false
+    {
+        return false;
+    }
+
+    protected function cast(mixed $value): bool
+    {
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+    }
+}

--- a/app/Values/User/Preferences/ConfirmBeforeClosingPreference.php
+++ b/app/Values/User/Preferences/ConfirmBeforeClosingPreference.php
@@ -2,15 +2,10 @@
 
 namespace App\Values\User\Preferences;
 
-class ConfirmBeforeClosingPreference extends Preference
+class ConfirmBeforeClosingPreference extends BooleanPreference
 {
     public function getDefaultValue(): false
     {
         return false;
-    }
-
-    protected function cast(mixed $value): bool
-    {
-        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
     }
 }

--- a/app/Values/User/Preferences/ContinuousPlaybackPreference.php
+++ b/app/Values/User/Preferences/ContinuousPlaybackPreference.php
@@ -2,15 +2,10 @@
 
 namespace App\Values\User\Preferences;
 
-class ContinuousPlaybackPreference extends Preference
+class ContinuousPlaybackPreference extends BooleanPreference
 {
     public function getDefaultValue(): false
     {
         return false;
-    }
-
-    protected function cast(mixed $value): bool
-    {
-        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
     }
 }

--- a/app/Values/User/Preferences/ContinuousPlaybackPreference.php
+++ b/app/Values/User/Preferences/ContinuousPlaybackPreference.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Values\User\Preferences;
+
+class ContinuousPlaybackPreference extends Preference
+{
+    public function getDefaultValue(): false
+    {
+        return false;
+    }
+
+    protected function cast(mixed $value): bool
+    {
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+    }
+}

--- a/app/Values/User/Preferences/CrossfadeDurationPreference.php
+++ b/app/Values/User/Preferences/CrossfadeDurationPreference.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Values\User\Preferences;
+
+use Webmozart\Assert\Assert;
+
+class CrossfadeDurationPreference extends Preference
+{
+    public function getDefaultValue(): int
+    {
+        return 0;
+    }
+
+    public function assert(): void
+    {
+        Assert::range($this->value, 0, 15);
+    }
+
+    protected function cast(mixed $value): int
+    {
+        return (int) $value;
+    }
+}

--- a/app/Values/User/Preferences/CurrentEqualizerPresetPreference.php
+++ b/app/Values/User/Preferences/CurrentEqualizerPresetPreference.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Values\User\Preferences;
+
+use App\Values\EqualizerPreset;
+
+class CurrentEqualizerPresetPreference extends Preference
+{
+    public function getDefaultValue(): EqualizerPreset
+    {
+        return EqualizerPreset::default();
+    }
+
+    public function getAliases(): array
+    {
+        return ['equalizer'];
+    }
+
+    protected function cast(mixed $value): EqualizerPreset
+    {
+        if ($value instanceof EqualizerPreset) {
+            return $value;
+        }
+
+        return EqualizerPreset::tryFromArray($value) ?? EqualizerPreset::default();
+    }
+}

--- a/app/Values/User/Preferences/DetectDuplicateUploadsPreference.php
+++ b/app/Values/User/Preferences/DetectDuplicateUploadsPreference.php
@@ -2,15 +2,10 @@
 
 namespace App\Values\User\Preferences;
 
-class DetectDuplicateUploadsPreference extends Preference
+class DetectDuplicateUploadsPreference extends BooleanPreference
 {
     public function getDefaultValue(): true
     {
         return true;
-    }
-
-    protected function cast(mixed $value): bool
-    {
-        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
     }
 }

--- a/app/Values/User/Preferences/DetectDuplicateUploadsPreference.php
+++ b/app/Values/User/Preferences/DetectDuplicateUploadsPreference.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Values\User\Preferences;
+
+class DetectDuplicateUploadsPreference extends Preference
+{
+    public function getDefaultValue(): true
+    {
+        return true;
+    }
+
+    protected function cast(mixed $value): bool
+    {
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+    }
+}

--- a/app/Values/User/Preferences/EqualizerPresetsPreference.php
+++ b/app/Values/User/Preferences/EqualizerPresetsPreference.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Values\User\Preferences;
+
+use App\Values\EqualizerPreset;
+use App\Values\EqualizerPresetCollection;
+
+class EqualizerPresetsPreference extends Preference
+{
+    public function getDefaultValue(): EqualizerPresetCollection
+    {
+        return new EqualizerPresetCollection();
+    }
+
+    protected function cast(mixed $value): EqualizerPresetCollection
+    {
+        if ($value instanceof EqualizerPresetCollection) {
+            return $value;
+        }
+
+        return EqualizerPresetCollection::fromArray(
+            is_array($value)
+                ? array_map(static fn (mixed $item): mixed => $item instanceof EqualizerPreset
+                    ? $item->toArray()
+                    : $item, $value) : [],
+        );
+    }
+}

--- a/app/Values/User/Preferences/GenresSortFieldPreference.php
+++ b/app/Values/User/Preferences/GenresSortFieldPreference.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Values\User\Preferences;
+
+use Webmozart\Assert\Assert;
+
+class GenresSortFieldPreference extends Preference
+{
+    public function getDefaultValue(): string
+    {
+        return 'name';
+    }
+
+    public function assert(): void
+    {
+        Assert::oneOf($this->value, ['name', 'song_count']);
+    }
+}

--- a/app/Values/User/Preferences/GenresSortOrderPreference.php
+++ b/app/Values/User/Preferences/GenresSortOrderPreference.php
@@ -2,17 +2,4 @@
 
 namespace App\Values\User\Preferences;
 
-use Webmozart\Assert\Assert;
-
-class GenresSortOrderPreference extends Preference
-{
-    public function getDefaultValue(): string
-    {
-        return 'asc';
-    }
-
-    public function assert(): void
-    {
-        Assert::oneOf(strtolower((string) $this->value), ['asc', 'desc']);
-    }
-}
+class GenresSortOrderPreference extends SortOrderPreference {}

--- a/app/Values/User/Preferences/GenresSortOrderPreference.php
+++ b/app/Values/User/Preferences/GenresSortOrderPreference.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Values\User\Preferences;
+
+use Webmozart\Assert\Assert;
+
+class GenresSortOrderPreference extends Preference
+{
+    public function getDefaultValue(): string
+    {
+        return 'asc';
+    }
+
+    public function assert(): void
+    {
+        Assert::oneOf(strtolower((string) $this->value), ['asc', 'desc']);
+    }
+}

--- a/app/Values/User/Preferences/IncludePublicMediaPreference.php
+++ b/app/Values/User/Preferences/IncludePublicMediaPreference.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Values\User\Preferences;
+
+class IncludePublicMediaPreference extends Preference
+{
+    public function getDefaultValue(): true
+    {
+        return true;
+    }
+
+    protected function cast(mixed $value): bool
+    {
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+    }
+}

--- a/app/Values/User/Preferences/IncludePublicMediaPreference.php
+++ b/app/Values/User/Preferences/IncludePublicMediaPreference.php
@@ -2,15 +2,10 @@
 
 namespace App\Values\User\Preferences;
 
-class IncludePublicMediaPreference extends Preference
+class IncludePublicMediaPreference extends BooleanPreference
 {
     public function getDefaultValue(): true
     {
         return true;
-    }
-
-    protected function cast(mixed $value): bool
-    {
-        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
     }
 }

--- a/app/Values/User/Preferences/LastfmSessionKeyPreference.php
+++ b/app/Values/User/Preferences/LastfmSessionKeyPreference.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Values\User\Preferences;
+
+class LastfmSessionKeyPreference extends Preference
+{
+    public function getProperty(): string
+    {
+        return 'lastFmSessionKey';
+    }
+
+    public function isCustomizable(): bool
+    {
+        return false;
+    }
+}

--- a/app/Values/User/Preferences/LyricsZoomLevelPreference.php
+++ b/app/Values/User/Preferences/LyricsZoomLevelPreference.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Values\User\Preferences;
+
+class LyricsZoomLevelPreference extends Preference
+{
+    public function getDefaultValue(): int
+    {
+        return 1;
+    }
+
+    protected function cast(mixed $value): int
+    {
+        return (int) $value;
+    }
+}

--- a/app/Values/User/Preferences/MakeUploadsPublicPreference.php
+++ b/app/Values/User/Preferences/MakeUploadsPublicPreference.php
@@ -2,15 +2,10 @@
 
 namespace App\Values\User\Preferences;
 
-class MakeUploadsPublicPreference extends Preference
+class MakeUploadsPublicPreference extends BooleanPreference
 {
     public function getDefaultValue(): false
     {
         return false;
-    }
-
-    protected function cast(mixed $value): bool
-    {
-        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
     }
 }

--- a/app/Values/User/Preferences/MakeUploadsPublicPreference.php
+++ b/app/Values/User/Preferences/MakeUploadsPublicPreference.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Values\User\Preferences;
+
+class MakeUploadsPublicPreference extends Preference
+{
+    public function getDefaultValue(): false
+    {
+        return false;
+    }
+
+    protected function cast(mixed $value): bool
+    {
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+    }
+}

--- a/app/Values/User/Preferences/PodcastsFavoritesOnlyPreference.php
+++ b/app/Values/User/Preferences/PodcastsFavoritesOnlyPreference.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Values\User\Preferences;
+
+class PodcastsFavoritesOnlyPreference extends Preference
+{
+    public function getDefaultValue(): false
+    {
+        return false;
+    }
+
+    protected function cast(mixed $value): bool
+    {
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+    }
+}

--- a/app/Values/User/Preferences/PodcastsFavoritesOnlyPreference.php
+++ b/app/Values/User/Preferences/PodcastsFavoritesOnlyPreference.php
@@ -2,15 +2,10 @@
 
 namespace App\Values\User\Preferences;
 
-class PodcastsFavoritesOnlyPreference extends Preference
+class PodcastsFavoritesOnlyPreference extends BooleanPreference
 {
     public function getDefaultValue(): false
     {
         return false;
-    }
-
-    protected function cast(mixed $value): bool
-    {
-        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
     }
 }

--- a/app/Values/User/Preferences/PodcastsSortFieldPreference.php
+++ b/app/Values/User/Preferences/PodcastsSortFieldPreference.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Values\User\Preferences;
+
+use Webmozart\Assert\Assert;
+
+class PodcastsSortFieldPreference extends Preference
+{
+    public function getDefaultValue(): string
+    {
+        return 'title';
+    }
+
+    public function assert(): void
+    {
+        Assert::oneOf($this->value, ['title', 'last_played_at', 'subscribed_at', 'author']);
+    }
+}

--- a/app/Values/User/Preferences/PodcastsSortOrderPreference.php
+++ b/app/Values/User/Preferences/PodcastsSortOrderPreference.php
@@ -2,17 +2,4 @@
 
 namespace App\Values\User\Preferences;
 
-use Webmozart\Assert\Assert;
-
-class PodcastsSortOrderPreference extends Preference
-{
-    public function getDefaultValue(): string
-    {
-        return 'asc';
-    }
-
-    public function assert(): void
-    {
-        Assert::oneOf(strtolower((string) $this->value), ['asc', 'desc']);
-    }
-}
+class PodcastsSortOrderPreference extends SortOrderPreference {}

--- a/app/Values/User/Preferences/PodcastsSortOrderPreference.php
+++ b/app/Values/User/Preferences/PodcastsSortOrderPreference.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Values\User\Preferences;
+
+use Webmozart\Assert\Assert;
+
+class PodcastsSortOrderPreference extends Preference
+{
+    public function getDefaultValue(): string
+    {
+        return 'asc';
+    }
+
+    public function assert(): void
+    {
+        Assert::oneOf(strtolower((string) $this->value), ['asc', 'desc']);
+    }
+}

--- a/app/Values/User/Preferences/Preference.php
+++ b/app/Values/User/Preferences/Preference.php
@@ -5,6 +5,7 @@ namespace App\Values\User\Preferences;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 use ReflectionClass;
+use Throwable;
 
 /**
  * @property mixed $value
@@ -29,8 +30,15 @@ abstract class Preference
             throw new InvalidArgumentException("Unknown property: {$name}");
         }
 
+        $previous = $this->resolvedValue;
         $this->resolvedValue = $value;
-        $this->assert();
+
+        try {
+            $this->assert();
+        } catch (Throwable $exception) {
+            $this->resolvedValue = $previous;
+            throw $exception;
+        }
     }
 
     public function __get(string $name): mixed

--- a/app/Values/User/Preferences/Preference.php
+++ b/app/Values/User/Preferences/Preference.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Values\User\Preferences;
+
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+use ReflectionClass;
+
+/**
+ * @property mixed $value
+ */
+abstract class Preference
+{
+    private mixed $resolvedValue = null;
+
+    final public function __construct() {}
+
+    public static function make(mixed $value): static
+    {
+        $instance = new static();
+        $instance->value = $value === null ? $instance->getDefaultValue() : $instance->cast($value);
+
+        return $instance;
+    }
+
+    public function __set(string $name, mixed $value): void
+    {
+        if ($name !== 'value') {
+            throw new InvalidArgumentException("Unknown property: {$name}");
+        }
+
+        $this->resolvedValue = $value;
+        $this->assert();
+    }
+
+    public function __get(string $name): mixed
+    {
+        if ($name !== 'value') {
+            throw new InvalidArgumentException("Unknown property: {$name}");
+        }
+
+        return $this->resolvedValue;
+    }
+
+    public function getKey(): string
+    {
+        $shortName = (new ReflectionClass(static::class))->getShortName();
+
+        return Str::snake(Str::beforeLast($shortName, 'Preference'));
+    }
+
+    public function getProperty(): string
+    {
+        return Str::camel($this->getKey());
+    }
+
+    public function getDefaultValue(): mixed
+    {
+        return null;
+    }
+
+    public function getValue(): mixed
+    {
+        return $this->resolvedValue;
+    }
+
+    public function assert(): void {}
+
+    public function isCustomizable(): bool
+    {
+        return true;
+    }
+
+    /** @return list<string> Legacy storage keys to read as a backwards-compat fallback. */
+    public function getAliases(): array
+    {
+        return [];
+    }
+
+    protected function cast(mixed $value): mixed
+    {
+        return $value;
+    }
+}

--- a/app/Values/User/Preferences/RadioStationsFavoritesOnlyPreference.php
+++ b/app/Values/User/Preferences/RadioStationsFavoritesOnlyPreference.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Values\User\Preferences;
+
+class RadioStationsFavoritesOnlyPreference extends Preference
+{
+    public function getDefaultValue(): false
+    {
+        return false;
+    }
+
+    protected function cast(mixed $value): bool
+    {
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+    }
+}

--- a/app/Values/User/Preferences/RadioStationsFavoritesOnlyPreference.php
+++ b/app/Values/User/Preferences/RadioStationsFavoritesOnlyPreference.php
@@ -2,15 +2,10 @@
 
 namespace App\Values\User\Preferences;
 
-class RadioStationsFavoritesOnlyPreference extends Preference
+class RadioStationsFavoritesOnlyPreference extends BooleanPreference
 {
     public function getDefaultValue(): false
     {
         return false;
-    }
-
-    protected function cast(mixed $value): bool
-    {
-        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
     }
 }

--- a/app/Values/User/Preferences/RadioStationsSortFieldPreference.php
+++ b/app/Values/User/Preferences/RadioStationsSortFieldPreference.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Values\User\Preferences;
+
+use Webmozart\Assert\Assert;
+
+class RadioStationsSortFieldPreference extends Preference
+{
+    public function getDefaultValue(): string
+    {
+        return 'name';
+    }
+
+    public function assert(): void
+    {
+        Assert::oneOf($this->value, ['name', 'created_at']);
+    }
+}

--- a/app/Values/User/Preferences/RadioStationsSortOrderPreference.php
+++ b/app/Values/User/Preferences/RadioStationsSortOrderPreference.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Values\User\Preferences;
+
+use Webmozart\Assert\Assert;
+
+class RadioStationsSortOrderPreference extends Preference
+{
+    public function getDefaultValue(): string
+    {
+        return 'asc';
+    }
+
+    public function assert(): void
+    {
+        Assert::oneOf(strtolower((string) $this->value), ['asc', 'desc']);
+    }
+}

--- a/app/Values/User/Preferences/RadioStationsSortOrderPreference.php
+++ b/app/Values/User/Preferences/RadioStationsSortOrderPreference.php
@@ -2,17 +2,4 @@
 
 namespace App\Values\User\Preferences;
 
-use Webmozart\Assert\Assert;
-
-class RadioStationsSortOrderPreference extends Preference
-{
-    public function getDefaultValue(): string
-    {
-        return 'asc';
-    }
-
-    public function assert(): void
-    {
-        Assert::oneOf(strtolower((string) $this->value), ['asc', 'desc']);
-    }
-}
+class RadioStationsSortOrderPreference extends SortOrderPreference {}

--- a/app/Values/User/Preferences/RadioStationsViewModePreference.php
+++ b/app/Values/User/Preferences/RadioStationsViewModePreference.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Values\User\Preferences;
+
+use Webmozart\Assert\Assert;
+
+class RadioStationsViewModePreference extends Preference
+{
+    public function getDefaultValue(): string
+    {
+        return 'thumbnails';
+    }
+
+    public function assert(): void
+    {
+        Assert::oneOf($this->value, ['list', 'thumbnails']);
+    }
+}

--- a/app/Values/User/Preferences/RepeatModePreference.php
+++ b/app/Values/User/Preferences/RepeatModePreference.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Values\User\Preferences;
+
+use Webmozart\Assert\Assert;
+
+class RepeatModePreference extends Preference
+{
+    public function getDefaultValue(): string
+    {
+        return 'NO_REPEAT';
+    }
+
+    public function assert(): void
+    {
+        Assert::oneOf($this->value, ['NO_REPEAT', 'REPEAT_ALL', 'REPEAT_ONE']);
+    }
+}

--- a/app/Values/User/Preferences/ShowAlbumArtOverlayPreference.php
+++ b/app/Values/User/Preferences/ShowAlbumArtOverlayPreference.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Values\User\Preferences;
+
+class ShowAlbumArtOverlayPreference extends Preference
+{
+    public function getDefaultValue(): true
+    {
+        return true;
+    }
+
+    protected function cast(mixed $value): bool
+    {
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+    }
+}

--- a/app/Values/User/Preferences/ShowAlbumArtOverlayPreference.php
+++ b/app/Values/User/Preferences/ShowAlbumArtOverlayPreference.php
@@ -2,15 +2,10 @@
 
 namespace App\Values\User\Preferences;
 
-class ShowAlbumArtOverlayPreference extends Preference
+class ShowAlbumArtOverlayPreference extends BooleanPreference
 {
     public function getDefaultValue(): true
     {
         return true;
-    }
-
-    protected function cast(mixed $value): bool
-    {
-        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
     }
 }

--- a/app/Values/User/Preferences/ShowNowPlayingNotificationPreference.php
+++ b/app/Values/User/Preferences/ShowNowPlayingNotificationPreference.php
@@ -2,15 +2,10 @@
 
 namespace App\Values\User\Preferences;
 
-class ShowNowPlayingNotificationPreference extends Preference
+class ShowNowPlayingNotificationPreference extends BooleanPreference
 {
     public function getDefaultValue(): true
     {
         return true;
-    }
-
-    protected function cast(mixed $value): bool
-    {
-        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
     }
 }

--- a/app/Values/User/Preferences/ShowNowPlayingNotificationPreference.php
+++ b/app/Values/User/Preferences/ShowNowPlayingNotificationPreference.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Values\User\Preferences;
+
+class ShowNowPlayingNotificationPreference extends Preference
+{
+    public function getDefaultValue(): true
+    {
+        return true;
+    }
+
+    protected function cast(mixed $value): bool
+    {
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+    }
+}

--- a/app/Values/User/Preferences/SortOrderPreference.php
+++ b/app/Values/User/Preferences/SortOrderPreference.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Values\User\Preferences;
+
+use Webmozart\Assert\Assert;
+
+abstract class SortOrderPreference extends Preference
+{
+    public function getDefaultValue(): string
+    {
+        return 'asc';
+    }
+
+    public function assert(): void
+    {
+        Assert::oneOf($this->value, ['asc', 'desc']);
+    }
+
+    protected function cast(mixed $value): string
+    {
+        return strtolower((string) $value);
+    }
+}

--- a/app/Values/User/Preferences/SupportBarNoBuggingPreference.php
+++ b/app/Values/User/Preferences/SupportBarNoBuggingPreference.php
@@ -2,15 +2,10 @@
 
 namespace App\Values\User\Preferences;
 
-class SupportBarNoBuggingPreference extends Preference
+class SupportBarNoBuggingPreference extends BooleanPreference
 {
     public function getDefaultValue(): false
     {
         return false;
-    }
-
-    protected function cast(mixed $value): bool
-    {
-        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
     }
 }

--- a/app/Values/User/Preferences/SupportBarNoBuggingPreference.php
+++ b/app/Values/User/Preferences/SupportBarNoBuggingPreference.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Values\User\Preferences;
+
+class SupportBarNoBuggingPreference extends Preference
+{
+    public function getDefaultValue(): false
+    {
+        return false;
+    }
+
+    protected function cast(mixed $value): bool
+    {
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+    }
+}

--- a/app/Values/User/Preferences/ThemePreference.php
+++ b/app/Values/User/Preferences/ThemePreference.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Values\User\Preferences;
+
+class ThemePreference extends Preference
+{
+    public function getDefaultValue(): string
+    {
+        return 'classic';
+    }
+}

--- a/app/Values/User/Preferences/TranscodeOnMobilePreference.php
+++ b/app/Values/User/Preferences/TranscodeOnMobilePreference.php
@@ -2,15 +2,10 @@
 
 namespace App\Values\User\Preferences;
 
-class TranscodeOnMobilePreference extends Preference
+class TranscodeOnMobilePreference extends BooleanPreference
 {
     public function getDefaultValue(): true
     {
         return true;
-    }
-
-    protected function cast(mixed $value): bool
-    {
-        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
     }
 }

--- a/app/Values/User/Preferences/TranscodeOnMobilePreference.php
+++ b/app/Values/User/Preferences/TranscodeOnMobilePreference.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Values\User\Preferences;
+
+class TranscodeOnMobilePreference extends Preference
+{
+    public function getDefaultValue(): true
+    {
+        return true;
+    }
+
+    protected function cast(mixed $value): bool
+    {
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+    }
+}

--- a/app/Values/User/Preferences/TranscodeQualityPreference.php
+++ b/app/Values/User/Preferences/TranscodeQualityPreference.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Values\User\Preferences;
+
+class TranscodeQualityPreference extends Preference
+{
+    private const array ALLOWED = [64, 96, 128, 192, 256, 320];
+
+    public function getDefaultValue(): int
+    {
+        return (int) config('koel.streaming.bitrate');
+    }
+
+    protected function cast(mixed $value): int
+    {
+        $cast = (int) $value;
+
+        return in_array($cast, self::ALLOWED, true) ? $cast : 128;
+    }
+}

--- a/app/Values/User/Preferences/VisualizerPreference.php
+++ b/app/Values/User/Preferences/VisualizerPreference.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Values\User\Preferences;
+
+class VisualizerPreference extends Preference
+{
+    public function getDefaultValue(): string
+    {
+        return 'default';
+    }
+}

--- a/app/Values/User/Preferences/VolumePreference.php
+++ b/app/Values/User/Preferences/VolumePreference.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Values\User\Preferences;
+
+class VolumePreference extends Preference
+{
+    public function getDefaultValue(): float
+    {
+        return 7.0;
+    }
+
+    protected function cast(mixed $value): float
+    {
+        return (float) $value;
+    }
+}

--- a/app/Values/User/UserPreferences.php
+++ b/app/Values/User/UserPreferences.php
@@ -4,257 +4,203 @@ namespace App\Values\User;
 
 use App\Values\EqualizerPreset;
 use App\Values\EqualizerPresetCollection;
+use App\Values\User\Preferences\Preference;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use JsonSerializable;
 use Webmozart\Assert\Assert;
 
-// @mago-ignore lint:cyclomatic-complexity
+// @mago-ignore lint:too-many-methods
+
+/**
+ * @property float $volume
+ * @property string $repeatMode
+ * @property EqualizerPreset $currentEqualizerPreset
+ * @property EqualizerPresetCollection $equalizerPresets
+ * @property string $albumsViewMode
+ * @property string $artistsViewMode
+ * @property string $radioStationsViewMode
+ * @property string $albumsSortField
+ * @property string $artistsSortField
+ * @property string $genresSortField
+ * @property string $podcastsSortField
+ * @property string $radioStationsSortField
+ * @property string $albumsSortOrder
+ * @property string $artistsSortOrder
+ * @property string $genresSortOrder
+ * @property string $podcastsSortOrder
+ * @property string $radioStationsSortOrder
+ * @property bool $albumsFavoritesOnly
+ * @property bool $artistsFavoritesOnly
+ * @property bool $podcastsFavoritesOnly
+ * @property bool $radioStationsFavoritesOnly
+ * @property string $theme
+ * @property bool $showNowPlayingNotification
+ * @property bool $confirmBeforeClosing
+ * @property bool $transcodeOnMobile
+ * @property int $transcodeQuality
+ * @property bool $showAlbumArtOverlay
+ * @property bool $makeUploadsPublic
+ * @property bool $detectDuplicateUploads
+ * @property bool $includePublicMedia
+ * @property bool $supportBarNoBugging
+ * @property bool $continuousPlayback
+ * @property int $crossfadeDuration
+ * @property int $lyricsZoomLevel
+ * @property string $visualizer
+ * @property ?string $activeExtraPanelTab
+ * @property ?string $lastFmSessionKey
+ */
 final class UserPreferences implements Arrayable, JsonSerializable
 {
-    private const array CASTS = [
-        'albums_favorites_only' => 'boolean',
-        'artists_favorites_only' => 'boolean',
-        'confirm_before_closing' => 'boolean',
-        'continuous_playback' => 'boolean',
-        'crossfade_duration' => 'integer',
-        'detect_duplicate_uploads' => 'boolean',
-        'include_public_media' => 'boolean',
-        'lyrics_zoom_level' => 'integer',
-        'make_uploads_public' => 'boolean',
-        'podcasts_favorites_only' => 'boolean',
-        'radio_stations_favorites_only' => 'boolean',
-        'show_album_art_overlay' => 'boolean',
-        'show_now_playing_notification' => 'boolean',
-        'support_bar_no_bugging' => 'boolean',
-        'transcode_on_mobile' => 'boolean',
-        'transcode_quality' => 'integer',
-        'volume' => 'float',
-    ];
+    /** @var Collection<int, class-string<Preference>>|null */
+    private static ?Collection $discoveredClasses = null;
 
-    private const array CUSTOMIZABLE_KEYS = [
-        'active_extra_panel_tab',
-        'albums_favorites_only',
-        'albums_sort_field',
-        'albums_sort_order',
-        'albums_view_mode',
-        'artists_favorites_only',
-        'artists_sort_field',
-        'artists_sort_order',
-        'artists_view_mode',
-        'confirm_before_closing',
-        'continuous_playback',
-        'crossfade_duration',
-        'detect_duplicate_uploads',
-        'current_equalizer_preset',
-        'equalizer_presets',
-        'genres_sort_field',
-        'genres_sort_order',
-        'include_public_media',
-        'lyrics_zoom_level',
-        'make_uploads_public',
-        'podcasts_favorites_only',
-        'podcasts_sort_field',
-        'podcasts_sort_order',
-        'radio_stations_favorites_only',
-        'radio_stations_sort_field',
-        'radio_stations_sort_order',
-        'radio_stations_view_mode',
-        'repeat_mode',
-        'show_album_art_overlay',
-        'show_now_playing_notification',
-        'support_bar_no_bugging',
-        'theme',
-        'transcode_on_mobile',
-        'transcode_quality',
-        'visualizer',
-        'volume',
-    ];
-
-    private const array ALL_KEYS = self::CUSTOMIZABLE_KEYS + ['lastfm_session_key'];
-
+    /** @param Collection<string, Preference> $preferences */
     private function __construct(
-        public float $volume,
-        public string $repeatMode,
-        public EqualizerPreset $currentEqualizerPreset,
-        public EqualizerPresetCollection $equalizerPresets,
-        public string $albumsViewMode,
-        public string $artistsViewMode,
-        public string $radioStationsViewMode,
-        public string $albumsSortField,
-        public string $artistsSortField,
-        public string $genresSortField,
-        public string $podcastsSortField,
-        public string $radioStationsSortField,
-        public string $albumsSortOrder,
-        public string $artistsSortOrder,
-        public string $genresSortOrder,
-        public string $podcastsSortOrder,
-        public string $radioStationsSortOrder,
-        public bool $albumsFavoritesOnly,
-        public bool $artistsFavoritesOnly,
-        public bool $podcastsFavoritesOnly,
-        public bool $radioStationsFavoritesOnly,
-        public string $theme,
-        public bool $showNowPlayingNotification,
-        public bool $confirmBeforeClosing,
-        public bool $transcodeOnMobile,
-        public int $transcodeQuality,
-        public bool $showAlbumArtOverlay,
-        public bool $makeUploadsPublic,
-        public bool $detectDuplicateUploads,
-        public bool $includePublicMedia,
-        public bool $supportBarNoBugging,
-        public bool $continuousPlayback,
-        public int $crossfadeDuration,
-        public int $lyricsZoomLevel,
-        public string $visualizer,
-        public ?string $activeExtraPanelTab,
-        public ?string $lastFmSessionKey,
-    ) {
-        Assert::oneOf($this->repeatMode, ['NO_REPEAT', 'REPEAT_ALL', 'REPEAT_ONE']);
-        Assert::oneOf($this->artistsViewMode, ['list', 'thumbnails']);
-        Assert::oneOf($this->albumsViewMode, ['list', 'thumbnails']);
-        Assert::oneOf($this->radioStationsViewMode, ['list', 'thumbnails']);
-        Assert::oneOf($this->activeExtraPanelTab, [null, 'Lyrics', 'Artist', 'Album', 'YouTube']);
-        Assert::oneOf(strtolower($this->albumsSortOrder), ['asc', 'desc']);
-        Assert::oneOf($this->albumsSortField, ['name', 'artist_name', 'year', 'created_at']);
-        Assert::oneOf(strtolower($this->artistsSortOrder), ['asc', 'desc']);
-        Assert::oneOf($this->artistsSortField, ['name', 'created_at']);
-        Assert::oneOf($this->genresSortField, ['name', 'song_count']);
-        Assert::oneOf(strtolower($this->genresSortOrder), ['asc', 'desc']);
-        Assert::oneOf($this->podcastsSortField, ['title', 'last_played_at', 'subscribed_at', 'author']);
-        Assert::oneOf(strtolower($this->podcastsSortOrder), ['asc', 'desc']);
-        Assert::oneOf($this->radioStationsSortField, ['name', 'created_at']);
-        Assert::oneOf(strtolower($this->radioStationsSortOrder), ['asc', 'desc']);
-
-        Assert::range($this->crossfadeDuration, 0, 15);
-
-        if (!in_array($this->transcodeQuality, [64, 96, 128, 192, 256, 320], true)) {
-            $this->transcodeQuality = 128;
-        }
-    }
+        private Collection $preferences,
+    ) {}
 
     public static function fromArray(array $data): self
     {
-        return new self(
-            volume: $data['volume'] ?? 7.0,
-            repeatMode: $data['repeat_mode'] ?? 'NO_REPEAT',
-            currentEqualizerPreset: EqualizerPreset::tryFromArray(
-                $data['current_equalizer_preset'] ?? $data['equalizer'] ?? null,
-            ) ?? EqualizerPreset::default(),
-            equalizerPresets: EqualizerPresetCollection::fromArray($data['equalizer_presets'] ?? []),
-            albumsViewMode: $data['albums_view_mode'] ?? 'thumbnails',
-            artistsViewMode: $data['artists_view_mode'] ?? 'thumbnails',
-            radioStationsViewMode: $data['radio_stations_view_mode'] ?? 'thumbnails',
-            albumsSortField: $data['albums_sort_field'] ?? 'name',
-            artistsSortField: $data['artists_sort_field'] ?? 'name',
-            genresSortField: $data['genres_sort_field'] ?? 'name',
-            podcastsSortField: $data['podcasts_sort_field'] ?? 'title',
-            radioStationsSortField: $data['radio_stations_sort_field'] ?? 'name',
-            albumsSortOrder: $data['albums_sort_order'] ?? 'asc',
-            artistsSortOrder: $data['artists_sort_order'] ?? 'asc',
-            genresSortOrder: $data['genres_sort_order'] ?? 'asc',
-            podcastsSortOrder: $data['podcasts_sort_order'] ?? 'asc',
-            radioStationsSortOrder: $data['radio_stations_sort_order'] ?? 'asc',
-            albumsFavoritesOnly: $data['albums_favorites_only'] ?? false,
-            artistsFavoritesOnly: $data['artists_favorites_only'] ?? false,
-            podcastsFavoritesOnly: $data['podcasts_favorites_only'] ?? false,
-            radioStationsFavoritesOnly: $data['radio_stations_favorites_only'] ?? false,
-            theme: $data['theme'] ?? 'classic',
-            showNowPlayingNotification: $data['show_now_playing_notification'] ?? true,
-            confirmBeforeClosing: $data['confirm_before_closing'] ?? false,
-            transcodeOnMobile: $data['transcode_on_mobile'] ?? true,
-            transcodeQuality: $data['transcode_quality'] ?? config('koel.streaming.bitrate'),
-            showAlbumArtOverlay: $data['show_album_art_overlay'] ?? true,
-            makeUploadsPublic: $data['make_uploads_public'] ?? false,
-            detectDuplicateUploads: $data['detect_duplicate_uploads'] ?? true,
-            includePublicMedia: $data['include_public_media'] ?? true,
-            supportBarNoBugging: $data['support_bar_no_bugging'] ?? false,
-            continuousPlayback: $data['continuous_playback'] ?? false,
-            crossfadeDuration: $data['crossfade_duration'] ?? 0,
-            lyricsZoomLevel: $data['lyrics_zoom_level'] ?? 1,
-            visualizer: $data['visualizer'] ?? 'default',
-            activeExtraPanelTab: $data['active_extra_panel_tab'] ?? null,
-            lastFmSessionKey: $data['lastfm_session_key'] ?? null,
-        );
+        $preferences = self::preferenceClasses()
+            ->mapWithKeys(static function (string $class) use ($data): array {
+                $proto = new $class();
+                $raw = self::readWithAliases($data, $proto);
+
+                return [$proto->getKey() => $proto::make($raw)];
+            });
+
+        return new self($preferences);
+    }
+
+    public function __get(string $property): mixed
+    {
+        return $this->requirePreferenceByProperty($property)->getValue();
+    }
+
+    public function __set(string $property, mixed $value): void
+    {
+        $preference = $this->requirePreferenceByProperty($property);
+        $this->preferences->put($preference->getKey(), $preference::make($value));
+    }
+
+    public function __isset(string $property): bool
+    {
+        return $this->preferenceByProperty($property) !== null;
     }
 
     public static function customizable(string $key): bool
     {
-        return in_array($key, self::CUSTOMIZABLE_KEYS, true);
+        $class = self::classByKey($key);
+
+        return $class !== null && (new $class())->isCustomizable();
     }
 
     public function set(string $key, mixed $value): self
     {
-        self::assertValidKey($key);
+        $class = self::classByKey($key);
+        Assert::notNull($class, "Unknown preference key: {$key}");
 
-        $cast = self::CASTS[$key] ?? null;
+        $copy = clone $this;
+        $copy->preferences = $copy->preferences->put($key, $class::make($value));
 
-        $value = match ($cast) {
-            'boolean' => filter_var($value, FILTER_VALIDATE_BOOLEAN),
-            'integer' => (int) $value,
-            'float' => (float) $value,
-            default => $value,
-        };
-
-        $arr = $this->toArray();
-        $arr[$key] = $value;
-
-        return self::fromArray($arr);
-    }
-
-    public static function assertValidKey(string $key): void
-    {
-        Assert::inArray($key, self::ALL_KEYS);
+        return $copy;
     }
 
     /** @inheritdoc */
     public function toArray(): array
     {
-        return [
-            'theme' => $this->theme,
-            'show_now_playing_notification' => $this->showNowPlayingNotification,
-            'confirm_before_closing' => $this->confirmBeforeClosing,
-            'show_album_art_overlay' => $this->showAlbumArtOverlay,
-            'transcode_on_mobile' => $this->transcodeOnMobile,
-            'transcode_quality' => $this->transcodeQuality,
-            'make_uploads_public' => $this->makeUploadsPublic,
-            'detect_duplicate_uploads' => $this->detectDuplicateUploads,
-            'include_public_media' => $this->includePublicMedia,
-            'lastfm_session_key' => $this->lastFmSessionKey,
-            'support_bar_no_bugging' => $this->supportBarNoBugging,
-            'albums_view_mode' => $this->albumsViewMode,
-            'artists_view_mode' => $this->artistsViewMode,
-            'radio_stations_view_mode' => $this->radioStationsViewMode,
-            'albums_sort_field' => $this->albumsSortField,
-            'artists_sort_field' => $this->artistsSortField,
-            'genres_sort_field' => $this->genresSortField,
-            'podcasts_sort_field' => $this->podcastsSortField,
-            'radio_stations_sort_field' => $this->radioStationsSortField,
-            'albums_sort_order' => $this->albumsSortOrder,
-            'artists_sort_order' => $this->artistsSortOrder,
-            'genres_sort_order' => $this->genresSortOrder,
-            'podcasts_sort_order' => $this->podcastsSortOrder,
-            'radio_stations_sort_order' => $this->radioStationsSortOrder,
-            'albums_favorites_only' => $this->albumsFavoritesOnly,
-            'artists_favorites_only' => $this->artistsFavoritesOnly,
-            'podcasts_favorites_only' => $this->podcastsFavoritesOnly,
-            'radio_stations_favorites_only' => $this->radioStationsFavoritesOnly,
-            'repeat_mode' => $this->repeatMode,
-            'volume' => $this->volume,
-            'current_equalizer_preset' => $this->currentEqualizerPreset->toArray(),
-            'equalizer_presets' => $this->equalizerPresets->map(static fn (EqualizerPreset $p) => $p->toArray())->all(),
-            'lyrics_zoom_level' => $this->lyricsZoomLevel,
-            'visualizer' => $this->visualizer,
-            'active_extra_panel_tab' => $this->activeExtraPanelTab,
-            'continuous_playback' => $this->continuousPlayback,
-            'crossfade_duration' => $this->crossfadeDuration,
-        ];
+        return $this->preferences->map(static fn (Preference $preference): mixed => self::serializeValue(
+            $preference->getValue(),
+        ))->all();
     }
 
     /** @inheritdoc */
     public function jsonSerialize(): array
     {
         return $this->toArray();
+    }
+
+    public function __clone(): void
+    {
+        $this->preferences = clone $this->preferences;
+    }
+
+    /** @return Collection<int, class-string<Preference>> */
+    private static function preferenceClasses(): Collection
+    {
+        if (self::$discoveredClasses !== null) {
+            return self::$discoveredClasses;
+        }
+
+        $namespace = 'App\\Values\\User\\Preferences\\';
+
+        $classes = collect(glob(__DIR__ . '/Preferences/*Preference.php') ?: [])
+            ->map(static fn (string $file): string => $namespace . pathinfo($file, PATHINFO_FILENAME))
+            ->filter(static fn (string $candidate): bool => is_subclass_of($candidate, Preference::class))
+            ->values();
+
+        self::$discoveredClasses = $classes;
+
+        return $classes;
+    }
+
+    private function preferenceByProperty(string $property): ?Preference
+    {
+        return $this->preferences->first(
+            static fn (Preference $preference): bool => $preference->getProperty() === $property,
+        );
+    }
+
+    private function requirePreferenceByProperty(string $property): Preference
+    {
+        $preference = $this->preferenceByProperty($property);
+        Assert::notNull($preference, "Unknown preference property: {$property}");
+
+        return $preference;
+    }
+
+    /** @return class-string<Preference>|null */
+    private static function classByKey(string $key): ?string
+    {
+        return self::preferenceClasses()->first(static fn (string $class): bool => (new $class())->getKey() === $key);
+    }
+
+    private static function readWithAliases(array $data, Preference $proto): mixed
+    {
+        $key = $proto->getKey();
+
+        if (Arr::exists($data, $key)) {
+            return $data[$key];
+        }
+
+        foreach ($proto->getAliases() as $alias) {
+            if (Arr::exists($data, $alias)) {
+                return $data[$alias];
+            }
+        }
+
+        return null;
+    }
+
+    private static function serializeValue(mixed $value): mixed
+    {
+        if ($value instanceof Arrayable) {
+            return $value->toArray();
+        }
+
+        if (is_iterable($value) && !is_array($value)) {
+            $items = [];
+
+            foreach ($value as $item) {
+                $items[] = $item instanceof Arrayable ? $item->toArray() : $item;
+            }
+
+            return $items;
+        }
+
+        return $value;
     }
 }

--- a/app/Values/User/UserPreferences.php
+++ b/app/Values/User/UserPreferences.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use JsonSerializable;
+use ReflectionClass;
 use Webmozart\Assert\Assert;
 
 // @mago-ignore lint:too-many-methods
@@ -88,7 +89,9 @@ final class UserPreferences implements Arrayable, JsonSerializable
 
     public function __isset(string $property): bool
     {
-        return $this->preferenceByProperty($property) !== null;
+        $preference = $this->preferenceByProperty($property);
+
+        return $preference !== null && $preference->getValue() !== null;
     }
 
     public static function customizable(string $key): bool
@@ -139,7 +142,11 @@ final class UserPreferences implements Arrayable, JsonSerializable
 
         $classes = collect(glob(__DIR__ . '/Preferences/*Preference.php') ?: [])
             ->map(static fn (string $file): string => $namespace . pathinfo($file, PATHINFO_FILENAME))
-            ->filter(static fn (string $candidate): bool => is_subclass_of($candidate, Preference::class))
+            ->filter(
+                static fn (string $candidate): bool => (
+                    is_subclass_of($candidate, Preference::class) && !(new ReflectionClass($candidate))->isAbstract()
+                ),
+            )
             ->values();
 
         self::$discoveredClasses = $classes;

--- a/tests/Integration/Casts/UserPreferencesCastTest.php
+++ b/tests/Integration/Casts/UserPreferencesCastTest.php
@@ -10,11 +10,6 @@ use function Tests\create_user;
 
 class UserPreferencesCastTest extends TestCase
 {
-    /**
-     * Tripwire: pins the full set of preference storage keys produced by toArray().
-     * Adding or removing a Preference subclass will break this test, forcing an
-     * explicit update so additions/removals can't slip through silently.
-     */
     #[Test]
     public function serializedArrayContainsExactlyTheRegisteredPreferenceKeys(): void
     {

--- a/tests/Integration/Casts/UserPreferencesCastTest.php
+++ b/tests/Integration/Casts/UserPreferencesCastTest.php
@@ -53,10 +53,7 @@ class UserPreferencesCastTest extends TestCase
             'volume',
         ];
 
-        $actual = array_keys(UserPreferences::fromArray([])->toArray());
-        sort($actual);
-
-        self::assertSame($expected, $actual);
+        self::assertEqualsCanonicalizing($expected, array_keys(UserPreferences::fromArray([])->toArray()));
     }
 
     #[Test]

--- a/tests/Integration/Casts/UserPreferencesCastTest.php
+++ b/tests/Integration/Casts/UserPreferencesCastTest.php
@@ -10,6 +10,60 @@ use function Tests\create_user;
 
 class UserPreferencesCastTest extends TestCase
 {
+    /**
+     * Tripwire: pins the full set of preference storage keys produced by toArray().
+     * Adding or removing a Preference subclass will break this test, forcing an
+     * explicit update so additions/removals can't slip through silently.
+     */
+    #[Test]
+    public function serializedArrayContainsExactlyTheRegisteredPreferenceKeys(): void
+    {
+        $expected = [
+            'active_extra_panel_tab',
+            'albums_favorites_only',
+            'albums_sort_field',
+            'albums_sort_order',
+            'albums_view_mode',
+            'artists_favorites_only',
+            'artists_sort_field',
+            'artists_sort_order',
+            'artists_view_mode',
+            'confirm_before_closing',
+            'continuous_playback',
+            'crossfade_duration',
+            'current_equalizer_preset',
+            'detect_duplicate_uploads',
+            'equalizer_presets',
+            'genres_sort_field',
+            'genres_sort_order',
+            'include_public_media',
+            'lastfm_session_key',
+            'lyrics_zoom_level',
+            'make_uploads_public',
+            'podcasts_favorites_only',
+            'podcasts_sort_field',
+            'podcasts_sort_order',
+            'radio_stations_favorites_only',
+            'radio_stations_sort_field',
+            'radio_stations_sort_order',
+            'radio_stations_view_mode',
+            'repeat_mode',
+            'show_album_art_overlay',
+            'show_now_playing_notification',
+            'support_bar_no_bugging',
+            'theme',
+            'transcode_on_mobile',
+            'transcode_quality',
+            'visualizer',
+            'volume',
+        ];
+
+        $actual = array_keys(UserPreferences::fromArray([])->toArray());
+        sort($actual);
+
+        self::assertSame($expected, $actual);
+    }
+
     #[Test]
     public function cast(): void
     {

--- a/tests/Unit/Values/User/Preferences/PreferenceBehaviorTest.php
+++ b/tests/Unit/Values/User/Preferences/PreferenceBehaviorTest.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace Tests\Unit\Values\User\Preferences;
+
+use App\Values\EqualizerPreset;
+use App\Values\EqualizerPresetCollection;
+use App\Values\User\Preferences\ActiveExtraPanelTabPreference;
+use App\Values\User\Preferences\AlbumsSortFieldPreference;
+use App\Values\User\Preferences\AlbumsSortOrderPreference;
+use App\Values\User\Preferences\AlbumsViewModePreference;
+use App\Values\User\Preferences\CrossfadeDurationPreference;
+use App\Values\User\Preferences\CurrentEqualizerPresetPreference;
+use App\Values\User\Preferences\EqualizerPresetsPreference;
+use App\Values\User\Preferences\LastfmSessionKeyPreference;
+use App\Values\User\Preferences\MakeUploadsPublicPreference;
+use App\Values\User\Preferences\RepeatModePreference;
+use App\Values\User\Preferences\TranscodeQualityPreference;
+use App\Values\User\Preferences\VolumePreference;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+use Webmozart\Assert\InvalidArgumentException as AssertException;
+
+class PreferenceBehaviorTest extends TestCase
+{
+    #[Test]
+    public function volumeCastsToFloat(): void
+    {
+        self::assertSame(7.5, VolumePreference::make('7.5')->getValue());
+        self::assertSame(0.0, VolumePreference::make(0)->getValue());
+        self::assertSame(7.0, VolumePreference::make(null)->getValue());
+    }
+
+    #[Test]
+    public function repeatModeRejectsUnknownValue(): void
+    {
+        $this->expectException(AssertException::class);
+        RepeatModePreference::make('SHUFFLE');
+    }
+
+    #[Test]
+    public function repeatModeAcceptsValidValues(): void
+    {
+        foreach (['NO_REPEAT', 'REPEAT_ALL', 'REPEAT_ONE'] as $value) {
+            self::assertSame($value, RepeatModePreference::make($value)->getValue());
+        }
+    }
+
+    #[Test]
+    public function albumsViewModeRejectsUnknownValue(): void
+    {
+        $this->expectException(AssertException::class);
+        AlbumsViewModePreference::make('grid');
+    }
+
+    #[Test]
+    public function albumsSortFieldRejectsUnknownValue(): void
+    {
+        $this->expectException(AssertException::class);
+        AlbumsSortFieldPreference::make('unknown_column');
+    }
+
+    #[Test]
+    public function albumsSortOrderIsCaseInsensitive(): void
+    {
+        self::assertSame('ASC', AlbumsSortOrderPreference::make('ASC')->getValue());
+        self::assertSame('Desc', AlbumsSortOrderPreference::make('Desc')->getValue());
+    }
+
+    #[Test]
+    public function activeExtraPanelTabAcceptsNull(): void
+    {
+        self::assertNull(ActiveExtraPanelTabPreference::make(null)->getValue());
+    }
+
+    #[Test]
+    public function activeExtraPanelTabRejectsUnknownTab(): void
+    {
+        $this->expectException(AssertException::class);
+        ActiveExtraPanelTabPreference::make('Settings');
+    }
+
+    #[Test]
+    public function makeUploadsPublicCoercesTruthyStrings(): void
+    {
+        self::assertTrue(MakeUploadsPublicPreference::make('true')->getValue());
+        self::assertTrue(MakeUploadsPublicPreference::make(1)->getValue());
+        self::assertFalse(MakeUploadsPublicPreference::make('false')->getValue());
+        self::assertFalse(MakeUploadsPublicPreference::make(0)->getValue());
+        self::assertFalse(MakeUploadsPublicPreference::make(null)->getValue());
+    }
+
+    #[Test]
+    public function crossfadeDurationCastsToInt(): void
+    {
+        self::assertSame(5, CrossfadeDurationPreference::make('5')->getValue());
+    }
+
+    #[Test]
+    public function crossfadeDurationRejectsOutOfRange(): void
+    {
+        $this->expectException(AssertException::class);
+        CrossfadeDurationPreference::make(20);
+    }
+
+    #[Test]
+    public function transcodeQualityFallsBackTo128ForUnknownBitrate(): void
+    {
+        self::assertSame(128, TranscodeQualityPreference::make(99)->getValue());
+        self::assertSame(256, TranscodeQualityPreference::make(256)->getValue());
+    }
+
+    #[Test]
+    public function lastfmSessionKeyIsNotCustomizable(): void
+    {
+        self::assertFalse((new LastfmSessionKeyPreference())->isCustomizable());
+        self::assertSame('lastFmSessionKey', (new LastfmSessionKeyPreference())->getProperty());
+        self::assertSame('lastfm_session_key', (new LastfmSessionKeyPreference())->getKey());
+    }
+
+    #[Test]
+    public function currentEqualizerPresetExposesLegacyAlias(): void
+    {
+        $aliases = (new CurrentEqualizerPresetPreference())->getAliases();
+        self::assertSame(['equalizer'], $aliases);
+    }
+
+    #[Test]
+    public function currentEqualizerPresetParsesArray(): void
+    {
+        $value = CurrentEqualizerPresetPreference::make([
+            'name' => 'Rock',
+            'preamp' => 2.0,
+            'gains' => [4, 4, 4, 4, 4, 4, 4, 4, 4, 4],
+        ])->getValue();
+
+        self::assertInstanceOf(EqualizerPreset::class, $value);
+        self::assertSame('Rock', $value->name);
+    }
+
+    #[Test]
+    public function currentEqualizerPresetPassesThroughInstance(): void
+    {
+        $preset = EqualizerPreset::default();
+        self::assertSame($preset, CurrentEqualizerPresetPreference::make($preset)->getValue());
+    }
+
+    #[Test]
+    public function equalizerPresetsParsesArrayOfPresets(): void
+    {
+        $value = EqualizerPresetsPreference::make([
+            ['id' => '01J0000000000000000000ABCD', 'name' => 'Mine', 'preamp' => 0, 'gains' => array_fill(0, 10, 0)],
+        ])->getValue();
+
+        self::assertInstanceOf(EqualizerPresetCollection::class, $value);
+        self::assertCount(1, $value);
+        self::assertSame('Mine', $value->first()->name);
+    }
+
+    #[Test]
+    public function unknownPropertyAccessThrows(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        VolumePreference::make(7.0)->somethingWrong; // @phpstan-ignore-line
+    }
+}

--- a/tests/Unit/Values/User/Preferences/PreferenceBehaviorTest.php
+++ b/tests/Unit/Values/User/Preferences/PreferenceBehaviorTest.php
@@ -61,10 +61,10 @@ class PreferenceBehaviorTest extends TestCase
     }
 
     #[Test]
-    public function albumsSortOrderIsCaseInsensitive(): void
+    public function albumsSortOrderNormalizesToLowercase(): void
     {
-        self::assertSame('ASC', AlbumsSortOrderPreference::make('ASC')->getValue());
-        self::assertSame('Desc', AlbumsSortOrderPreference::make('Desc')->getValue());
+        self::assertSame('asc', AlbumsSortOrderPreference::make('ASC')->getValue());
+        self::assertSame('desc', AlbumsSortOrderPreference::make('Desc')->getValue());
     }
 
     #[Test]

--- a/tests/Unit/Values/User/Preferences/PreferenceContractTest.php
+++ b/tests/Unit/Values/User/Preferences/PreferenceContractTest.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace Tests\Unit\Values\User\Preferences;
+
+use App\Values\User\Preferences\AlbumsFavoritesOnlyPreference;
+use App\Values\User\Preferences\ArtistsFavoritesOnlyPreference;
+use App\Values\User\Preferences\ConfirmBeforeClosingPreference;
+use App\Values\User\Preferences\ContinuousPlaybackPreference;
+use App\Values\User\Preferences\CrossfadeDurationPreference;
+use App\Values\User\Preferences\DetectDuplicateUploadsPreference;
+use App\Values\User\Preferences\IncludePublicMediaPreference;
+use App\Values\User\Preferences\LastfmSessionKeyPreference;
+use App\Values\User\Preferences\LyricsZoomLevelPreference;
+use App\Values\User\Preferences\MakeUploadsPublicPreference;
+use App\Values\User\Preferences\PodcastsFavoritesOnlyPreference;
+use App\Values\User\Preferences\Preference;
+use App\Values\User\Preferences\RadioStationsFavoritesOnlyPreference;
+use App\Values\User\Preferences\ShowAlbumArtOverlayPreference;
+use App\Values\User\Preferences\ShowNowPlayingNotificationPreference;
+use App\Values\User\Preferences\SupportBarNoBuggingPreference;
+use App\Values\User\Preferences\TranscodeOnMobilePreference;
+use Generator;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionClass;
+use Tests\TestCase;
+
+class PreferenceContractTest extends TestCase
+{
+    /** @param class-string<Preference> $class */
+    #[Test]
+    #[DataProvider('preferenceClasses')]
+    public function keyIsSnakeCase(string $class): void
+    {
+        $key = (new $class())->getKey();
+        self::assertNotEmpty($key);
+        self::assertSame($key, Str::snake($key), "Key {$key} on {$class} is not snake_case");
+        self::assertDoesNotMatchRegularExpression('/[A-Z]/', $key);
+    }
+
+    /** @param class-string<Preference> $class */
+    #[Test]
+    #[DataProvider('preferenceClasses')]
+    public function propertyIsCamelCase(string $class): void
+    {
+        $property = (new $class())->getProperty();
+        self::assertNotEmpty($property);
+        self::assertDoesNotMatchRegularExpression('/[_\s]/', $property);
+        self::assertDoesNotMatchRegularExpression('/^[A-Z]/', $property);
+    }
+
+    /** @param class-string<Preference> $class */
+    #[Test]
+    #[DataProvider('preferenceClasses')]
+    public function makeWithNullYieldsDefaultValue(string $class): void
+    {
+        $proto = new $class();
+        $instance = $class::make(null);
+
+        self::assertEquals($proto->getDefaultValue(), $instance->getValue());
+    }
+
+    /** @param class-string<Preference> $class */
+    #[Test]
+    #[DataProvider('preferenceClasses')]
+    public function defaultValuePassesAssert(string $class): void
+    {
+        $instance = $class::make(null);
+        $instance->assert();
+
+        $this->addToAssertionCount(1);
+    }
+
+    /** @param class-string<Preference> $class */
+    #[Test]
+    #[DataProvider('preferenceClasses')]
+    public function customizableDefaultsTrueExceptForLastFmSessionKey(string $class): void
+    {
+        $customizable = (new $class())->isCustomizable();
+
+        if ($class === LastfmSessionKeyPreference::class) {
+            self::assertFalse($customizable);
+        } else {
+            self::assertTrue($customizable);
+        }
+    }
+
+    /** @param class-string<Preference> $class */
+    #[Test]
+    #[DataProvider('booleanPreferences')]
+    public function booleanPreferencesCoerceTruthyAndFalsyInputs(string $class): void
+    {
+        foreach ([true, 1, '1', 'true', 'on', 'yes'] as $truthy) {
+            self::assertTrue($class::make($truthy)->getValue(), 'Expected truthy: ' . var_export($truthy, true));
+        }
+
+        foreach ([false, 0, '0', 'false', 'off', 'no', ''] as $falsy) {
+            self::assertFalse($class::make($falsy)->getValue(), 'Expected falsy: ' . var_export($falsy, true));
+        }
+    }
+
+    /** @param class-string<Preference> $class */
+    #[Test]
+    #[DataProvider('integerPreferences')]
+    public function integerPreferencesCastNumericStringsAndFloats(string $class): void
+    {
+        $cast = $class::make('5')->getValue();
+        self::assertIsInt($cast);
+        self::assertSame(5, $cast);
+
+        $cast = $class::make(7.9)->getValue();
+        self::assertIsInt($cast);
+        self::assertSame(7, $cast);
+    }
+
+    /** @return Generator<string, array{class-string<Preference>}> */
+    public static function preferenceClasses(): Generator
+    {
+        $namespace = 'App\\Values\\User\\Preferences\\';
+        $directory = dirname(__DIR__, 5) . '/app/Values/User/Preferences';
+
+        foreach (glob($directory . '/*Preference.php') ?: [] as $file) {
+            $class = $namespace . pathinfo($file, PATHINFO_FILENAME);
+
+            if (!is_subclass_of($class, Preference::class)) {
+                continue;
+            }
+
+            $shortName = (new ReflectionClass($class))->getShortName();
+            yield $shortName => [$class];
+        }
+    }
+
+    /** @return Generator<string, array{class-string<Preference>}> */
+    public static function booleanPreferences(): Generator
+    {
+        $classes = [
+            AlbumsFavoritesOnlyPreference::class,
+            ArtistsFavoritesOnlyPreference::class,
+            PodcastsFavoritesOnlyPreference::class,
+            RadioStationsFavoritesOnlyPreference::class,
+            ConfirmBeforeClosingPreference::class,
+            MakeUploadsPublicPreference::class,
+            SupportBarNoBuggingPreference::class,
+            ContinuousPlaybackPreference::class,
+            ShowNowPlayingNotificationPreference::class,
+            TranscodeOnMobilePreference::class,
+            ShowAlbumArtOverlayPreference::class,
+            DetectDuplicateUploadsPreference::class,
+            IncludePublicMediaPreference::class,
+        ];
+
+        foreach ($classes as $class) {
+            yield (new ReflectionClass($class))->getShortName() => [$class];
+        }
+    }
+
+    /** @return Generator<string, array{class-string<Preference>}> */
+    public static function integerPreferences(): Generator
+    {
+        foreach ([CrossfadeDurationPreference::class, LyricsZoomLevelPreference::class] as $class) {
+            yield (new ReflectionClass($class))->getShortName() => [$class];
+        }
+    }
+}

--- a/tests/Unit/Values/User/Preferences/PreferenceContractTest.php
+++ b/tests/Unit/Values/User/Preferences/PreferenceContractTest.php
@@ -127,8 +127,13 @@ class PreferenceContractTest extends TestCase
                 continue;
             }
 
-            $shortName = (new ReflectionClass($class))->getShortName();
-            yield $shortName => [$class];
+            $reflection = new ReflectionClass($class);
+
+            if ($reflection->isAbstract()) {
+                continue;
+            }
+
+            yield $reflection->getShortName() => [$class];
         }
     }
 


### PR DESCRIPTION
## Summary

Collapses `UserPreferences` from a 260-line monolith into a polymorphic `Preference` hierarchy under `App\Values\User\Preferences\`. Adding a new preference is now **one new file**.

### Before

Every new preference required edits in 5–6 places: the `__construct` signature, the `CASTS` table, the `CUSTOMIZABLE_KEYS` list, `fromArray`, `toArray`, plus per-key `Assert::oneOf` calls in the constructor.

### After

- Abstract `App\Values\User\Preferences\Preference` with `getKey() / getProperty() / getDefaultValue() / make() / assert() / isCustomizable() / getAliases()`. Auto-derives `getKey()` from class name (`RepeatModePreference` → `repeat_mode`). Routes value writes through `__set` so `assert()` fires automatically on every assignment.
- 37 concrete subclasses (`VolumePreference`, `RepeatModePreference`, `CurrentEqualizerPresetPreference`, `LastfmSessionKeyPreference`, etc.). Each is 5–15 lines and overrides only what it needs (`cast`, `assert`, `getDefaultValue`, `getAliases`).
- `UserPreferences` becomes a Collection-backed dispatcher: glob-scans the `Preferences/` directory at boot, exposes `__get`/`__set`/`__isset`/`set`/`toArray`/`jsonSerialize`. The `@property` docblock keeps PHPStan and IDEs typing the magic surface (e.g. `$user->preferences->volume: float`).
- All existing typed call sites (`$user->preferences->lastFmSessionKey`, `$user->preferences->includePublicMedia`, etc.) work unchanged.
- BC for legacy persisted data preserved via `getAliases()` — `current_equalizer_preset` falls back to the old `equalizer` key.

### Tests

- `tests/Unit/Values/User/Preferences/PreferenceContractTest.php` — auto-discovers all preferences and runs 7 contract assertions per class:
  - `getKey()` is snake_case
  - `getProperty()` is camelCase
  - `make(null)` yields `getDefaultValue()`
  - default value passes `assert()`
  - `isCustomizable()` is `true` everywhere except `LastfmSessionKeyPreference`
  - boolean preferences coerce truthy/falsy strings (13 prefs)
  - integer preferences cast numeric strings/floats (2 prefs)
- `tests/Unit/Values/User/Preferences/PreferenceBehaviorTest.php` — 18 targeted tests for non-trivial cases: volume float cast, repeat-mode enum, sort-order case-insensitivity, crossfade range, transcode-quality fallback, `EqualizerPreset` hydration + passthrough, BC alias, unknown-property `__get` throw.
- Existing `UserPreferencesCastTest` and `EqualizerPresetTest` pass unchanged.

### Also

Adds an `AGENTS.md` rule banning combined assignment-and-return (`return $x = expr;` → `$x = expr; return $x;`).

## Test plan

- [x] `php artisan test --compact tests/Unit/Values/User/Preferences/` — 218 tests pass
- [x] `php artisan test --compact tests/Integration/Casts/UserPreferencesCastTest.php tests/Feature/EqualizerPresetTest.php` — 26 tests pass
- [x] `composer cs` — clean
- [x] `composer analyze` — clean
- [x] `composer lint` — clean
- [ ] CI green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Major overhaul of user preferences: dynamic, extensible preference system with many new customizable options (view modes, sort fields/orders, favorites-only toggles, playback, equalizer, volume, theme, notifications, transcode/quality, visualizer, and more).

* **Bug Fixes / Behavior**
  * Improved input coercion and validation for numeric, boolean, range and enumerated preference values.

* **Tests**
  * Added unit and integration tests covering preference behavior, serialization, and contract compliance.

* **Documentation**
  * Coding guideline updated to forbid combined assignment-and-return statements.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2457)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->