### PR TITLE
feat: support FrankenPHP, bump default upload limit to 512M

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 Homestead.yaml
 Homestead.json
 .env
+/Caddyfile
 .idea
 /_ide_helper.php
 /config.testing

--- a/Caddyfile.example
+++ b/Caddyfile.example
@@ -2,7 +2,18 @@
 # Copy to `Caddyfile`, replace `localhost` with your domain, then run
 # `frankenphp run` from the project root.
 {
-	frankenphp
+	frankenphp {
+		# Suppress display + mute deprecation notices. FrankenPHP ships PHP 8.5,
+		# which deprecates the PDO::MYSQL_ATTR_* constants Laravel's stock
+		# config/database.php still uses; without these, the deprecation lands
+		# in the HTTP response stream and corrupts JSON responses.
+		php_ini display_errors "off"
+		php_ini error_reporting "E_ALL & ~E_DEPRECATED & ~E_STRICT"
+
+		# Match Koel's nginx.conf.example / .htaccess.example upload ceiling.
+		php_ini upload_max_filesize "50M"
+		php_ini post_max_size "50M"
+	}
 }
 
 localhost {

--- a/Caddyfile.example
+++ b/Caddyfile.example
@@ -1,6 +1,7 @@
 {
 	frankenphp {
 		php_ini display_errors "off"
+		php_ini log_errors "on"
 		php_ini error_reporting "E_ALL & ~E_DEPRECATED & ~E_STRICT"
 		php_ini upload_max_filesize "512M"
 		php_ini post_max_size "512M"

--- a/Caddyfile.example
+++ b/Caddyfile.example
@@ -1,16 +1,7 @@
-# Sample Caddyfile for running Koel with FrankenPHP (https://frankenphp.dev).
-# Copy to `Caddyfile`, replace `localhost` with your domain, then run
-# `frankenphp run` from the project root.
 {
 	frankenphp {
-		# Suppress display + mute deprecation notices. FrankenPHP ships PHP 8.5,
-		# which deprecates the PDO::MYSQL_ATTR_* constants Laravel's stock
-		# config/database.php still uses; without these, the deprecation lands
-		# in the HTTP response stream and corrupts JSON responses.
 		php_ini display_errors "off"
 		php_ini error_reporting "E_ALL & ~E_DEPRECATED & ~E_STRICT"
-
-		# Match Koel's nginx.conf.example / .htaccess.example upload ceiling.
 		php_ini upload_max_filesize "50M"
 		php_ini post_max_size "50M"
 	}

--- a/Caddyfile.example
+++ b/Caddyfile.example
@@ -2,8 +2,8 @@
 	frankenphp {
 		php_ini display_errors "off"
 		php_ini error_reporting "E_ALL & ~E_DEPRECATED & ~E_STRICT"
-		php_ini upload_max_filesize "50M"
-		php_ini post_max_size "50M"
+		php_ini upload_max_filesize "512M"
+		php_ini post_max_size "512M"
 	}
 }
 
@@ -13,7 +13,7 @@ localhost {
 	encode zstd br gzip
 
 	request_body {
-		max_size 50MB
+		max_size 512MB
 	}
 
 	php_server {

--- a/Caddyfile.example
+++ b/Caddyfile.example
@@ -1,0 +1,20 @@
+# Sample Caddyfile for running Koel with FrankenPHP (https://frankenphp.dev).
+# Copy to `Caddyfile`, replace `localhost` with your domain, then run
+# `frankenphp run` from the project root.
+{
+	frankenphp
+}
+
+localhost {
+	root public/
+
+	encode zstd br gzip
+
+	request_body {
+		max_size 50MB
+	}
+
+	php_server {
+		try_files {path} index.php
+	}
+}

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -63,10 +63,16 @@ In both cases, you should now be able to visit http://localhost:8000 in your bro
 
 ::: warning Use a proper webserver
 http://localhost:8000 is only the _development_ server for Koel (or rather, Laravel).
-For optimal performance, you'll want to set up a production server (Apache, nginx, Caddy etc.) and point it to the
-`public` directory of Koel.
-Koel provides a sample configuration for nginx in `nginx.conf.example`,
-but the process shouldn't be any different from that of a standard PHP application.
+For production, point a proper server (Apache, nginx, Caddy, etc.) at Koel's
+`public/` directory — the process is no different from any standard PHP application.
+
+Koel ships two starter configs at the project root:
+
+- `nginx.conf.example` — nginx + PHP-FPM.
+- `Caddyfile.example` — [FrankenPHP](https://frankenphp.dev), which bundles the
+  webserver and PHP runtime in a single binary. After installing FrankenPHP,
+  copy this file to `Caddyfile`, replace `localhost` with your domain, and run
+  `frankenphp run` from the project root.
 :::
 
 ### Using Docker

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -143,7 +143,6 @@ User=www-data
 WorkingDirectory=/var/www/koel
 ExecStart=/usr/local/bin/frankenphp run
 Restart=on-failure
-# Allow binding to privileged ports 80 and 443 without running as root.
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 
@@ -168,7 +167,7 @@ that owns them.
 If you're already running nginx (or another reverse proxy) and want to use FrankenPHP only as the PHP runtime, bind it
 to a loopback port and disable Caddy's automatic HTTPS. Replace the site block in `Caddyfile` with:
 
-```
+```caddyfile
 :8001 {
 	bind 127.0.0.1
 	root public/

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -98,9 +98,11 @@ and Koel will know to remove/disable these features.
 runtime into a single binary — replacing the typical nginx + PHP-FPM pair with one process and giving you automatic
 HTTPS out of the box. Koel ships a `Caddyfile.example` at the project root that wires it up correctly.
 
+::: info Note
 FrankenPHP is only the runtime — you still need a fully prepared Koel install (i.e. `vendor/` from `composer install`
 and the compiled frontend in `public/build/`) before it has anything to serve. Use either of the installation methods
 above (pre-compiled archive or building from source) first.
+:::
 
 ### Install FrankenPHP
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -158,10 +158,6 @@ sudo systemctl enable --now koel
 sudo journalctl -u koel -f
 ```
 
-The `AmbientCapabilities=CAP_NET_BIND_SERVICE` directive is what lets the unrooted service bind to ports 80 and 443.
-Without it, you'd have to either run as root (don't) or pick non-privileged ports and front the service with something
-that owns them.
-
 ### Behind a reverse proxy
 
 If you're already running nginx (or another reverse proxy) and want to use FrankenPHP only as the PHP runtime, bind it

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -98,6 +98,10 @@ and Koel will know to remove/disable these features.
 runtime into a single binary — replacing the typical nginx + PHP-FPM pair with one process and giving you automatic
 HTTPS out of the box. Koel ships a `Caddyfile.example` at the project root that wires it up correctly.
 
+FrankenPHP is only the runtime — you still need a fully prepared Koel install (i.e. `vendor/` from `composer install`
+and the compiled frontend in `public/build/`) before it has anything to serve. Use either of the installation methods
+above (pre-compiled archive or building from source) first.
+
 ### Install FrankenPHP
 
 Pre-built binaries are published at [frankenphp.dev/docs/#install](https://frankenphp.dev/docs/#install). On Linux,

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,5 +1,5 @@
 ---
-description: Requirements, installation methods (pre-compiled, source, Docker), configuration, upgrading, and downgrading Koel.
+description: Requirements, installation methods (pre-compiled, source, Docker), configuration, running with FrankenPHP (binary + systemd), upgrading, and downgrading Koel.
 ---
 
 # Getting Started
@@ -63,16 +63,10 @@ In both cases, you should now be able to visit http://localhost:8000 in your bro
 
 ::: warning Use a proper webserver
 http://localhost:8000 is only the _development_ server for Koel (or rather, Laravel).
-For production, point a proper server (Apache, nginx, Caddy, etc.) at Koel's
-`public/` directory — the process is no different from any standard PHP application.
-
-Koel ships two starter configs at the project root:
-
-- `nginx.conf.example` — nginx + PHP-FPM.
-- `Caddyfile.example` — [FrankenPHP](https://frankenphp.dev), which bundles the
-  webserver and PHP runtime in a single binary. After installing FrankenPHP,
-  copy this file to `Caddyfile`, replace `localhost` with your domain, and run
-  `frankenphp run` from the project root.
+For production, point a proper server (Apache, nginx, Caddy, etc.) at Koel's `public/`
+directory — the process is no different from any standard PHP application.
+Koel ships starter configs at the project root: `nginx.conf.example` for nginx + PHP-FPM,
+and `Caddyfile.example` for [FrankenPHP](#running-with-frankenphp).
 :::
 
 ### Using Docker
@@ -97,6 +91,96 @@ Any non-empty value other than `log` or `array` is considered a proper mailer.
 As such, if you don't need email-required features, you can simply set `MAIL_MAILER` to `log` or `array` and leave the
 rest of the mailer-related values empty,
 and Koel will know to remove/disable these features.
+
+## Running with FrankenPHP
+
+[FrankenPHP](https://frankenphp.dev) is a modern PHP application server that bundles the webserver (Caddy) and the PHP
+runtime into a single binary — replacing the typical nginx + PHP-FPM pair with one process and giving you automatic
+HTTPS out of the box. Koel ships a `Caddyfile.example` at the project root that wires it up correctly.
+
+### Install FrankenPHP
+
+Pre-built binaries are published at [frankenphp.dev/docs/#install](https://frankenphp.dev/docs/#install). On Linux,
+the one-line installer fetches the right binary for your architecture:
+
+```bash
+curl https://frankenphp.dev/install.sh | sh
+sudo mv frankenphp /usr/local/bin/
+```
+
+### Configure the Caddyfile
+
+From the Koel project root:
+
+```bash
+cp Caddyfile.example Caddyfile
+```
+
+Edit `Caddyfile` and replace `localhost` with the domain you'll serve from. Using a real public domain enables automatic
+HTTPS via Let's Encrypt; keeping `localhost` is fine for local testing and uses Caddy's local development CA.
+
+### Run it
+
+```bash
+frankenphp run
+```
+
+That's it — Koel is now served on port 443 (and 80, redirected to HTTPS).
+
+### Run as a systemd service (Ubuntu)
+
+For a production deployment, run FrankenPHP under `systemd` so it starts on boot and restarts on failure. Create
+`/etc/systemd/system/koel.service`:
+
+```ini
+[Unit]
+Description=Koel (FrankenPHP)
+After=network.target
+
+[Service]
+Type=simple
+User=www-data
+WorkingDirectory=/var/www/koel
+ExecStart=/usr/local/bin/frankenphp run
+Restart=on-failure
+# Allow binding to privileged ports 80 and 443 without running as root.
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Adjust `WorkingDirectory` and `User` to match where Koel lives on your host. Then enable and start it:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now koel
+sudo journalctl -u koel -f
+```
+
+The `AmbientCapabilities=CAP_NET_BIND_SERVICE` directive is what lets the unrooted service bind to ports 80 and 443.
+Without it, you'd have to either run as root (don't) or pick non-privileged ports and front the service with something
+that owns them.
+
+### Behind a reverse proxy
+
+If you're already running nginx (or another reverse proxy) and want to use FrankenPHP only as the PHP runtime, bind it
+to a loopback port and disable Caddy's automatic HTTPS. Replace the site block in `Caddyfile` with:
+
+```
+:8001 {
+	bind 127.0.0.1
+	root public/
+	encode zstd gzip
+	php_server {
+		try_files {path} index.php
+	}
+}
+```
+
+…and add `auto_https off` to the global block. Then point your existing reverse proxy at `127.0.0.1:8001` and let it
+terminate TLS as before.
 
 ## Upgrade
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -123,7 +123,7 @@ cp Caddyfile.example Caddyfile
 ```
 
 Edit `Caddyfile` and replace `localhost` with the domain you'll serve from. Using a real public domain enables automatic
-HTTPS via Let's Encrypt; keeping `localhost` is fine for local testing and uses Caddy's local development CA.
+HTTPS via Let's Encrypt.
 
 ### Run it
 

--- a/nginx.conf.example
+++ b/nginx.conf.example
@@ -9,7 +9,7 @@ server {
   gzip_comp_level  9;
 
   send_timeout    3600;
-  client_max_body_size  50M;
+  client_max_body_size  512M;
 
   location / {
     try_files   $uri $uri/ /index.php?$args;

--- a/public/.htaccess.example
+++ b/public/.htaccess.example
@@ -107,5 +107,5 @@
 
 </IfModule>
 
-php_value upload_max_filesize 50M
-php_value post_max_size 50M
+php_value upload_max_filesize 512M
+php_value post_max_size 512M

--- a/public/.user.ini.example
+++ b/public/.user.ini.example
@@ -2,5 +2,5 @@
 ; via .user.ini files. For example, you can increase the upload file and post size
 ; limits by setting the desired values here and renaming this file into .user.ini.
 
-upload_max_filesize = 50M
-post_max_size = 50M
+upload_max_filesize = 512M
+post_max_size = 512M


### PR DESCRIPTION
## Summary

Two changes:

1. **First-class support for running Koel with [FrankenPHP](https://frankenphp.dev)** — the single-binary distribution that bundles Caddy and PHP, replacing the typical nginx + PHP-FPM pair. No application-level changes; just a starter `Caddyfile.example` template and documentation.
2. **Default upload ceiling bumped from 50M to 512M** across all four server-config templates Koel ships. Koel users routinely upload lossless audio (FLAC, ALAC) in the 100–300MB range; the previous 50M default has been a chronic source of "upload failed" reports.

## Changes

### `Caddyfile.example` (new)

Mirrors the FrankenPHP project's recommended Laravel template, with Koel-specific PHP settings baked into the `frankenphp` global block:

- `display_errors off` and `error_reporting "E_ALL & ~E_DEPRECATED & ~E_STRICT"` — production-correct, and necessary on PHP 8.5 (the version FrankenPHP currently ships) because Laravel's stock `config/database.php` still references `PDO::MYSQL_ATTR_*` constants that PHP 8.5 deprecated; without these settings, the deprecation notice lands in the HTTP response stream and corrupts JSON responses.
- `upload_max_filesize "512M"` and `post_max_size "512M"`.

Plus a Caddy-level `request_body { max_size 512MB }` so large media uploads aren't blocked by Caddy's default 10MB cap before they even reach PHP.

### Upload-limit bump in existing server-config templates

- `nginx.conf.example`: `client_max_body_size 50M;` → `512M;`
- `public/.htaccess.example`: `upload_max_filesize` / `post_max_size` 50M → 512M
- `public/.user.ini.example`: `upload_max_filesize` / `post_max_size` 50M → 512M

### `.gitignore`

Adds `/Caddyfile` so the recommended `cp Caddyfile.example Caddyfile` workflow doesn't leak users' tweaked copies into the tree. Same pattern as `.env` / `.env.example`.

### `docs/guide/getting-started.md`

- The existing "Use a proper webserver" callout now points at both `nginx.conf.example` and `Caddyfile.example`, with an in-page anchor to the new section below.
- A new `## Running with FrankenPHP` section covers: installing the binary (one-line installer), copying `Caddyfile.example` to `Caddyfile` and editing the domain, running `frankenphp run`, a complete `/etc/systemd/system/koel.service` unit (Ubuntu) with `AmbientCapabilities=CAP_NET_BIND_SERVICE` for unprivileged port-80/443 binding, and a "Behind a reverse proxy" subsection for the loopback-port + `auto_https off` pattern.

## Test plan

- [x] `frankenphp validate` returns `Valid configuration` for the Caddyfile.
- [x] `frankenphp fmt` reports correctly formatted.
- [x] Live smoke test with the native macOS arm64 FrankenPHP binary (`v1.12.2`) run from the Koel project root with `Caddyfile.example` (adapted to bind `:8000` HTTP for the unprivileged test): `curl http://localhost:8000/` returned HTTP 200 with `<title>Koel</title>` and no exceptions — Laravel boots cleanly through the Caddyfile + `php_server` directive.
- [x] `bash docs/.vitepress/check-frontmatter.sh` — all doc pages have a description.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive deployment guide including FrankenPHP setup and configuration instructions.

* **Chores**
  * Added Caddyfile example configuration for FrankenPHP deployments.
  * Increased maximum file upload size limits to 512MB across all server configurations (nginx, Apache, PHP).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2475)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->