### PR TITLE
feat: store user-generated images under LARAVEL_STORAGE_PATH

### DIFF
--- a/app/Console/Commands/InitCommand.php
+++ b/app/Console/Commands/InitCommand.php
@@ -266,9 +266,16 @@ class InitCommand extends Command
 
     private function linkStorage(): void
     {
-        $this->components->task('Linking storage', static function (): void {
-            Artisan::call('storage:link', ['--quiet' => true]);
+        $result = self::SUCCESS;
+
+        $this->components->task('Linking storage', static function () use (&$result): void {
+            $result = Artisan::call('storage:link', ['--quiet' => true]);
         });
+
+        if ($result !== self::SUCCESS) {
+            $this->components->warn('Failed to link storage. Album and artist images may not load until you run '
+            . '`php artisan storage:link` manually.');
+        }
     }
 
     private function maybeSetMediaPath(): void

--- a/app/Console/Commands/InitCommand.php
+++ b/app/Console/Commands/InitCommand.php
@@ -57,6 +57,7 @@ class InitCommand extends Command
             $this->maybeSetUpDatabase();
             $this->migrateDatabase();
             $this->maybeSeedDatabase();
+            $this->linkStorage();
             $this->maybeSetMediaPath();
             $this->maybeCompileFrontEndAssets();
             $this->maybeCopyManifests();
@@ -260,6 +261,13 @@ class InitCommand extends Command
     {
         $this->components->task('Migrating database', static function (): void {
             Artisan::call('migrate', ['--force' => true, '--quiet' => true]);
+        });
+    }
+
+    private function linkStorage(): void
+    {
+        $this->components->task('Linking storage', static function (): void {
+            Artisan::call('storage:link', ['--quiet' => true]);
         });
     }
 

--- a/app/Helpers.php
+++ b/app/Helpers.php
@@ -29,12 +29,12 @@ function base_url(): string
 
 function image_storage_path(?string $fileName, ?string $default = null): ?string
 {
-    return $fileName ? public_path(config('koel.image_storage_dir') . $fileName) : $default;
+    return $fileName ? config('koel.image_storage_dir') . DIRECTORY_SEPARATOR . $fileName : $default;
 }
 
 function image_storage_url(?string $fileName, ?string $default = null): ?string
 {
-    return $fileName ? static_url(config('koel.image_storage_dir') . $fileName) : $default;
+    return $fileName ? static_url('storage/images/' . $fileName) : $default;
 }
 
 function artifact_path(?string $subPath = null, $ensureDirectoryExists = true): string

--- a/config/koel.php
+++ b/config/koel.php
@@ -9,9 +9,7 @@ return [
     // or downloaded podcast episodes. By default, it is set to the system's temporary directory.
     'artifacts_path' => env('ARTIFACTS_PATH') ?: sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'koel',
 
-    // The *relative* path to the directory to store artist images, playlist covers, user avatars, etc.
-    // This is relative to the public path.
-    'image_storage_dir' => 'img/storage/',
+    'image_storage_dir' => storage_path('app/public/images'),
 
     /*
      |--------------------------------------------------------------------------

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -21,6 +21,7 @@ for details.
 | `STORAGE_DRIVER` | The storage driver for your media files. Valid values: `local`, `sftp`, `s3` (Koel Plus), `dropbox` (Koel Plus). See [Cloud Storage Support](plus/cloud-storage-support). | `local` |
 | `MEDIA_PATH` | The absolute path to your media directory. Required when using `STORAGE_DRIVER=local`. Can also be changed via the web interface. | _(empty)_ |
 | `ARTIFACTS_PATH` | The absolute path to store Koel artifacts (transcoded files, podcast episodes, temporary downloads, etc.). If empty, uses the system's temporary directory. | _(empty)_ |
+| `LARAVEL_STORAGE_PATH` | Absolute path Koel uses for writable runtime data — album/artist images (under `app/public/images`), logs, search indexes, framework cache, sessions. Set this to keep mutable state outside the application directory (read-only deploys, multi-instance setups, etc.). After setting it, run `php artisan storage:link` (or `composer koel:init`) so `public/storage` symlinks to `LARAVEL_STORAGE_PATH/app/public`. | `<app>/storage` |
 
 ### S3 / S3-Compatible
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -23,6 +23,20 @@ for details.
 | `ARTIFACTS_PATH` | The absolute path to store Koel artifacts (transcoded files, podcast episodes, temporary downloads, etc.). If empty, uses the system's temporary directory. | _(empty)_ |
 | `LARAVEL_STORAGE_PATH` | Absolute path Koel uses for writable runtime data — album/artist images (under `app/public/images`), logs, search indexes, framework cache, sessions. Set this to keep mutable state outside the application directory (read-only deploys, multi-instance setups, etc.). After setting it, run `php artisan storage:link` (or `composer koel:init`) so `public/storage` symlinks to `LARAVEL_STORAGE_PATH/app/public`. | `<app>/storage` |
 
+:::warning Upgrading from a Koel version < TBD
+The image storage location moved from `public/img/storage/` to `storage/app/public/images/`
+(or `LARAVEL_STORAGE_PATH/app/public/images/` when set). Existing installs need to migrate
+their images once, or album/artist art will appear broken:
+
+```bash
+mkdir -p "${LARAVEL_STORAGE_PATH:-$(pwd)/storage}/app/public/images"
+rsync -a public/img/storage/ "${LARAVEL_STORAGE_PATH:-$(pwd)/storage}/app/public/images/"
+php artisan storage:link
+```
+
+After confirming images render, the old `public/img/storage/` directory can be removed.
+:::
+
 ### S3 / S3-Compatible
 
 Required when `STORAGE_DRIVER=s3`. Remember to set your CORS policy to allow access from Koel's domain.

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -23,10 +23,10 @@ for details.
 | `ARTIFACTS_PATH` | The absolute path to store Koel artifacts (transcoded files, podcast episodes, temporary downloads, etc.). If empty, uses the system's temporary directory. | _(empty)_ |
 | `LARAVEL_STORAGE_PATH` | Absolute path Koel uses for writable runtime data — album/artist images (under `app/public/images`), logs, search indexes, framework cache, sessions. Set this to keep mutable state outside the application directory (read-only deploys, multi-instance setups, etc.). After setting it, run `php artisan storage:link` (or `composer koel:init`) so `public/storage` symlinks to `LARAVEL_STORAGE_PATH/app/public`. | `<app>/storage` |
 
-:::warning Upgrading from a Koel version < TBD
+:::warning Upgrading an older Koel install
 The image storage location moved from `public/img/storage/` to `storage/app/public/images/`
-(or `LARAVEL_STORAGE_PATH/app/public/images/` when set). Existing installs need to migrate
-their images once, or album/artist art will appear broken:
+(or `LARAVEL_STORAGE_PATH/app/public/images/` when set). If you have a `public/img/storage/`
+directory with files in it, migrate them once or album/artist art will appear broken:
 
 ```bash
 mkdir -p "${LARAVEL_STORAGE_PATH:-$(pwd)/storage}/app/public/images"

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -66,11 +66,11 @@ abstract class TestCase extends BaseTestCase
     private static function createSandbox(): void
     {
         config([
-            'koel.image_storage_dir' => 'sandbox/img/storage/',
+            'koel.image_storage_dir' => public_path('sandbox/img/storage'),
             'koel.artifacts_path' => public_path('sandbox/artifacts/'),
         ]);
 
-        File::ensureDirectoryExists(public_path(config('koel.image_storage_dir')));
+        File::ensureDirectoryExists(config('koel.image_storage_dir'));
         File::ensureDirectoryExists(public_path('sandbox/media/'));
     }
 


### PR DESCRIPTION
## Summary
Lay the foundation for relocating Koel's writable image storage out of the application directory, so the eventual single-binary FrankenPHP distribution can keep mutable state under `LARAVEL_STORAGE_PATH` (Laravel's native env-driven storage path) instead of inside the embedded payload.

## Changes
- **`config/koel.php`** — `image_storage_dir` defaults to `storage_path('app/public/images')` (absolute). Was a relative-to-public-path string.
- **`app/Helpers.php`** — `image_storage_path()` now treats the config as an absolute base path. `image_storage_url()` returns `/storage/images/{filename}`, served via Laravel's standard `public/storage` symlink.
- **`app/Console/Commands/InitCommand.php`** — adds a `Linking storage` task that runs `php artisan storage:link`. Required so the new `/storage/images/...` URL path resolves to the on-disk image dir.
- **`tests/TestCase.php`** — sandbox uses an absolute path for `koel.image_storage_dir` (consistent with the new helper semantics).
- **`docs/environment-variables.md`** — documents `LARAVEL_STORAGE_PATH`.

## Upgrade step for existing installs
One-time migration to move pre-existing images into the new location:

```bash
mkdir -p "${LARAVEL_STORAGE_PATH:-$(pwd)/storage}/app/public/images"
rsync -a public/img/storage/ "${LARAVEL_STORAGE_PATH:-$(pwd)/storage}/app/public/images/"
php artisan storage:link
```

After this, you can remove `public/img/storage/`. `composer koel:init` already runs `storage:link` going forward.

## What this enables (future work, not in this PR)
The FrankenPHP single-binary build can ship a Caddyfile that sets `LARAVEL_STORAGE_PATH={$HOME}/.koel/storage` by default, so the binary writes all runtime state under `~/.koel/` and that state survives binary upgrades (the binary's extracted payload directory is per-version; `~/.koel/` is not).

## Test plan
- [x] `composer cs` clean
- [x] `composer lint` clean
- [x] `composer analyze` clean
- [x] `php artisan test` — 1146 tests pass (was 1146)
- [x] `pnpm typecheck` clean
- [x] `vp check resources/assets` clean
- [ ] Manual: deploy + run the upgrade-step rsync + verify album/artist images still render at new URLs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration Changes**
  * Image storage now uses Laravel's storage path (storage/app/public/images) and supports LARAVEL_STORAGE_PATH for custom locations

* **New Behavior**
  * Init now attempts to create the public storage link during setup and warns if linking fails, prompting a manual repair

* **Documentation**
  * Added storage configuration and upgrade/migration instructions for existing images

* **Tests**
  * Sandbox tests updated to match the new storage path handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2472)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->