### PR TITLE
refactor: consolidate window globals under window.KOEL

### DIFF
--- a/resources/assets/js/App.vue
+++ b/resources/assets/js/App.vue
@@ -120,8 +120,8 @@ onMounted(() => {
 
   // If the user is authenticated via a proxy, we have the token in the window object.
   // Simply forward it to the authService and continue with the normal flow.
-  if (window.AUTH_TOKEN) {
-    authService.setTokensUsingCompositeToken(window.AUTH_TOKEN)
+  if (window.KOEL.auth_token) {
+    authService.setTokensUsingCompositeToken(window.KOEL.auth_token)
   }
 
   // The app has just been initialized, check if we can get the user data with an already existing token

--- a/resources/assets/js/__tests__/TestHarness.ts
+++ b/resources/assets/js/__tests__/TestHarness.ts
@@ -61,7 +61,7 @@ class TestHarness {
   }
 
   private setDefaultBranding() {
-    window.BRANDING = {
+    window.KOEL.branding = {
       name: 'Koel',
       logo: '',
       cover: '',
@@ -165,16 +165,16 @@ class TestHarness {
   public async withCustomBranding(branding: Branding, cb: Closure) {
     // Custom branding implicitly requires Plus edition.
     return await this.withPlusEdition(async () => {
-      window.BRANDING = branding
+      window.KOEL.branding = branding
       await cb()
       this.setDefaultBranding()
     })
   }
 
   public async withDemoMode(cb: Closure) {
-    window.IS_DEMO = true
+    window.KOEL.is_demo = true
     await cb()
-    window.IS_DEMO = false
+    window.KOEL.is_demo = false
 
     return this
   }

--- a/resources/assets/js/__tests__/setup.ts
+++ b/resources/assets/js/__tests__/setup.ts
@@ -53,9 +53,15 @@ HTMLDialogElement.prototype.close = vi.fn(function mock(this: HTMLDialogElement)
   this.open = false
 })
 
-window.BASE_URL = 'http://test/'
-window.MAILER_CONFIGURED = true
-window.SSO_PROVIDERS = []
+window.KOEL = {
+  base_url: 'http://test/',
+  is_demo: false,
+  pusher: { app_key: '', app_cluster: '' },
+  branding: { name: 'Koel', logo: '', cover: '' },
+  mailer_configured: true,
+  sso_providers: [],
+  accepted_audio_extensions: [],
+}
 window.RUNNING_UNIT_TESTS = true
 
 window.createLemonSqueezy = vi.fn()

--- a/resources/assets/js/__tests__/setup.ts
+++ b/resources/assets/js/__tests__/setup.ts
@@ -4,10 +4,6 @@ import './shims/popover'
 
 declare global {
   interface Window {
-    BASE_URL: string
-    MAILER_CONFIGURED: boolean
-    SSO_PROVIDERS: SSOProvider[]
-    BRANDING: Branding
     createLemonSqueezy?: () => Closure
     RUNNING_UNIT_TESTS?: boolean
   }

--- a/resources/assets/js/components/album/AlbumTrackListItem.vue
+++ b/resources/assets/js/components/album/AlbumTrackListItem.vue
@@ -40,7 +40,7 @@ const fmtLength = computed(() => secondsToHis(track.value.length))
 const active = computed(() => matchedSong.value && matchedSong.value.playback_state !== 'Stopped')
 
 const iTunesUrl = computed(() => {
-  return `${window.BASE_URL}itunes/song/${album.value.id}?q=${encodeURIComponent(track.value.title)}&api_token=${authService.getApiToken()}`
+  return `${window.KOEL.base_url}itunes/song/${album.value.id}?q=${encodeURIComponent(track.value.title)}&api_token=${authService.getApiToken()}`
 })
 
 const play = () => matchedSong.value && playback().play(matchedSong.value)

--- a/resources/assets/js/components/auth/LoginForm.spec.ts
+++ b/resources/assets/js/components/auth/LoginForm.spec.ts
@@ -47,15 +47,15 @@ describe('loginForm.vue', () => {
   })
 
   it('does not show forgot password form if mailer is not configure', async () => {
-    window.MAILER_CONFIGURED = false
+    window.KOEL.mailer_configured = false
     h.render(Component)
 
     expect(screen.queryByText('Forgot password?')).toBeNull()
-    window.MAILER_CONFIGURED = true
+    window.KOEL.mailer_configured = true
   })
 
   it('shows Google login button', async () => {
-    window.SSO_PROVIDERS = ['Google']
+    window.KOEL.sso_providers = ['Google']
 
     h.render(Component, {
       global: {
@@ -67,6 +67,6 @@ describe('loginForm.vue', () => {
 
     screen.getByTestId('google-login-button')
 
-    window.SSO_PROVIDERS = []
+    window.KOEL.sso_providers = []
   })
 })

--- a/resources/assets/js/components/auth/LoginForm.vue
+++ b/resources/assets/js/components/auth/LoginForm.vue
@@ -58,20 +58,20 @@ const emit = defineEmits<{ (e: 'loggedin'): void }>()
 const { toastWarning, toastError } = useMessageToaster()
 const { logo } = useBranding()
 
-const demoAccount = window.DEMO_ACCOUNT || {
+const demoAccount = window.KOEL.demo_account || {
   email: 'demo@koel.dev',
   password: 'demo',
 }
 
 const failed = ref(false)
 const showingForgotPasswordForm = ref(false)
-const canResetPassword = window.MAILER_CONFIGURED && !window.IS_DEMO
-const ssoProviders = window.SSO_PROVIDERS || []
-const emailPlaceholder = window.IS_DEMO ? demoAccount.email : 'Your email address'
-const passwordPlaceholder = window.IS_DEMO ? demoAccount.password : 'Your password'
+const canResetPassword = window.KOEL.mailer_configured && !window.KOEL.is_demo
+const ssoProviders = window.KOEL.sso_providers || []
+const emailPlaceholder = window.KOEL.is_demo ? demoAccount.email : 'Your email address'
+const passwordPlaceholder = window.KOEL.is_demo ? demoAccount.password : 'Your password'
 
 const { data, handleSubmit } = useForm<{ email: string; password: string }>({
-  initialValues: window.IS_DEMO
+  initialValues: window.KOEL.is_demo
     ? demoAccount
     : {
         email: '',

--- a/resources/assets/js/components/embed/CreateEmbedForm.vue
+++ b/resources/assets/js/components/embed/CreateEmbedForm.vue
@@ -89,7 +89,7 @@ const embedSrc = computed(() => {
     return null
   }
 
-  return `${window.BASE_URL}#/embed/${embed.value.id}/${encryptedOptions.value}`
+  return `${window.KOEL.base_url}#/embed/${embed.value.id}/${encryptedOptions.value}`
 })
 
 const code = computed(() => {

--- a/resources/assets/js/components/layout/main-wrapper/sidebar/SidebarYourLibrarySection.vue
+++ b/resources/assets/js/components/layout/main-wrapper/sidebar/SidebarYourLibrarySection.vue
@@ -81,7 +81,7 @@ const { url, isCurrentScreen } = useRouter()
 const usesMediaBrowser = toRef(commonStore.state, 'uses_media_browser')
 const { swReady, cachedSongCount } = useOfflinePlayback()
 const supportsOffline = computed(() => swReady.value && cachedSongCount.value > 0)
-const isDemo = window.IS_DEMO
+const isDemo = window.KOEL.is_demo
 
 eventBus.on('PLAY_YOUTUBE_VIDEO', payload => (youtubeVideoTitle.value = unescape(payload.title)))
 </script>

--- a/resources/assets/js/components/meta/AboutKoelModal.vue
+++ b/resources/assets/js/components/meta/AboutKoelModal.vue
@@ -85,7 +85,7 @@ const close = () => emit('close')
 
 const showPlusModal = () => openModal<'KOEL_PLUS'>(KoelPlusModal)
 
-const isDemo = window.IS_DEMO
+const isDemo = window.KOEL.is_demo
 </script>
 
 <style lang="postcss" scoped>

--- a/resources/assets/js/components/meta/CreditsBlock.vue
+++ b/resources/assets/js/components/meta/CreditsBlock.vue
@@ -22,7 +22,7 @@ interface DemoCredits {
 const credits = ref<DemoCredits[]>([])
 
 onMounted(async () => {
-  credits.value = window.IS_DEMO ? orderBy(await http.get<DemoCredits[]>('demo/credits'), 'name') : []
+  credits.value = window.KOEL.is_demo ? orderBy(await http.get<DemoCredits[]>('demo/credits'), 'name') : []
 })
 </script>
 

--- a/resources/assets/js/components/profile-preferences/LastfmIntegration.vue
+++ b/resources/assets/js/components/profile-preferences/LastfmIntegration.vue
@@ -65,7 +65,7 @@ const connected = computed(() => Boolean(currentUser.value.preferences.lastfm_se
  */
 const connect = () =>
   window.open(
-    `${window.BASE_URL}lastfm/connect?api_token=${authService.getApiToken()}`,
+    `${window.KOEL.base_url}lastfm/connect?api_token=${authService.getApiToken()}`,
     '_blank',
     'toolbar=no,titlebar=no,location=no,width=1024,height=640',
   )

--- a/resources/assets/js/components/profile-preferences/ProfileForm.vue
+++ b/resources/assets/js/components/profile-preferences/ProfileForm.vue
@@ -86,7 +86,7 @@ import FormRow from '@/components/ui/form/FormRow.vue'
 const { toastSuccess } = useMessageToaster()
 const { currentUser } = useAuthorization()
 
-const isDemo = window.IS_DEMO
+const isDemo = window.KOEL.is_demo
 
 const { data, handleSubmit } = useForm<UpdateCurrentProfileData>({
   initialValues: {

--- a/resources/assets/js/components/profile-preferences/QRLogin.vue
+++ b/resources/assets/js/components/profile-preferences/QRLogin.vue
@@ -22,7 +22,7 @@ watch(oneTimeToken, () => {
   qrCodeData.value = base64Encode(
     JSON.stringify({
       token: oneTimeToken.value,
-      host: window.BASE_URL,
+      host: window.KOEL.base_url,
     }),
   )
 })

--- a/resources/assets/js/components/screens/UserListScreen.vue
+++ b/resources/assets/js/components/screens/UserListScreen.vue
@@ -73,7 +73,7 @@ const users = computed(() =>
 
 const prospects = computed(() => allUsers.value.filter(({ is_prospect }) => is_prospect))
 
-const canInvite = window.MAILER_CONFIGURED
+const canInvite = window.KOEL.mailer_configured
 
 const showAddUserForm = () => openModal<'ADD_USER_FORM'>(AddUserForm)
 const showInviteUserForm = () => openModal<'INVITE_USER_FORM'>(InviteUserForm)

--- a/resources/assets/js/components/screens/settings/BrandingSettingGroup.spec.ts
+++ b/resources/assets/js/components/screens/settings/BrandingSettingGroup.spec.ts
@@ -8,7 +8,7 @@ describe('brandingSettingGroup.vue', () => {
   const h = createHarness()
 
   const renderComponent = (currentBranding?: Branding) => {
-    currentBranding = currentBranding ?? window.BRANDING
+    currentBranding = currentBranding ?? window.KOEL.branding
 
     const rendered = h.render(Component, {
       props: {

--- a/resources/assets/js/composables/useBranding.spec.ts
+++ b/resources/assets/js/composables/useBranding.spec.ts
@@ -7,55 +7,55 @@ describe('useBranding', () => {
 
   it('returns branding name from window', () => {
     const { name } = useBranding()
-    expect(name).toBe(window.BRANDING.name)
+    expect(name).toBe(window.KOEL.branding.name)
   })
 
   it('falls back to default logo when none set', () => {
-    const originalLogo = window.BRANDING.logo
-    window.BRANDING.logo = ''
+    const originalLogo = window.KOEL.branding.logo
+    window.KOEL.branding.logo = ''
 
     const { logo, koelBirdLogo, isKoelBirdLogo } = useBranding()
     expect(logo).toBe(koelBirdLogo)
     expect(isKoelBirdLogo(logo)).toBe(true)
 
-    window.BRANDING.logo = originalLogo
+    window.KOEL.branding.logo = originalLogo
   })
 
   it('falls back to default cover when none set', () => {
-    const originalCover = window.BRANDING.cover
-    window.BRANDING.cover = ''
+    const originalCover = window.KOEL.branding.cover
+    window.KOEL.branding.cover = ''
 
     const { cover, koelBirdCover, isKoelBirdCover } = useBranding()
     expect(cover).toBe(koelBirdCover)
     expect(isKoelBirdCover(cover)).toBe(true)
 
-    window.BRANDING.cover = originalCover
+    window.KOEL.branding.cover = originalCover
   })
 
   it('detects custom branding when logo is custom', () => {
-    const originalLogo = window.BRANDING.logo
-    window.BRANDING.logo = 'https://example.com/custom-logo.png'
+    const originalLogo = window.KOEL.branding.logo
+    window.KOEL.branding.logo = 'https://example.com/custom-logo.png'
 
     const { hasCustomBranding } = useBranding()
     expect(hasCustomBranding).toBe(true)
 
-    window.BRANDING.logo = originalLogo
+    window.KOEL.branding.logo = originalLogo
   })
 
   it('detects no custom branding with defaults', () => {
-    const originalLogo = window.BRANDING.logo
-    const originalCover = window.BRANDING.cover
-    const originalName = window.BRANDING.name
-    window.BRANDING.logo = ''
-    window.BRANDING.cover = ''
-    window.BRANDING.name = 'Koel'
+    const originalLogo = window.KOEL.branding.logo
+    const originalCover = window.KOEL.branding.cover
+    const originalName = window.KOEL.branding.name
+    window.KOEL.branding.logo = ''
+    window.KOEL.branding.cover = ''
+    window.KOEL.branding.name = 'Koel'
 
     const { hasCustomBranding } = useBranding()
     expect(hasCustomBranding).toBe(false)
 
-    window.BRANDING.logo = originalLogo
-    window.BRANDING.cover = originalCover
-    window.BRANDING.name = originalName
+    window.KOEL.branding.logo = originalLogo
+    window.KOEL.branding.cover = originalCover
+    window.KOEL.branding.name = originalName
   })
 
   it('identifies koel bird logo correctly', () => {

--- a/resources/assets/js/composables/useBranding.ts
+++ b/resources/assets/js/composables/useBranding.ts
@@ -3,9 +3,9 @@ import koelBirdCover from '@/../img/covers/default.svg'
 
 export const useBranding = () => {
   const currentBranding: Branding = {
-    name: window.BRANDING.name,
-    logo: window.BRANDING.logo || koelBirdLogo,
-    cover: window.BRANDING.cover || koelBirdCover,
+    name: window.KOEL.branding.name,
+    logo: window.KOEL.branding.logo || koelBirdLogo,
+    cover: window.KOEL.branding.cover || koelBirdCover,
   }
 
   const isKoelBirdLogo = (logo: string) => logo === koelBirdLogo

--- a/resources/assets/js/composables/usePolicies.ts
+++ b/resources/assets/js/composables/usePolicies.ts
@@ -30,7 +30,7 @@ export const usePolicies = () => {
     deleteRadioStation: (station: RadioStation) => station.permissions.delete,
 
     // If the user has the permission, they can always add a radio station, even in demo mode.
-    addRadioStation: () => !window.IS_DEMO || currentUser.value.abilities.includes('manage radio stations'),
+    addRadioStation: () => !window.KOEL.is_demo || currentUser.value.abilities.includes('manage radio stations'),
 
     manageSettings: () => currentUser.value.abilities.includes('manage settings'),
     manageUsers: () => currentUser.value.abilities.includes('manage users'),

--- a/resources/assets/js/services/downloadService.ts
+++ b/resources/assets/js/services/downloadService.ts
@@ -62,7 +62,7 @@ export const downloadService = {
 
   trigger: (uri: string) => {
     const sep = uri.includes('?') ? '&' : '?'
-    const url = `${window.BASE_URL}download/${uri}${sep}t=${authService.getAudioToken()}`
+    const url = `${window.KOEL.base_url}download/${uri}${sep}t=${authService.getAudioToken()}`
 
     open(url)
   },

--- a/resources/assets/js/services/http.ts
+++ b/resources/assets/js/services/http.ts
@@ -13,7 +13,7 @@ class Http {
 
   constructor() {
     this.client = ky.create({
-      prefixUrl: `${window.BASE_URL}api`,
+      prefixUrl: `${window.KOEL.base_url}api`,
       headers: {
         Accept: 'application/json',
         'X-Api-Version': 'v7',

--- a/resources/assets/js/services/httpUpload.ts
+++ b/resources/assets/js/services/httpUpload.ts
@@ -16,7 +16,7 @@ export const postWithProgress = <T>(
   const xhr = new XMLHttpRequest()
 
   const promise = new Promise<T>((resolve, reject) => {
-    xhr.open('POST', `${window.BASE_URL}api/${url}`)
+    xhr.open('POST', `${window.KOEL.base_url}api/${url}`)
     xhr.setRequestHeader('Accept', 'application/json')
     xhr.setRequestHeader('Authorization', `Bearer ${authService.getApiToken()}`)
     xhr.setRequestHeader('X-Api-Version', 'v7')

--- a/resources/assets/js/services/socketService.spec.ts
+++ b/resources/assets/js/services/socketService.spec.ts
@@ -32,16 +32,15 @@ import { userStore } from '@/stores/userStore'
 describe('socketService', () => {
   const h = createHarness()
 
-  it('does not init without PUSHER_APP_KEY', async () => {
-    Object.defineProperty(window, 'PUSHER_APP_KEY', { value: '', writable: true, configurable: true })
+  it('does not init without a Pusher app key', async () => {
+    window.KOEL.pusher = { app_key: '', app_cluster: '' }
     const result = await socketService.init()
     expect(result).toBe(false)
   })
 
-  it('inits with PUSHER_APP_KEY', async () => {
-    Object.defineProperty(window, 'PUSHER_APP_KEY', { value: 'test-key', writable: true, configurable: true })
-    Object.defineProperty(window, 'PUSHER_APP_CLUSTER', { value: 'mt1', writable: true, configurable: true })
-    window.BASE_URL = 'http://localhost/'
+  it('inits with a Pusher app key', async () => {
+    window.KOEL.pusher = { app_key: 'test-key', app_cluster: 'mt1' }
+    window.KOEL.base_url = 'http://localhost/'
 
     const result = await socketService.init()
     expect(result).toBe(true)

--- a/resources/assets/js/services/socketService.ts
+++ b/resources/assets/js/services/socketService.ts
@@ -6,20 +6,20 @@ export const socketService = {
   channel: null as any,
 
   async init() {
-    if (!window.PUSHER_APP_KEY) {
+    if (!window.KOEL.pusher.app_key) {
       return false
     }
 
     const { default: PusherLib } = await import('pusher-js')
 
-    this.pusher = new PusherLib(window.PUSHER_APP_KEY, {
-      authEndpoint: `${window.BASE_URL}api/broadcasting/auth`,
+    this.pusher = new PusherLib(window.KOEL.pusher.app_key, {
+      authEndpoint: `${window.KOEL.base_url}api/broadcasting/auth`,
       auth: {
         headers: {
           Authorization: `Bearer ${authService.getApiToken()}`,
         },
       },
-      cluster: window.PUSHER_APP_CLUSTER,
+      cluster: window.KOEL.pusher.app_cluster,
       encrypted: true,
     })
 

--- a/resources/assets/js/stores/playableStore.ts
+++ b/resources/assets/js/stores/playableStore.ts
@@ -196,7 +196,7 @@ export const playableStore = {
       : `${commonStore.state.cdn_url}play/${playable.id}?t=${authService.getAudioToken()}`
   },
 
-  getShareableUrl: (song: Playable) => `${window.BASE_URL}#/songs/${song.id}`,
+  getShareableUrl: (song: Playable) => `${window.KOEL.base_url}#/songs/${song.id}`,
 
   ensureNotDeleted: (songs: MaybeArray<Song>) => arrayify(songs).filter(({ deleted }) => !deleted),
 

--- a/resources/assets/js/types.d.ts
+++ b/resources/assets/js/types.d.ts
@@ -53,25 +53,28 @@ interface CompositeToken {
 
 type SSOProvider = 'Google' | 'Reverse Proxy'
 
-interface Window {
-  BASE_URL: string
-  MAILER_CONFIGURED: boolean
-  IS_DEMO: boolean
-
-  DEMO_ACCOUNT?: {
+interface KoelGlobals {
+  base_url: string
+  is_demo: boolean
+  pusher: {
+    readonly app_key: string
+    readonly app_cluster: string
+  }
+  branding: Branding
+  mailer_configured: boolean
+  sso_providers: SSOProvider[]
+  accepted_audio_extensions: string[]
+  demo_account?: {
     email: string
     password: string
   }
+  auth_token?: CompositeToken | null
+}
 
-  SSO_PROVIDERS: SSOProvider[]
-  AUTH_TOKEN: CompositeToken | null
-  ACCEPTED_AUDIO_EXTENSIONS: string[]
+interface Window {
+  KOEL: KoelGlobals
+
   RUNNING_UNIT_TESTS?: boolean
-
-  BRANDING: Branding
-
-  readonly PUSHER_APP_KEY: string
-  readonly PUSHER_APP_CLUSTER: string
 
   readonly MediaMetadata: Constructable<Record<string, any>>
   createLemonSqueezy?: () => Closure

--- a/resources/assets/js/utils/mediaHelper.spec.ts
+++ b/resources/assets/js/utils/mediaHelper.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vite-plus/test'
 import { createHarness } from '@/__tests__/TestHarness'
 
 vi.hoisted(() => {
-  window.ACCEPTED_AUDIO_EXTENSIONS = ['mp3', 'flac', 'ogg', 'wav']
+  window.KOEL.accepted_audio_extensions = ['mp3', 'flac', 'ogg', 'wav']
 })
 
 import { acceptsFile } from './mediaHelper'

--- a/resources/assets/js/utils/mediaHelper.ts
+++ b/resources/assets/js/utils/mediaHelper.ts
@@ -1,4 +1,4 @@
-export const acceptedExtensions = window.ACCEPTED_AUDIO_EXTENSIONS
+export const acceptedExtensions = window.KOEL.accepted_audio_extensions
 
 const getFileExtension = (filename: string): string | null => {
   const match = filename.toLowerCase().match(/\.([a-z0-9+]+)$/)

--- a/resources/views/base.blade.php
+++ b/resources/views/base.blade.php
@@ -30,13 +30,15 @@
 <div id="app"></div>
 
 <script>
-    window.BASE_URL = @json(base_url());
-    window.IS_DEMO = @json(config('koel.misc.demo'));
-
-    window.PUSHER_APP_KEY = @json(config('broadcasting.connections.pusher.key'));
-    window.PUSHER_APP_CLUSTER = @json(config('broadcasting.connections.pusher.options.cluster'));
-
-    window.BRANDING = @json(koel_branding());
+    window.KOEL = @json([
+        'base_url' => base_url(),
+        'is_demo' => config('koel.misc.demo'),
+        'pusher' => [
+            'app_key' => config('broadcasting.connections.pusher.key'),
+            'app_cluster' => config('broadcasting.connections.pusher.options.cluster'),
+        ],
+        'branding' => koel_branding(),
+    ]);
 </script>
 
 @stack('scripts')

--- a/resources/views/base.blade.php
+++ b/resources/views/base.blade.php
@@ -30,15 +30,18 @@
 <div id="app"></div>
 
 <script>
-    window.KOEL = @json([
-        'base_url' => base_url(),
-        'is_demo' => config('koel.misc.demo'),
-        'pusher' => [
-            'app_key' => config('broadcasting.connections.pusher.key'),
-            'app_cluster' => config('broadcasting.connections.pusher.options.cluster'),
-        ],
-        'branding' => koel_branding(),
-    ]);
+    @php
+        $koelGlobals = [
+            'base_url' => base_url(),
+            'is_demo' => config('koel.misc.demo'),
+            'pusher' => [
+                'app_key' => config('broadcasting.connections.pusher.key'),
+                'app_cluster' => config('broadcasting.connections.pusher.options.cluster'),
+            ],
+            'branding' => koel_branding(),
+        ];
+    @endphp
+    window.KOEL = @json($koelGlobals);
 </script>
 
 @stack('scripts')

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -4,14 +4,16 @@
 
 @push('scripts')
     <script>
-        window.MAILER_CONFIGURED = @json(mailer_configured());
-        window.SSO_PROVIDERS = @json(collect_sso_providers());
-        window.ACCEPTED_AUDIO_EXTENSIONS = @json(collect_accepted_audio_extensions());
+        Object.assign(window.KOEL, @json([
+            'mailer_configured' => mailer_configured(),
+            'sso_providers' => collect_sso_providers(),
+            'accepted_audio_extensions' => collect_accepted_audio_extensions(),
+        ]));
 
         @if (session()->has('demo_account'))
-            window.DEMO_ACCOUNT = @json(session('demo_account'));
+            window.KOEL.demo_account = @json(session('demo_account'));
         @elseif (isset($token))
-            window.AUTH_TOKEN = @json($token);
+            window.KOEL.auth_token = @json($token);
         @endif
     </script>
     @vite(['resources/assets/js/app.ts'])

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -4,11 +4,14 @@
 
 @push('scripts')
     <script>
-        Object.assign(window.KOEL, @json([
-            'mailer_configured' => mailer_configured(),
-            'sso_providers' => collect_sso_providers(),
-            'accepted_audio_extensions' => collect_accepted_audio_extensions(),
-        ]));
+        @php
+            $koelExtraGlobals = [
+                'mailer_configured' => mailer_configured(),
+                'sso_providers' => collect_sso_providers(),
+                'accepted_audio_extensions' => collect_accepted_audio_extensions(),
+            ];
+        @endphp
+        Object.assign(window.KOEL, @json($koelExtraGlobals));
 
         @if (session()->has('demo_account'))
             window.KOEL.demo_account = @json(session('demo_account'));

--- a/tests/Feature/Demo/DemoSessionTest.php
+++ b/tests/Feature/Demo/DemoSessionTest.php
@@ -33,7 +33,7 @@ class DemoSessionTest extends TestCase
         $demoAccount = $this
             ->get('/')
             ->assertSuccessful()
-            ->assertSee('window.DEMO_ACCOUNT')
+            ->assertSee('window.KOEL.demo_account', false)
             ->viewData('demo_account');
 
         self::assertStringEndsWith('@demo.koel.dev', $demoAccount['email']);
@@ -45,7 +45,7 @@ class DemoSessionTest extends TestCase
     {
         $this->mock(CrawlerDetect::class)->expects('isCrawler')->andReturnTrue();
 
-        $this->get('/')->assertSee('window.DEMO_ACCOUNT')->assertViewHas('demo_account', [
+        $this->get('/')->assertSee('window.KOEL.demo_account', false)->assertViewHas('demo_account', [
             'email' => 'demo@koel.dev',
             'password' => 'demo',
         ]);

--- a/tests/Feature/HomeTest.php
+++ b/tests/Feature/HomeTest.php
@@ -14,9 +14,10 @@ class HomeTest extends TestCase
             ->withoutVite()
             ->get('/')
             ->assertOk()
-            ->assertSee('window.ACCEPTED_AUDIO_EXTENSIONS')
-            ->assertSee('window.BRANDING')
-            ->assertSee('window.MAILER_CONFIGURED')
-            ->assertSee('window.SSO_PROVIDERS');
+            ->assertSee('window.KOEL = ', false)
+            ->assertSee('accepted_audio_extensions', false)
+            ->assertSee('mailer_configured', false)
+            ->assertSee('sso_providers', false)
+            ->assertSee('branding', false);
     }
 }


### PR DESCRIPTION
## Summary
- Before: ten unrelated PHP-sourced values were dumped onto `window` as separate top-level globals (`window.BASE_URL`, `window.IS_DEMO`, `window.PUSHER_APP_KEY`, …). Each needed its own `Window` interface augmentation, each needed its own assignment in test setup, and tests of services that read several of them needed several `Object.defineProperty` incantations.
- After: a single `window.KOEL: KoelGlobals` umbrella. Tests seed it with one object literal; the type lives in one `interface KoelGlobals`; the pusher pair gets a natural `pusher: { app_key, app_cluster }` sub-object.
- `window.RUNNING_UNIT_TESTS` is **not** moved — it's set by the test runner, not by the server, so it doesn't share the motivation.

## Shape of `window.KOEL`

```ts
interface KoelGlobals {
  base_url: string
  is_demo: boolean
  pusher: {
    readonly app_key: string
    readonly app_cluster: string
  }
  branding: Branding
  mailer_configured: boolean
  sso_providers: SSOProvider[]
  accepted_audio_extensions: string[]
  demo_account?: { email: string; password: string }
  auth_token?: CompositeToken | null
}
```

Keys use snake_case to match the rest of the PHP-sourced data shapes in `types.d.ts` (`Song.album_id`, `User.created_at`, …) and to let the blade `@json([...])` array use the source PHP values verbatim with no per-key renaming.

## Blade side

`base.blade.php` initializes the whole object in one `@json` literal:

```blade
window.KOEL = @json([
    'base_url' => base_url(),
    'is_demo' => config('koel.misc.demo'),
    'pusher' => [
        'app_key' => config('broadcasting.connections.pusher.key'),
        'app_cluster' => config('broadcasting.connections.pusher.options.cluster'),
    ],
    'branding' => koel_branding(),
]);
```

`index.blade.php` extends it via `Object.assign(window.KOEL, @json([...]))` plus the existing conditional branches for `demo_account` / `auth_token`.

## Scope

- 2 Blade templates rewritten
- 1 `types.d.ts` interface consolidation
- 64 frontend callsites: pure mechanical renames (`window.OLD_NAME` → `window.KOEL.new_name`)
- 1 test setup file: replaces six individual `window.X = …` lines with one `window.KOEL = { … }` literal
- 1 test harness: `setDefaultBranding` / `actingAsDemo` now assign through `window.KOEL.{branding,is_demo}`
- 1 spec file: `socketService.spec.ts` swaps two `Object.defineProperty(window, 'PUSHER_APP_KEY', { writable: true, configurable: true, value: … })` calls for a single `window.KOEL.pusher = { app_key, app_cluster }` — the kind of testing-ergonomics win that motivated the refactor

## Test plan
- [x] `pnpm typecheck` — 0 errors
- [x] `vp check resources/assets` clean (format + lint)
- [x] Full frontend test suite: 1531/1531 pass
- [x] `vp build` clean
- [ ] Manual: visit a deployed instance, confirm app boots and login + branding both render correctly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Frontend configuration consolidated into a single global object for consistent behavior.
* **Bug Fixes**
  * App initialization now reliably picks up the auth token for more consistent authentication.
* **User-facing updates**
  * Login, embeds, demo-mode indicators, sharing, downloads, integrations, and profile/settings now read from the consolidated configuration.
* **Tests**
  * Test helpers and suites updated to use the consolidated configuration for stable test runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2464)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->