### PR TITLE
fix: show newly uploaded songs in their album and artist screens

### DIFF
--- a/resources/assets/js/services/uploadService.spec.ts
+++ b/resources/assets/js/services/uploadService.spec.ts
@@ -318,7 +318,7 @@ describe('uploadService', () => {
   it('invalidates album and artist song caches when handling an upload result', () => {
     const song = h.factory('song').make()
     const album = h.factory('album').make()
-    const invalidateMock = h.mock(playableStore, 'invalidateCachedSongsFor')
+    const invalidateMock = h.mock(playableStore, 'invalidateAlbumAndArtistSongCaches')
     h.mock(playableStore, 'syncWithVault')
     h.mock(albumStore, 'syncWithVault')
 

--- a/resources/assets/js/services/uploadService.spec.ts
+++ b/resources/assets/js/services/uploadService.spec.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from 'vite-plus/test'
 import { createHarness } from '@/__tests__/TestHarness'
+import { albumStore } from '@/stores/albumStore'
+import { playableStore } from '@/stores/playableStore'
 import type { UploadFile } from '@/services/uploadService'
 import { uploadService } from '@/services/uploadService'
 
@@ -311,5 +313,17 @@ describe('uploadService', () => {
 
     expect(file.status).toBe('Ready')
     expect(file.progress).toBe(0)
+  })
+
+  it('invalidates album and artist song caches when handling an upload result', () => {
+    const song = h.factory('song').make()
+    const album = h.factory('album').make()
+    const invalidateMock = h.mock(playableStore, 'invalidateCachedSongsFor')
+    h.mock(playableStore, 'syncWithVault')
+    h.mock(albumStore, 'syncWithVault')
+
+    uploadService.handleUploadResult({ song, album })
+
+    expect(invalidateMock).toHaveBeenCalledWith(song)
   })
 })

--- a/resources/assets/js/services/uploadService.ts
+++ b/resources/assets/js/services/uploadService.ts
@@ -176,7 +176,7 @@ export const uploadService = {
 
   handleUploadResult: (result: UploadResult) => {
     playableStore.syncWithVault(result.song)
-    playableStore.invalidateCachedSongsFor(result.song)
+    playableStore.invalidateAlbumAndArtistSongCaches(result.song)
     albumStore.syncWithVault(result.album)
     commonStore.state.song_length += 1
     eventBus.emit('SONG_UPLOADED', result.song)

--- a/resources/assets/js/services/uploadService.ts
+++ b/resources/assets/js/services/uploadService.ts
@@ -176,6 +176,7 @@ export const uploadService = {
 
   handleUploadResult: (result: UploadResult) => {
     playableStore.syncWithVault(result.song)
+    playableStore.invalidateCachedSongsFor(result.song)
     albumStore.syncWithVault(result.album)
     commonStore.state.song_length += 1
     eventBus.emit('SONG_UPLOADED', result.song)

--- a/resources/assets/js/stores/playableStore.spec.ts
+++ b/resources/assets/js/stores/playableStore.spec.ts
@@ -219,13 +219,13 @@ describe('playableStore', () => {
   })
 
   it('invalidates the album and artist song caches for a song', () => {
-    const song = h.factory('song').make({ album_id: 1, artist_id: 2 })
+    const song = h.factory('song').make({ album_id: 'album-1', artist_id: 'artist-1' })
     const removeMock = h.mock(cache, 'remove')
 
     playableStore.invalidateAlbumAndArtistSongCaches(song)
 
-    expect(removeMock).toHaveBeenCalledWith(['album.songs', 1])
-    expect(removeMock).toHaveBeenCalledWith(['artist.songs', 2])
+    expect(removeMock).toHaveBeenCalledWith(['album.songs', 'album-1'])
+    expect(removeMock).toHaveBeenCalledWith(['artist.songs', 'artist-1'])
   })
 
   it('fetches for playlist', async () => {

--- a/resources/assets/js/stores/playableStore.spec.ts
+++ b/resources/assets/js/stores/playableStore.spec.ts
@@ -218,6 +218,16 @@ describe('playableStore', () => {
     expect(syncMock).toHaveBeenCalledWith(songs)
   })
 
+  it('invalidates the album and artist song caches for a song', () => {
+    const song = h.factory('song').make({ album_id: 1, artist_id: 2 })
+    const removeMock = h.mock(cache, 'remove')
+
+    playableStore.invalidateCachedSongsFor(song)
+
+    expect(removeMock).toHaveBeenCalledWith(['album.songs', 1])
+    expect(removeMock).toHaveBeenCalledWith(['artist.songs', 2])
+  })
+
   it('fetches for playlist', async () => {
     const songs = h.factory('song').make(3)
     const playlist = h.factory('playlist').make({ id: '966268ea-935d-4f63-a84e-180385376a78' })

--- a/resources/assets/js/stores/playableStore.spec.ts
+++ b/resources/assets/js/stores/playableStore.spec.ts
@@ -222,7 +222,7 @@ describe('playableStore', () => {
     const song = h.factory('song').make({ album_id: 1, artist_id: 2 })
     const removeMock = h.mock(cache, 'remove')
 
-    playableStore.invalidateCachedSongsFor(song)
+    playableStore.invalidateAlbumAndArtistSongCaches(song)
 
     expect(removeMock).toHaveBeenCalledWith(['album.songs', 1])
     expect(removeMock).toHaveBeenCalledWith(['artist.songs', 2])

--- a/resources/assets/js/stores/playableStore.ts
+++ b/resources/assets/js/stores/playableStore.ts
@@ -210,6 +210,11 @@ export const playableStore = {
     )
   },
 
+  invalidateCachedSongsFor(song: Song) {
+    cache.remove(['album.songs', song.album_id])
+    cache.remove(['artist.songs', song.artist_id])
+  },
+
   async fetchSongsForArtist(artist: Artist | Artist['id']) {
     const id = typeof artist === 'string' ? artist : artist.id
 

--- a/resources/assets/js/stores/playableStore.ts
+++ b/resources/assets/js/stores/playableStore.ts
@@ -210,7 +210,7 @@ export const playableStore = {
     )
   },
 
-  invalidateCachedSongsFor(song: Song) {
+  invalidateAlbumAndArtistSongCaches(song: Song) {
     cache.remove(['album.songs', song.album_id])
     cache.remove(['artist.songs', song.artist_id])
   },


### PR DESCRIPTION
## Summary
- After uploading a song, the album and artist screens still showed their cached pre-upload song list until a hard refresh.
- `playableStore.fetchSongsForAlbum` / `fetchSongsForArtist` cache results under `['album.songs', id]` / `['artist.songs', id]` via `cache.remember`, and the upload flow never invalidated those keys.
- Added `playableStore.invalidateCachedSongsFor(song)` and call it from `uploadService.handleUploadResult` after the vault sync.

## Test plan
- [x] `vp test run resources/assets/js/stores/playableStore.spec.ts resources/assets/js/services/uploadService.spec.ts` — 54 pass, including two new unit tests
- [x] `vp check` clean on all four changed files
- [ ] Manual: upload one song into a fresh album, navigate to that album, upload a second song into the same album, navigate back — both songs should appear without a refresh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Album and artist song lists are now invalidated after a song upload so cached song data refreshes promptly across the app.
* **Tests**
  * Added unit tests to verify cache invalidation and related synchronization behavior following uploads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2462)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->