### PR TITLE
fix(tailwind-v4): remove duplicate preflight imports in shared.pcss

### DIFF
--- a/resources/assets/css/partials/shared.pcss
+++ b/resources/assets/css/partials/shared.pcss
@@ -1,6 +1,3 @@
-@import 'tailwindcss/theme' layer(theme);
-@import 'tailwindcss/preflight' layer(base);
-
 /*
   The default border color has changed to `currentcolor` in Tailwind CSS v4,
   so we've added these compatibility styles to make sure everything still


### PR DESCRIPTION
## Summary
The Tailwind v3 → v4 codemod added explicit `@import 'tailwindcss/theme'` and `@import 'tailwindcss/preflight'` to `resources/assets/css/partials/shared.pcss`. But both `app.pcss` and `remote.pcss` already `@import 'tailwindcss'`, which transitively pulls in theme + preflight + utilities.

Net effect: preflight (and the universal-selector `* { margin: 0; padding: 0 }` reset it ships) was emitted **three times** in the production app CSS bundle. The duplicated `@layer base{}` blocks interfered with the cascade and prevented v4's utility layer from overriding the universal margin/padding zero — producing visually-broken margin/padding across the deployed UI.

## Fix
Drop the two redundant imports from `shared.pcss`. After the fix, the production app CSS contains the preflight exactly once.

## Test plan
- [x] `pnpm build` — emits one `*, :after, :before, ::backdrop` reset block (was: three)
- [x] `pnpm typecheck` clean
- [x] `vp check` clean
- [ ] Manual: deploy to stream, hard-reload franken.phanan.net, confirm margin/padding render correctly across the UI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused styling framework imports to optimize the build configuration while maintaining all existing styles and visual appearance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2468)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->