### PR TITLE
feat: let LARAVEL_STORAGE_PATH relocate .env

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -14,7 +14,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 
-return Application::configure(basePath: dirname(__DIR__))
+$app = Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         using: static function (): void {
             RouteServiceProvider::loadVersionAwareRoutes('web');
@@ -59,3 +59,11 @@ return Application::configure(basePath: dirname(__DIR__))
         });
     })
     ->create();
+
+$storagePath = $_ENV['LARAVEL_STORAGE_PATH'] ?? $_SERVER['LARAVEL_STORAGE_PATH'] ?? null;
+
+if ($storagePath !== null) {
+    $app->useEnvironmentPath($storagePath);
+}
+
+return $app;

--- a/composer.json
+++ b/composer.json
@@ -100,8 +100,8 @@
     "post-install-cmd": [
       "@php artisan clear-compiled",
       "@php artisan cache:clear",
-      "@php -r \"if (!file_exists('.env')) copy('.env.example', '.env');\"",
-      "@php -r \"if (!file_exists('./public/.htaccess')) copy('.htaccess.example', './public/.htaccess');\""
+      "@php scripts/ensure-env.php",
+      "@php scripts/ensure-htaccess.php"
     ],
     "pre-update-cmd": [
       "@php artisan clear-compiled"
@@ -111,7 +111,7 @@
       "@php artisan boost:update --ansi"
     ],
     "post-root-package-install": [
-      "@php -r \"copy('.env.example', '.env');\""
+      "@php scripts/ensure-env.php"
     ],
     "post-create-project-cmd": [
       "@php artisan key:generate"

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -21,7 +21,7 @@ for details.
 | `STORAGE_DRIVER` | The storage driver for your media files. Valid values: `local`, `sftp`, `s3` (Koel Plus), `dropbox` (Koel Plus). See [Cloud Storage Support](plus/cloud-storage-support). | `local` |
 | `MEDIA_PATH` | The absolute path to your media directory. Required when using `STORAGE_DRIVER=local`. Can also be changed via the web interface. | _(empty)_ |
 | `ARTIFACTS_PATH` | The absolute path to store Koel artifacts (transcoded files, podcast episodes, temporary downloads, etc.). If empty, uses the system's temporary directory. | _(empty)_ |
-| `LARAVEL_STORAGE_PATH` | Absolute path Koel uses for writable runtime data — album/artist images (under `app/public/images`), logs, search indexes, framework cache, sessions. Set this to keep mutable state outside the application directory (read-only deploys, multi-instance setups, etc.). After setting it, run `php artisan storage:link` (or `composer koel:init`) so `public/storage` symlinks to `LARAVEL_STORAGE_PATH/app/public`. | `<app>/storage` |
+| `LARAVEL_STORAGE_PATH` | Absolute path Koel uses for writable runtime data — `.env`, album/artist images (under `app/public/images`), logs, search indexes, framework cache, sessions. Set this to keep mutable state outside the application directory (read-only deploys, multi-instance setups, etc.). When set, Koel reads `.env` from `LARAVEL_STORAGE_PATH/.env`. After setting it, run `php artisan storage:link` (or `composer koel:init`) so `public/storage` symlinks to `LARAVEL_STORAGE_PATH/app/public`. | `<app>/storage` |
 
 :::warning Upgrading an older Koel install
 The image storage location moved from `public/img/storage/` to `storage/app/public/images/`

--- a/scripts/ensure-env.php
+++ b/scripts/ensure-env.php
@@ -1,0 +1,13 @@
+<?php
+
+$base = dirname(__DIR__);
+$target = getenv('LARAVEL_STORAGE_PATH') ?: $base;
+$target = rtrim($target, '/\\');
+
+if (!is_dir($target)) {
+    @mkdir($target, 0755, true);
+}
+
+if (!file_exists($target . '/.env')) {
+    copy($base . '/.env.example', $target . '/.env');
+}

--- a/scripts/ensure-env.php
+++ b/scripts/ensure-env.php
@@ -1,13 +1,18 @@
 <?php
 
 $base = dirname(__DIR__);
-$target = getenv('LARAVEL_STORAGE_PATH') ?: $base;
+$target = $_ENV['LARAVEL_STORAGE_PATH'] ?? $_SERVER['LARAVEL_STORAGE_PATH'] ?? $base;
 $target = rtrim($target, '/\\');
 
-if (!is_dir($target)) {
-    @mkdir($target, 0755, true);
+if (!is_dir($target) && !mkdir($target, 0755, true) && !is_dir($target)) {
+    fwrite(STDERR, "Failed to create directory: $target\n");
+    exit(1);
 }
 
-if (!file_exists($target . '/.env')) {
-    copy($base . '/.env.example', $target . '/.env');
+$source = $base . '/.env.example';
+$destination = $target . '/.env';
+
+if (!file_exists($destination) && !copy($source, $destination)) {
+    fwrite(STDERR, "Failed to copy $source to $destination\n");
+    exit(1);
 }

--- a/scripts/ensure-htaccess.php
+++ b/scripts/ensure-htaccess.php
@@ -1,0 +1,8 @@
+<?php
+
+$base = dirname(__DIR__);
+$target = $base . '/public/.htaccess';
+
+if (!file_exists($target)) {
+    copy($base . '/.htaccess.example', $target);
+}

--- a/scripts/ensure-htaccess.php
+++ b/scripts/ensure-htaccess.php
@@ -1,8 +1,10 @@
 <?php
 
 $base = dirname(__DIR__);
-$target = $base . '/public/.htaccess';
+$source = $base . '/.htaccess.example';
+$destination = $base . '/public/.htaccess';
 
-if (!file_exists($target)) {
-    copy($base . '/.htaccess.example', $target);
+if (!file_exists($destination) && !copy($source, $destination)) {
+    fwrite(STDERR, "Failed to copy $source to $destination\n");
+    exit(1);
 }


### PR DESCRIPTION
## Summary

Lets `LARAVEL_STORAGE_PATH` relocate `.env` alongside the rest of Koel's writable state, in preparation for the FrankenPHP single-binary distribution where the application directory is read-only.

When `LARAVEL_STORAGE_PATH` is set:

- `bootstrap/app.php` calls `$app->useEnvironmentPath($LARAVEL_STORAGE_PATH)`, so Laravel reads `.env` from there instead of `<app>/.env`.
- The composer `post-install-cmd` / `post-root-package-install` scripts write `.env` to `$LARAVEL_STORAGE_PATH/.env` instead of `<app>/.env`.

When it is unset, behavior is unchanged — `.env` is read from and written to the application root, exactly as before.

## Changes

- `bootstrap/app.php` — conditional `useEnvironmentPath()` hook driven by `$_ENV['LARAVEL_STORAGE_PATH']` / `$_SERVER['LARAVEL_STORAGE_PATH']`.
- `composer.json` — replaces the inline `@php -r "..."` `.env` and `.htaccess` copies with `@php scripts/ensure-env.php` and `@php scripts/ensure-htaccess.php`. The `.env` script respects `LARAVEL_STORAGE_PATH`; the `.htaccess` script doesn't (the file is tied to the webserver, not the storage path).
- `scripts/ensure-env.php`, `scripts/ensure-htaccess.php` — new helper scripts lifted out of the inline composer commands.
- `docs/environment-variables.md` — `LARAVEL_STORAGE_PATH` row now mentions `.env`.

## Test plan

- [x] `composer cs` clean
- [x] `composer lint` clean
- [x] `composer analyze` clean (1089 files, no errors)
- [x] `php artisan test tests/Feature/HomeTest.php` — app boots without `LARAVEL_STORAGE_PATH` set (no-op path)
- [ ] Manual smoke test: set `LARAVEL_STORAGE_PATH=/tmp/koel-test`, place a `.env` there, confirm Laravel picks it up


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable storage-path support so the app can read its runtime files from a custom location via an environment variable.

* **Documentation**
  * Updated environment variables docs with the new storage-path option and clarified runtime data locations (logs, cache, indexes, sessions).

* **Chores**
  * Improved project setup to automatically ensure required environment and webserver bootstrap files are present during installation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2473)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->