### PR TITLE
fix(tailwind-v4): silence two prod-build CSS warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,4 @@ docs/.vitepress/cache
 demo-credits.json
 
 public/sandbox
+build/

--- a/resources/assets/css/app.pcss
+++ b/resources/assets/css/app.pcss
@@ -12,11 +12,6 @@
 
 @config "../../../tailwind.config.js";
 
-/*
-  Register `no-hover:` as a v4 custom variant (was a `screens.raw` entry in v3).
-  Keeping it in `theme.screens` made the `container` utility iterate it and
-  emit invalid `@media (width >= (hover: none))` rules in production output.
-*/
 @custom-variant no-hover (&:where(@media (hover: none) *));
 
 /*

--- a/resources/assets/css/app.pcss
+++ b/resources/assets/css/app.pcss
@@ -13,6 +13,13 @@
 @config "../../../tailwind.config.js";
 
 /*
+  Register `no-hover:` as a v4 custom variant (was a `screens.raw` entry in v3).
+  Keeping it in `theme.screens` made the `container` utility iterate it and
+  emit invalid `@media (width >= (hover: none))` rules in production output.
+*/
+@custom-variant no-hover (&:where(@media (hover: none) *));
+
+/*
   The default border color has changed to `currentcolor` in Tailwind CSS v4,
   so we've added these compatibility styles to make sure everything still
   looks the same as it did with Tailwind CSS v3.

--- a/resources/assets/css/partials/skeleton.pcss
+++ b/resources/assets/css/partials/skeleton.pcss
@@ -4,14 +4,17 @@
     @apply bg-k-fg-5;
     animation: skeleton-pulse 2s infinite;
   }
+}
 
-  @keyframes skeleton-pulse {
-    0%,
-    100% {
-      opacity: 0;
-    }
-    50% {
-      opacity: 1;
-    }
+/* `@keyframes` must live at the top level — nesting it inside `.skeleton`
+   is invalid CSS that v3's postcss-nested flattened silently but v4's
+   lightningcss optimizer rejects, dropping the animation from the bundle. */
+@keyframes skeleton-pulse {
+  0%,
+  100% {
+    opacity: 0;
+  }
+  50% {
+    opacity: 1;
   }
 }

--- a/resources/assets/css/partials/skeleton.pcss
+++ b/resources/assets/css/partials/skeleton.pcss
@@ -6,9 +6,6 @@
   }
 }
 
-/* `@keyframes` must live at the top level — nesting it inside `.skeleton`
-   is invalid CSS that v3's postcss-nested flattened silently but v4's
-   lightningcss optimizer rejects, dropping the animation from the bundle. */
 @keyframes skeleton-pulse {
   0%,
   100% {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -46,9 +46,6 @@ export default {
         'k-sidebar-width': 'var(--sidebar-width)',
         'k-side-sheet-width': 'var(--side-sheet-width)',
       },
-      screens: {
-        'no-hover': { 'raw': '(hover: none)' },
-      }
     },
     variants: {
       extend: {


### PR DESCRIPTION
## Summary
Two CSS authoring patterns left by the Tailwind v3 → v4 migration that v3's postcss-nested pipeline forgave but v4's lightningcss optimizer rejects. Both warnings surface only at production-build time, not in `pnpm dev` — which is why the breakage shows up on deployed servers and not on developer laptops.

## What was broken

**1. `@keyframes` nested inside a rule** — `resources/assets/css/partials/skeleton.pcss` had `@keyframes skeleton-pulse` nested inside the `.skeleton {}` block. v3's postcss-nested silently lifted it to the top level; v4's lightningcss leaves it nested, which is invalid CSS, and the skeleton-pulse animation gets dropped from the production bundle.

**2. `container` utility iterates raw-media screens** — `tailwind.config.js` had `screens: { 'no-hover': { raw: '(hover: none)' } }`. In v3 the `container` utility skipped raw-media screens; in v4 it iterates every screen and emits invalid `@media (width >= (hover: none)) { max-width: (hover: none); }` rules that lightningcss bails on, taking adjacent valid CSS with it.

## Fixes
- Lift `@keyframes skeleton-pulse` out of the `.skeleton` block.
- Drop `screens.no-hover` from `tailwind.config.js`, and register `no-hover:` as a proper v4 `@custom-variant` in `app.pcss`. All existing `no-hover:` modifier usages in Vue templates continue to work unchanged.
- Gitignore `build/` so the FrankenPHP single-binary experiment scratch directory doesn't accidentally land on master.

## Test plan
- [x] `pnpm build` — no warnings emitted (was: 1 `@keyframes` warning + 2 `container` warnings, one per CSS entrypoint)
- [x] `pnpm typecheck` clean
- [x] `vp check` clean (format + lint)
- [x] All 1531 frontend unit tests pass (no behavioral change)
- [ ] Manual: deploy to a server and verify (a) skeleton-pulse animations appear during loading states and (b) `no-hover:` variants still apply on touch devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated project ignore rules to exclude build artifacts.

* **Style**
  * Ensured skeleton loading animation is emitted at top-level for consistent rendering.
  * Added a device-aware "no-hover" styling variant for hover-less environments and simplified breakpoint handling in the styling config.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2467)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->