### PR TITLE
docs: recommend pre-compiled archive when pairing with FrankenPHP

### DIFF
--- a/docs/guide/running-with-frankenphp.md
+++ b/docs/guide/running-with-frankenphp.md
@@ -8,7 +8,7 @@ description: Install FrankenPHP, configure Koel's Caddyfile, run artisan command
 runtime into a single binary — replacing the typical nginx + PHP-FPM pair with one process and giving you automatic
 HTTPS out of the box. Koel ships a `Caddyfile.example` at the project root that wires it up correctly.
 
-FrankenPHP is only the runtime — Koel itself still needs to be installed first, with `vendor/` populated and the
+Note that FrankenPHP is only the runtime — Koel itself still needs to be installed first, with `vendor/` populated and the
 frontend built into `public/build/`. The
 [pre-compiled archive](/guide/getting-started#using-a-pre-compiled-archive) is the recommended path when pairing with
 FrankenPHP: it ships both folders pre-built, so the FrankenPHP binary becomes your only runtime dependency — no system

--- a/docs/guide/running-with-frankenphp.md
+++ b/docs/guide/running-with-frankenphp.md
@@ -13,7 +13,7 @@ frontend built into `public/build/`. As such, a
 [pre-compiled archive](/guide/getting-started#using-a-pre-compiled-archive) is the recommended path when pairing with
 FrankenPHP: it ships both folders pre-built, so the FrankenPHP binary becomes your only runtime dependency — no system
 PHP, Composer, Node, or pnpm needed on the host.
-[Building from source](/guide/getting-started#building-from-source) still works if you already have that toolchain
+Of course, [building from source](/guide/getting-started#building-from-source) still works if you already have that toolchain
 installed.
 
 ## Install FrankenPHP

--- a/docs/guide/running-with-frankenphp.md
+++ b/docs/guide/running-with-frankenphp.md
@@ -9,7 +9,7 @@ runtime into a single binary — replacing the typical nginx + PHP-FPM pair with
 HTTPS out of the box. Koel ships a `Caddyfile.example` at the project root that wires it up correctly.
 
 Note that FrankenPHP is only the runtime — Koel itself still needs to be installed first, with `vendor/` populated and the
-frontend built into `public/build/`. The
+frontend built into `public/build/`. As such, a
 [pre-compiled archive](/guide/getting-started#using-a-pre-compiled-archive) is the recommended path when pairing with
 FrankenPHP: it ships both folders pre-built, so the FrankenPHP binary becomes your only runtime dependency — no system
 PHP, Composer, Node, or pnpm needed on the host.

--- a/docs/guide/running-with-frankenphp.md
+++ b/docs/guide/running-with-frankenphp.md
@@ -8,12 +8,13 @@ description: Install FrankenPHP, configure Koel's Caddyfile, run artisan command
 runtime into a single binary — replacing the typical nginx + PHP-FPM pair with one process and giving you automatic
 HTTPS out of the box. Koel ships a `Caddyfile.example` at the project root that wires it up correctly.
 
-::: info Note
-FrankenPHP is only the runtime — you still need a fully prepared Koel install (i.e. `vendor/` from `composer install`
-and the compiled frontend in `public/build/`) before it has anything to serve. Follow either of the installation
-methods on the [Getting Started](/guide/getting-started#installation) page (pre-compiled archive or building from
-source) first.
-:::
+FrankenPHP is only the runtime — Koel itself still needs to be installed first, with `vendor/` populated and the
+frontend built into `public/build/`. The
+[pre-compiled archive](/guide/getting-started#using-a-pre-compiled-archive) is the recommended path when pairing with
+FrankenPHP: it ships both folders pre-built, so the FrankenPHP binary becomes your only runtime dependency — no system
+PHP, Composer, Node, or pnpm needed on the host.
+[Building from source](/guide/getting-started#building-from-source) still works if you already have that toolchain
+installed.
 
 ## Install FrankenPHP
 


### PR DESCRIPTION
## Summary

Replaces the prerequisite `::: info Note` callout at the top of the FrankenPHP guide with a regular paragraph that explicitly recommends the pre-compiled archive install path for FrankenPHP users.

The reasoning: a big part of FrankenPHP's appeal is "I don't have to install a PHP toolchain on the host." If the doc then sends FrankenPHP users to "build from source", they need exactly the toolchain they were trying to avoid (system PHP, Composer, Node, pnpm). The pre-compiled archive ships `vendor/` and `public/build/` pre-built, so FrankenPHP's single binary becomes the only runtime dependency on the host — which is the actual end state most people are after.

Building from source is still mentioned as a fallback for users who already have the toolchain.

## Test plan

- [x] `bash docs/.vitepress/check-frontmatter.sh` — all doc pages have a description.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that FrankenPHP provides only the runtime and Koel must be fully installed first.
  * Emphasized the need for all dependencies and the compiled frontend to be present before using FrankenPHP.
  * Improved wording and guidance for both pre-compiled archive usage and building from source.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2478?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->