### PR TITLE
feat: add execution timeouts and reverse-proxy hints to Caddyfile.example

### DIFF
--- a/Caddyfile.example
+++ b/Caddyfile.example
@@ -1,10 +1,20 @@
 {
+	# Uncomment the following block when running behind a reverse proxy that
+	# terminates TLS (e.g. nginx, Apache). Adjust the trusted-proxies CIDR if
+	# the proxy lives on a different host.
+	# auto_https off
+	# servers {
+	# 	trusted_proxies static 127.0.0.1/32
+	# }
+
 	frankenphp {
 		php_ini display_errors "off"
 		php_ini log_errors "on"
 		php_ini error_reporting "E_ALL & ~E_DEPRECATED & ~E_STRICT"
 		php_ini upload_max_filesize "512M"
 		php_ini post_max_size "512M"
+		php_ini max_execution_time "300"
+		php_ini max_input_time "300"
 	}
 }
 


### PR DESCRIPTION
## Summary

Three small tweaks to `Caddyfile.example`, driven by yesterday's dogfood deployment to franken.phanan.net (PR #2475 follow-up).

- Add `php_ini max_execution_time "300"` and `php_ini max_input_time "300"` to the `frankenphp` block. With `post_max_size` at 512M, the default 30s PHP execution/input timeouts are too tight for slower uploaders to push a full-size body through. 300s matches the franken.phanan.net production config that's been working reliably.
- Add a commented `auto_https off` directive in the global block, with a comment above explaining when to uncomment it (running behind a reverse proxy that terminates TLS).
- Add a commented `servers { trusted_proxies static 127.0.0.1/32 }` block alongside, with a note that the CIDR may need adjustment if the reverse proxy lives on a different host.

## Test plan

- [x] `frankenphp validate` returns `Valid configuration`.
- [x] `frankenphp fmt` is clean.
- [x] The exact same Caddyfile shape (with the commented blocks uncommented + a `:8001 { bind 127.0.0.1 … }` site block instead of `localhost { … }`) is currently serving franken.phanan.net in production behind nginx without errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example configuration to include guidance for reverse proxy deployments with TLS termination and trusted proxy directives
  * Added PHP configuration options for execution and input time limits in the example setup

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2476?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->