### PR TITLE
test: move SongStorageType enum tests to tests/Unit

### DIFF
--- a/tests/Unit/Enums/SongStorageTypeTest.php
+++ b/tests/Unit/Enums/SongStorageTypeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Integration\Enums;
+namespace Tests\Unit\Enums;
 
 use App\Enums\SongStorageType;
 use PHPUnit\Framework\Attributes\Test;

--- a/tests/Unit/KoelPlus/Enums/SongStorageTypeTest.php
+++ b/tests/Unit/KoelPlus/Enums/SongStorageTypeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Integration\KoelPlus\Enums;
+namespace Tests\Unit\KoelPlus\Enums;
 
 use App\Enums\SongStorageType;
 use PHPUnit\Framework\Attributes\Test;


### PR DESCRIPTION
## Summary

Moves the two `SongStorageType` enum tests from `tests/Integration/Enums/` to `tests/Unit/Enums/`. Both files exercise enum methods with no DB, filesystem, or multi-module wiring — they're unit tests by koel's scope-based suite classification.

- `tests/Integration/Enums/SongStorageTypeTest.php` → `tests/Unit/Enums/SongStorageTypeTest.php`
- `tests/Integration/KoelPlus/Enums/SongStorageTypeTest.php` → `tests/Unit/KoelPlus/Enums/SongStorageTypeTest.php`

Namespace declarations updated accordingly. No other changes.

## Test plan

- [x] `php artisan test --compact tests/Unit/Enums tests/Unit/KoelPlus/Enums` — 3 tests pass
- [ ] CI green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reorganized test structure for improved test categorization.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2459)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->