### PR TITLE
fix(tailwind-v4): restore padding/margin cascade for logical-shorthand utilities

### DIFF
--- a/resources/assets/css/app.pcss
+++ b/resources/assets/css/app.pcss
@@ -81,3 +81,15 @@
     @apply bg-k-fg-10;
   }
 }
+
+@layer base {
+  *,
+  ::after,
+  ::before,
+  ::backdrop {
+    padding-block: revert;
+    padding-inline: revert;
+    margin-block: revert;
+    margin-inline: revert;
+  }
+}

--- a/resources/assets/css/remote.pcss
+++ b/resources/assets/css/remote.pcss
@@ -29,3 +29,15 @@
     @apply h-screen relative;
   }
 }
+
+@layer base {
+  *,
+  ::after,
+  ::before,
+  ::backdrop {
+    padding-block: revert;
+    padding-inline: revert;
+    margin-block: revert;
+    margin-inline: revert;
+  }
+}


### PR DESCRIPTION
## Summary
After the v3→v4 migration, the production UI rendered with margin/padding stripped from elements that have explicit logical-shorthand utility classes like `.px-3.5` and `.py-2` (e.g. the `Btn` component). Despite `.px-3.5` being in `@layer utilities` and `* { padding: 0 }` being in `@layer base`, computed padding resolved to `0px` — physical longhand (`padding-left: 0` from v4's preflight) won over logical longhand (`padding-inline-start: calc(--spacing * 3.5)` from the utility), regardless of the layer order.

## Fix
Append a `@layer base` rule to both CSS entry points (`app.pcss` and `remote.pcss`), declared *after* `@import 'tailwindcss'` so it wins by source order *within* `@layer base`:

```css
@layer base {
  *, ::after, ::before, ::backdrop {
    padding-block: revert;
    padding-inline: revert;
    margin-block: revert;
    margin-inline: revert;
  }
}
```

How it untangles the cascade:
- Lives in `@layer base`, later than Tailwind's preflight (also `@layer base`), so source order makes the `revert` win within the layer.
- Uses logical longhands so it clears both physical and logical padding/margin cascaded values.
- Utility classes in `@layer utilities` (`.px-3.5`, `.py-2`, etc.) still win across layers when present.
- Elements without an explicit utility fall back to the browser default (v3-equivalent behavior).

## Test plan
- [x] `pnpm build` clean
- [x] Local production build emits the new rule once
- [ ] Manual: deploy + verify Btn (and the rest of the UI) renders with correct padding/margin


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted default spacing properties across the application to restore baseline browser behavior and ensure consistent element spacing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2470)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->