### PR TITLE
docs: extract FrankenPHP guide to its own page

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -55,6 +55,7 @@ export default defineConfig({
         items: [
           { text: 'What Is Koel?', link: '/guide/what-is-koel' },
           { text: 'Getting Started', link: '/guide/getting-started' },
+          { text: 'Running with FrankenPHP', link: '/guide/running-with-frankenphp' },
         ],
       },
       {

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -66,7 +66,7 @@ http://localhost:8000 is only the _development_ server for Koel (or rather, Lara
 For production, point a proper server (Apache, nginx, Caddy, etc.) at Koel's `public/`
 directory — the process is no different from any standard PHP application.
 Koel ships starter configs at the project root: `nginx.conf.example` for nginx + PHP-FPM,
-and `Caddyfile.example` for [FrankenPHP](#running-with-frankenphp).
+and `Caddyfile.example` for [FrankenPHP](/guide/running-with-frankenphp).
 :::
 
 ### Using Docker
@@ -94,122 +94,10 @@ and Koel will know to remove/disable these features.
 
 ## Running with FrankenPHP
 
-[FrankenPHP](https://frankenphp.dev) is a modern PHP application server that bundles the webserver (Caddy) and the PHP
-runtime into a single binary — replacing the typical nginx + PHP-FPM pair with one process and giving you automatic
-HTTPS out of the box. Koel ships a `Caddyfile.example` at the project root that wires it up correctly.
-
-::: info Note
-FrankenPHP is only the runtime — you still need a fully prepared Koel install (i.e. `vendor/` from `composer install`
-and the compiled frontend in `public/build/`) before it has anything to serve. Use either of the installation methods
-above (pre-compiled archive or building from source) first.
-:::
-
-### Install FrankenPHP
-
-Pre-built binaries are published at [frankenphp.dev/docs/#install](https://frankenphp.dev/docs/#install). On Linux,
-the one-line installer fetches the right binary for your architecture:
-
-```bash
-curl https://frankenphp.dev/install.sh | sh
-sudo mv frankenphp /usr/local/bin/
-```
-
-### Configure the Caddyfile
-
-From the Koel project root:
-
-```bash
-cp Caddyfile.example Caddyfile
-```
-
-Edit `Caddyfile` and replace `localhost` with the domain you'll serve from. Using a real public domain enables automatic
-HTTPS via Let's Encrypt.
-
-### Run it
-
-```bash
-frankenphp run
-```
-
-That's it — Koel is now served on port 443 (and 80, redirected to HTTPS).
-
-### Running artisan commands
-
-FrankenPHP bundles its own PHP, exposed via the `php-cli` subcommand. Any `php artisan …` from Koel's CLI documentation
-becomes:
-
-```bash
-frankenphp php-cli artisan <command>
-```
-
-For example, `frankenphp php-cli artisan migrate` runs database migrations and `frankenphp php-cli artisan koel:sync`
-triggers a media scan. For convenience: `alias artisan='frankenphp php-cli artisan'`.
-
-If Koel was installed alongside a system PHP (used by `composer install`, etc.), running `php artisan <command>` against
-the system PHP works too — both PHPs share the same `.env` and database.
-
-::: warning DB_HOST=localhost gotcha
-FrankenPHP's bundled PHP has a different compiled-in default MySQL socket path than the system PHP your distro ships.
-If `.env` has `DB_HOST=localhost`, Laravel connects via Unix socket — and `frankenphp php-cli` will look at the wrong
-path. Symptom: `Checking database connection … ERROR` when running `koel:init` under FrankenPHP even though
-HTTP serving works fine. Fix either of:
-
-- Override per-command: `DB_HOST=127.0.0.1 frankenphp php-cli artisan <command>`
-- Or change `.env` to `DB_HOST=127.0.0.1` to force TCP for everyone (small loopback overhead, but uniform).
-:::
-
-For FrankenPHP CLI options not covered here (worker mode, multi-domain serving, custom PHP flags, etc.), refer to the
-[official FrankenPHP documentation](https://frankenphp.dev/docs/).
-
-### Run as a systemd service (Ubuntu)
-
-For a production deployment, run FrankenPHP under `systemd` so it starts on boot and restarts on failure. Create
-`/etc/systemd/system/koel.service`:
-
-```ini
-[Unit]
-Description=Koel (FrankenPHP)
-After=network.target
-
-[Service]
-Type=simple
-User=www-data
-WorkingDirectory=/var/www/koel
-ExecStart=/usr/local/bin/frankenphp run
-Restart=on-failure
-AmbientCapabilities=CAP_NET_BIND_SERVICE
-CapabilityBoundingSet=CAP_NET_BIND_SERVICE
-
-[Install]
-WantedBy=multi-user.target
-```
-
-Adjust `WorkingDirectory` and `User` to match where Koel lives on your host. Then enable and start it:
-
-```bash
-sudo systemctl daemon-reload
-sudo systemctl enable --now koel
-sudo journalctl -u koel -f
-```
-
-### Behind a reverse proxy
-
-If you're already running nginx (or another reverse proxy) and want to use FrankenPHP only as the PHP runtime, bind it
-to a loopback port and disable Caddy's automatic HTTPS. Replace the site block in `Caddyfile` with:
-
-```caddyfile
-:8001 {
-	bind 127.0.0.1
-	root public/
-	encode zstd gzip
-	php_server {
-		try_files {path} index.php
-	}
-}
-```
-
-…and add `auto_https off` to the global block. Then point your existing reverse proxy at `127.0.0.1:8001` and let it
-terminate TLS as before.
+Koel works well with [FrankenPHP](https://frankenphp.dev), a modern PHP application server that bundles a webserver
+(Caddy) and the PHP runtime into a single binary, with automatic HTTPS out of the box. See
+[Running with FrankenPHP](/guide/running-with-frankenphp) for the full setup guide — install, Caddyfile, artisan
+commands, systemd service, and reverse-proxy mode.
 
 ## Upgrade
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -133,6 +133,34 @@ frankenphp run
 
 That's it — Koel is now served on port 443 (and 80, redirected to HTTPS).
 
+### Running artisan commands
+
+FrankenPHP bundles its own PHP, exposed via the `php-cli` subcommand. Any `php artisan …` from Koel's CLI documentation
+becomes:
+
+```bash
+frankenphp php-cli artisan <command>
+```
+
+For example, `frankenphp php-cli artisan migrate` runs database migrations and `frankenphp php-cli artisan koel:sync`
+triggers a media scan. For convenience: `alias artisan='frankenphp php-cli artisan'`.
+
+If Koel was installed alongside a system PHP (used by `composer install`, etc.), running `php artisan <command>` against
+the system PHP works too — both PHPs share the same `.env` and database.
+
+::: warning DB_HOST=localhost gotcha
+FrankenPHP's bundled PHP has a different compiled-in default MySQL socket path than the system PHP your distro ships.
+If `.env` has `DB_HOST=localhost`, Laravel connects via Unix socket — and `frankenphp php-cli` will look at the wrong
+path. Symptom: `Checking database connection … ERROR` when running `koel:init` under FrankenPHP even though
+HTTP serving works fine. Fix either of:
+
+- Override per-command: `DB_HOST=127.0.0.1 frankenphp php-cli artisan <command>`
+- Or change `.env` to `DB_HOST=127.0.0.1` to force TCP for everyone (small loopback overhead, but uniform).
+:::
+
+For FrankenPHP CLI options not covered here (worker mode, multi-domain serving, custom PHP flags, etc.), refer to the
+[official FrankenPHP documentation](https://frankenphp.dev/docs/).
+
 ### Run as a systemd service (Ubuntu)
 
 For a production deployment, run FrankenPHP under `systemd` so it starts on boot and restarts on failure. Create

--- a/docs/guide/running-with-frankenphp.md
+++ b/docs/guide/running-with-frankenphp.md
@@ -105,19 +105,13 @@ sudo journalctl -u koel -f
 
 ## Behind a reverse proxy
 
-If you're already running nginx (or another reverse proxy) and want to use FrankenPHP only as the PHP runtime, bind it
-to a loopback port and disable Caddy's automatic HTTPS. Replace the site block in `Caddyfile` with:
+If you're already running nginx (or another reverse proxy) and want to use FrankenPHP only as the PHP runtime, make two
+changes to your `Caddyfile`:
 
-```caddyfile
-:8001 {
-	bind 127.0.0.1
-	root public/
-	encode zstd gzip
-	php_server {
-		try_files {path} index.php
-	}
-}
-```
+1. **Uncomment the `auto_https off` and `servers { trusted_proxies … }` block** at the top — `Caddyfile.example` ships
+   it commented and ready for this case. Adjust the trusted-proxies CIDR if the reverse proxy lives on a different
+   host.
+2. **Bind the site block to a loopback port** — change `localhost {` to `:8001 {` and add `bind 127.0.0.1` as the first
+   line inside the block. Everything else inside the site block stays as-is.
 
-…and add `auto_https off` to the global block. Then point your existing reverse proxy at `127.0.0.1:8001` and let it
-terminate TLS as before.
+Then point your existing reverse proxy at `127.0.0.1:8001` and let it terminate TLS as before.

--- a/docs/guide/running-with-frankenphp.md
+++ b/docs/guide/running-with-frankenphp.md
@@ -1,0 +1,123 @@
+---
+description: Install FrankenPHP, configure Koel's Caddyfile, run artisan commands via php-cli, set up a systemd service on Ubuntu, and serve behind a reverse proxy.
+---
+
+# Running with FrankenPHP
+
+[FrankenPHP](https://frankenphp.dev) is a modern PHP application server that bundles the webserver (Caddy) and the PHP
+runtime into a single binary — replacing the typical nginx + PHP-FPM pair with one process and giving you automatic
+HTTPS out of the box. Koel ships a `Caddyfile.example` at the project root that wires it up correctly.
+
+::: info Note
+FrankenPHP is only the runtime — you still need a fully prepared Koel install (i.e. `vendor/` from `composer install`
+and the compiled frontend in `public/build/`) before it has anything to serve. Follow either of the installation
+methods on the [Getting Started](/guide/getting-started#installation) page (pre-compiled archive or building from
+source) first.
+:::
+
+## Install FrankenPHP
+
+Pre-built binaries are published at [frankenphp.dev/docs/#install](https://frankenphp.dev/docs/#install). On Linux,
+the one-line installer fetches the right binary for your architecture:
+
+```bash
+curl https://frankenphp.dev/install.sh | sh
+sudo mv frankenphp /usr/local/bin/
+```
+
+## Configure the Caddyfile
+
+From the Koel project root:
+
+```bash
+cp Caddyfile.example Caddyfile
+```
+
+Edit `Caddyfile` and replace `localhost` with the domain you'll serve from. Using a real public domain enables automatic
+HTTPS via Let's Encrypt.
+
+## Run it
+
+```bash
+frankenphp run
+```
+
+That's it — Koel is now served on port 443 (and 80, redirected to HTTPS).
+
+## Running artisan commands
+
+FrankenPHP bundles its own PHP, exposed via the `php-cli` subcommand. Any `php artisan …` from Koel's CLI documentation
+becomes:
+
+```bash
+frankenphp php-cli artisan <command>
+```
+
+For example, `frankenphp php-cli artisan migrate` runs database migrations and `frankenphp php-cli artisan koel:sync`
+triggers a media scan. For convenience: `alias artisan='frankenphp php-cli artisan'`.
+
+If Koel was installed alongside a system PHP (used by `composer install`, etc.), running `php artisan <command>` against
+the system PHP works too — both PHPs share the same `.env` and database.
+
+::: warning DB_HOST=localhost gotcha
+FrankenPHP's bundled PHP has a different compiled-in default MySQL socket path than the system PHP your distro ships.
+If `.env` has `DB_HOST=localhost`, Laravel connects via Unix socket — and `frankenphp php-cli` will look at the wrong
+path. Symptom: `Checking database connection … ERROR` when running `koel:init` under FrankenPHP even though
+HTTP serving works fine. Fix either of:
+
+- Override per-command: `DB_HOST=127.0.0.1 frankenphp php-cli artisan <command>`
+- Or change `.env` to `DB_HOST=127.0.0.1` to force TCP for everyone (small loopback overhead, but uniform).
+:::
+
+For FrankenPHP CLI options not covered here (worker mode, multi-domain serving, custom PHP flags, etc.), refer to the
+[official FrankenPHP documentation](https://frankenphp.dev/docs/).
+
+## Run as a systemd service (Ubuntu)
+
+For a production deployment, run FrankenPHP under `systemd` so it starts on boot and restarts on failure. Create
+`/etc/systemd/system/koel.service`:
+
+```ini
+[Unit]
+Description=Koel (FrankenPHP)
+After=network.target
+
+[Service]
+Type=simple
+User=www-data
+WorkingDirectory=/var/www/koel
+ExecStart=/usr/local/bin/frankenphp run
+Restart=on-failure
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Adjust `WorkingDirectory` and `User` to match where Koel lives on your host. Then enable and start it:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now koel
+sudo journalctl -u koel -f
+```
+
+## Behind a reverse proxy
+
+If you're already running nginx (or another reverse proxy) and want to use FrankenPHP only as the PHP runtime, bind it
+to a loopback port and disable Caddy's automatic HTTPS. Replace the site block in `Caddyfile` with:
+
+```caddyfile
+:8001 {
+	bind 127.0.0.1
+	root public/
+	encode zstd gzip
+	php_server {
+		try_files {path} index.php
+	}
+}
+```
+
+…and add `auto_https off` to the global block. Then point your existing reverse proxy at `127.0.0.1:8001` and let it
+terminate TLS as before.


### PR DESCRIPTION
## Summary

Extracts the FrankenPHP setup guide out of `docs/guide/getting-started.md` into its own page at `docs/guide/running-with-frankenphp.md`, and adds a new `## Running artisan commands` subsection to that page (driven by feedback from the franken.phanan.net dogfood).

`getting-started.md` keeps a short stub under `## Running with FrankenPHP` with a two-sentence description and a link to the new page, so the entry point remains visible to anyone reading the install guide top-to-bottom.

## Changes

### `docs/guide/running-with-frankenphp.md` (new)

Contains the previously-inline FrankenPHP setup walkthrough (Install FrankenPHP, Configure the Caddyfile, Run it, Run as a systemd service, Behind a reverse proxy) — H3 headings bumped to H2 since they're now the top level of their own page.

Adds a new `## Running artisan commands` section:

- The `frankenphp php-cli artisan <command>` pattern with examples (`migrate`, `koel:sync`) and an alias snippet.
- A note that a system PHP works for artisan too, sharing the same `.env` and database.
- A `::: warning DB_HOST=localhost gotcha` callout documenting the MySQL-socket-mismatch issue that surfaced during the dogfood (HTTP serving works fine, but `koel:init` fails at the DB-connection check because the Caddyfile's `env DB_HOST 127.0.0.1` override doesn't apply to CLI invocations). With both fixes: per-command env override, or change `.env` to use `127.0.0.1`.
- A pointer to the [official FrankenPHP documentation](https://frankenphp.dev/docs/) for CLI options Koel's guide doesn't cover (worker mode, multi-domain serving, custom PHP flags, etc.).

### `docs/guide/getting-started.md`

- `## Running with FrankenPHP` shrinks to a two-sentence stub linking to the new page.
- The "Use a proper webserver" warning callout's link to `[FrankenPHP](#running-with-frankenphp)` is rewritten to point at `/guide/running-with-frankenphp`.

### `docs/.vitepress/config.mts`

- Adds a "Running with FrankenPHP" entry to the Introduction sidebar group, immediately after "Getting Started".

## Test plan

- [x] `bash docs/.vitepress/check-frontmatter.sh` — all doc pages have a description.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a full guide for running Koel with FrankenPHP covering installation, Caddyfile setup, starting FrankenPHP, running artisan via the FrankenPHP CLI, systemd service, and reverse-proxy configuration.
  * Updated Getting Started to link to the new FrankenPHP guide and replaced the long description with a short overview and link.
  * Documented DB_HOST/local socket troubleshooting and linked to official FrankenPHP CLI docs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2477?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->