### PR TITLE
fix: show a sensible error when an upload's response body is not JSON

### DIFF
--- a/resources/assets/js/services/httpUpload.ts
+++ b/resources/assets/js/services/httpUpload.ts
@@ -24,16 +24,16 @@ export const postWithProgress = <T>(
     xhr.upload.addEventListener('progress', onUploadProgress)
 
     xhr.addEventListener('load', () => {
-      let responseData: any
+      let responseData: unknown
 
       try {
         responseData = JSON.parse(xhr.responseText)
       } catch {
-        responseData = xhr.responseText
+        responseData = undefined
       }
 
       if (xhr.status >= 200 && xhr.status < 300) {
-        resolve(responseData)
+        resolve(responseData as T)
       } else {
         const error = Object.assign(new Error(`Upload failed with status ${xhr.status}`), {
           responseData,

--- a/resources/assets/js/services/uploadService.spec.ts
+++ b/resources/assets/js/services/uploadService.spec.ts
@@ -192,7 +192,23 @@ describe('uploadService', () => {
     await uploadService.upload(file)
 
     expect(file.status).toBe('Errored')
-    expect(file.message).toBe('Upload failed: Unknown error.')
+    expect(file.message).toBe('Server error.')
+  })
+
+  it('shows a generic server error when responseData cannot be parsed', async () => {
+    const error = Object.assign(new Error('Upload failed with status 413'), {
+      status: 413,
+      responseData: undefined,
+    })
+
+    mockPostWithProgressRejection(error)
+    h.mock(uploadService, 'proceed')
+
+    const file = createUploadFile()
+    await uploadService.upload(file)
+
+    expect(file.status).toBe('Errored')
+    expect(file.message).toBe('Server error.')
   })
 
   it('aborts an in-progress upload', async () => {

--- a/resources/assets/js/services/uploadService.ts
+++ b/resources/assets/js/services/uploadService.ts
@@ -125,20 +125,22 @@ export const uploadService = {
 
       const err = error as {
         status?: number
-        responseData?: DuplicateUpload | { message?: string }
+        responseData?: unknown
       }
 
-      if (err.status === 409 && err.responseData) {
-        this.state.duplicatedSongs.push(err.responseData as DuplicateUpload)
+      const responseData = err.responseData
+      const isObjectResponse = responseData !== null && typeof responseData === 'object'
+
+      if (err.status === 409 && isObjectResponse) {
+        this.state.duplicatedSongs.push(responseData as DuplicateUpload)
         this.remove(file)
         return
       }
 
-      if (err.responseData && 'message' in err.responseData && err.responseData.message) {
-        file.message = `Upload failed: ${err.responseData.message}`
-      } else {
-        file.message = 'Upload failed: Unknown error.'
-      }
+      const message =
+        isObjectResponse && 'message' in responseData ? (responseData as { message?: unknown }).message : undefined
+
+      file.message = typeof message === 'string' && message ? `Upload failed: ${message}` : 'Server error.'
 
       this.proceed() // upload the next file
     } finally {


### PR DESCRIPTION
## Summary
- Uploads exceeding `post_max_size` returned a 413 whose body was HTML + JSON (PHP echoes a startup warning before Laravel renders the JSON in dev with `display_startup_errors=On`).
- `JSON.parse` failed and the response text was assigned to `responseData` as a raw string, then `'message' in responseData` threw a `TypeError` — no toast or error message was ever shown.
- Now: if the body isn't valid JSON, `responseData` is `undefined`; the upload service guards the `in` operator with `typeof === 'object'` and falls back to `Server error.` when there's no parseable message.

## Test plan
- [x] `vp test run resources/assets/js/services/uploadService.spec.ts` — 23 pass, including a new regression test for non-object `responseData`
- [x] `vp check` clean on all three changed files
- [ ] Manual: try uploading a file larger than `post_max_size` and confirm the upload item shows `Upload failed: The POST data is too large.` (parsed) or `Server error.` (when the body can't be parsed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages during file uploads to provide clearer feedback.
  * Enhanced server response validation to handle edge cases and malformed responses more gracefully.
  * Updated error handling logic to ensure consistent error messaging across different upload failure scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2461)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->