### PR TITLE
feat: store user-generated images under storage/app/public/images

### DIFF
--- a/app/Console/Commands/InitCommand.php
+++ b/app/Console/Commands/InitCommand.php
@@ -57,6 +57,7 @@ class InitCommand extends Command
             $this->maybeSetUpDatabase();
             $this->migrateDatabase();
             $this->maybeSeedDatabase();
+            $this->linkStorage();
             $this->maybeSetMediaPath();
             $this->maybeCompileFrontEndAssets();
             $this->maybeCopyManifests();
@@ -261,6 +262,20 @@ class InitCommand extends Command
         $this->components->task('Migrating database', static function (): void {
             Artisan::call('migrate', ['--force' => true, '--quiet' => true]);
         });
+    }
+
+    private function linkStorage(): void
+    {
+        $result = self::SUCCESS;
+
+        $this->components->task('Linking storage', static function () use (&$result): void {
+            $result = Artisan::call('storage:link', ['--quiet' => true]);
+        });
+
+        if ($result !== self::SUCCESS) {
+            $this->components->warn('Failed to link storage. Album and artist images may not load until you run '
+            . '`php artisan storage:link` manually.');
+        }
     }
 
     private function maybeSetMediaPath(): void

--- a/app/Console/Commands/InitCommand.php
+++ b/app/Console/Commands/InitCommand.php
@@ -58,6 +58,7 @@ class InitCommand extends Command
             $this->migrateDatabase();
             $this->maybeSeedDatabase();
             $this->linkStorage();
+            $this->migrateLegacyImages();
             $this->maybeSetMediaPath();
             $this->maybeCompileFrontEndAssets();
             $this->maybeCopyManifests();
@@ -276,6 +277,43 @@ class InitCommand extends Command
             $this->components->warn('Failed to link storage. Album and artist images may not load until you run '
             . '`php artisan storage:link` manually.');
         }
+    }
+
+    private function migrateLegacyImages(): void
+    {
+        $legacyDir = public_path('img/storage');
+
+        if (!File::isDirectory($legacyDir)) {
+            return;
+        }
+
+        $files = File::files($legacyDir);
+
+        if (!count($files)) {
+            File::deleteDirectory($legacyDir);
+
+            return;
+        }
+
+        $this->components->task(
+            sprintf('Migrating %d legacy image(s) to storage/app/public/images/', count($files)),
+            static function () use ($files, $legacyDir): void {
+                $destDir = storage_path('app/public/images');
+                File::ensureDirectoryExists($destDir);
+
+                foreach ($files as $file) {
+                    $dest = $destDir . DIRECTORY_SEPARATOR . $file->getFilename();
+
+                    if (File::exists($dest)) {
+                        File::delete($file->getPathname());
+                    } else {
+                        File::move($file->getPathname(), $dest);
+                    }
+                }
+
+                File::deleteDirectory($legacyDir);
+            },
+        );
     }
 
     private function maybeSetMediaPath(): void

--- a/app/Console/Commands/InitCommand.php
+++ b/app/Console/Commands/InitCommand.php
@@ -295,25 +295,33 @@ class InitCommand extends Command
             return;
         }
 
+        $allMigrated = true;
+
         $this->components->task(
             sprintf('Migrating %d legacy image(s) to storage/app/public/images/', count($files)),
-            static function () use ($files, $legacyDir): void {
+            static function () use ($files, &$allMigrated): void {
                 $destDir = storage_path('app/public/images');
                 File::ensureDirectoryExists($destDir);
 
                 foreach ($files as $file) {
                     $dest = $destDir . DIRECTORY_SEPARATOR . $file->getFilename();
 
-                    if (File::exists($dest)) {
-                        File::delete($file->getPathname());
-                    } else {
-                        File::move($file->getPathname(), $dest);
-                    }
-                }
+                    $ok = File::exists($dest)
+                        ? File::delete($file->getPathname())
+                        : File::move($file->getPathname(), $dest);
 
-                File::deleteDirectory($legacyDir);
+                    $allMigrated = $allMigrated && $ok;
+                }
             },
         );
+
+        if ($allMigrated) {
+            File::deleteDirectory($legacyDir);
+        } else {
+            $this->components->warn(
+                'Some legacy images could not be migrated. Keeping public/img/storage for manual recovery.',
+            );
+        }
     }
 
     private function maybeSetMediaPath(): void

--- a/app/Helpers.php
+++ b/app/Helpers.php
@@ -29,12 +29,12 @@ function base_url(): string
 
 function image_storage_path(?string $fileName, ?string $default = null): ?string
 {
-    return $fileName ? public_path(config('koel.image_storage_dir') . $fileName) : $default;
+    return $fileName ? config('koel.image_storage_dir') . DIRECTORY_SEPARATOR . $fileName : $default;
 }
 
 function image_storage_url(?string $fileName, ?string $default = null): ?string
 {
-    return $fileName ? static_url(config('koel.image_storage_dir') . $fileName) : $default;
+    return $fileName ? static_url('storage/images/' . $fileName) : $default;
 }
 
 function artifact_path(?string $subPath = null, $ensureDirectoryExists = true): string

--- a/app/Helpers.php
+++ b/app/Helpers.php
@@ -29,12 +29,12 @@ function base_url(): string
 
 function image_storage_path(?string $fileName, ?string $default = null): ?string
 {
-    return $fileName ? config('koel.image_storage_dir') . DIRECTORY_SEPARATOR . $fileName : $default;
+    return $fileName ? public_path(config('koel.image_storage_dir') . DIRECTORY_SEPARATOR . $fileName) : $default;
 }
 
 function image_storage_url(?string $fileName, ?string $default = null): ?string
 {
-    return $fileName ? static_url('storage/images/' . $fileName) : $default;
+    return $fileName ? static_url(config('koel.image_storage_dir') . '/' . $fileName) : $default;
 }
 
 function artifact_path(?string $subPath = null, $ensureDirectoryExists = true): string

--- a/config/koel.php
+++ b/config/koel.php
@@ -9,9 +9,7 @@ return [
     // or downloaded podcast episodes. By default, it is set to the system's temporary directory.
     'artifacts_path' => env('ARTIFACTS_PATH') ?: sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'koel',
 
-    // The *relative* path to the directory to store artist images, playlist covers, user avatars, etc.
-    // This is relative to the public path.
-    'image_storage_dir' => 'img/storage/',
+    'image_storage_dir' => storage_path('app/public/images'),
 
     /*
      |--------------------------------------------------------------------------

--- a/config/koel.php
+++ b/config/koel.php
@@ -9,7 +9,7 @@ return [
     // or downloaded podcast episodes. By default, it is set to the system's temporary directory.
     'artifacts_path' => env('ARTIFACTS_PATH') ?: sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'koel',
 
-    'image_storage_dir' => storage_path('app/public/images'),
+    'image_storage_dir' => 'storage/images',
 
     /*
      |--------------------------------------------------------------------------

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -21,6 +21,21 @@ for details.
 | `STORAGE_DRIVER` | The storage driver for your media files. Valid values: `local`, `sftp`, `s3` (Koel Plus), `dropbox` (Koel Plus). See [Cloud Storage Support](plus/cloud-storage-support). | `local` |
 | `MEDIA_PATH` | The absolute path to your media directory. Required when using `STORAGE_DRIVER=local`. Can also be changed via the web interface. | _(empty)_ |
 | `ARTIFACTS_PATH` | The absolute path to store Koel artifacts (transcoded files, podcast episodes, temporary downloads, etc.). If empty, uses the system's temporary directory. | _(empty)_ |
+| `LARAVEL_STORAGE_PATH` | Absolute path Koel uses for writable runtime data — album/artist images (under `app/public/images`), logs, search indexes, framework cache, sessions. Set this to keep mutable state outside the application directory (read-only deploys, multi-instance setups, etc.). After setting it, run `php artisan storage:link` (or `composer koel:init`) so `public/storage` symlinks to `LARAVEL_STORAGE_PATH/app/public`. | `<app>/storage` |
+
+:::warning Upgrading an older Koel install
+The image storage location moved from `public/img/storage/` to `storage/app/public/images/`
+(or `LARAVEL_STORAGE_PATH/app/public/images/` when set). If you have a `public/img/storage/`
+directory with files in it, migrate them once or album/artist art will appear broken:
+
+```bash
+mkdir -p "${LARAVEL_STORAGE_PATH:-$(pwd)/storage}/app/public/images"
+rsync -a public/img/storage/ "${LARAVEL_STORAGE_PATH:-$(pwd)/storage}/app/public/images/"
+php artisan storage:link
+```
+
+After confirming images render, the old `public/img/storage/` directory can be removed.
+:::
 
 ### S3 / S3-Compatible
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -23,10 +23,14 @@ for details.
 | `ARTIFACTS_PATH` | The absolute path to store Koel artifacts (transcoded files, podcast episodes, temporary downloads, etc.). If empty, uses the system's temporary directory. | _(empty)_ |
 | `LARAVEL_STORAGE_PATH` | Absolute path Koel uses for writable runtime data — album/artist images (under `app/public/images`), logs, search indexes, framework cache, sessions. Set this to keep mutable state outside the application directory (read-only deploys, multi-instance setups, etc.). After setting it, run `php artisan storage:link` (or `composer koel:init`) so `public/storage` symlinks to `LARAVEL_STORAGE_PATH/app/public`. | `<app>/storage` |
 
-:::warning Upgrading an older Koel install
+:::info Upgrading an older Koel install
 The image storage location moved from `public/img/storage/` to `storage/app/public/images/`
-(or `LARAVEL_STORAGE_PATH/app/public/images/` when set). If you have a `public/img/storage/`
-directory with files in it, migrate them once or album/artist art will appear broken:
+(or `LARAVEL_STORAGE_PATH/app/public/images/` when set). `php artisan koel:init` handles the
+migration automatically on the first run after upgrading — no manual action needed.
+
+If `koel:init` reports `Some legacy images could not be migrated. Keeping public/img/storage
+for manual recovery.`, rerun `koel:init` after fixing the underlying cause (most often a
+permissions issue on `storage/`). As a last resort, perform the move manually:
 
 ```bash
 mkdir -p "${LARAVEL_STORAGE_PATH:-$(pwd)/storage}/app/public/images"

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -66,11 +66,11 @@ abstract class TestCase extends BaseTestCase
     private static function createSandbox(): void
     {
         config([
-            'koel.image_storage_dir' => 'sandbox/img/storage/',
+            'koel.image_storage_dir' => public_path('sandbox/img/storage'),
             'koel.artifacts_path' => public_path('sandbox/artifacts/'),
         ]);
 
-        File::ensureDirectoryExists(public_path(config('koel.image_storage_dir')));
+        File::ensureDirectoryExists(config('koel.image_storage_dir'));
         File::ensureDirectoryExists(public_path('sandbox/media/'));
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -66,11 +66,11 @@ abstract class TestCase extends BaseTestCase
     private static function createSandbox(): void
     {
         config([
-            'koel.image_storage_dir' => public_path('sandbox/img/storage'),
+            'koel.image_storage_dir' => 'sandbox/img/storage',
             'koel.artifacts_path' => public_path('sandbox/artifacts/'),
         ]);
 
-        File::ensureDirectoryExists(config('koel.image_storage_dir'));
+        File::ensureDirectoryExists(public_path(config('koel.image_storage_dir')));
         File::ensureDirectoryExists(public_path('sandbox/media/'));
     }
 


### PR DESCRIPTION
## Summary

Moves user-generated images (album / artist / podcast covers, user avatars, theme assets) from `public/img/storage/` to `storage_path('app/public/images/')`, served at `/storage/images/{filename}` via Laravel's standard `public/storage` symlink.

Three benefits:

1. **Idiomatic Laravel location** — user-generated mutable content belongs under `storage/app/public/`, not in the `public/` asset dir. Cleanly separates mutable state from the bundle assets the webserver primarily serves.
2. **Native relocation support** — Laravel reads the `LARAVEL_STORAGE_PATH` env var to relocate the entire storage tree (logs, cache, sessions, user-generated content) onto a different disk or path. Useful for read-only deploys, multi-instance setups, and similar shapes.
3. **Symmetric helpers** — `image_storage_path()` and `image_storage_url()` both derive from one config value (`koel.image_storage_dir`, now a path relative to `public/`), so changing the storage subdirectory updates both the filesystem path and the public URL in lockstep.

## Changes

### Storage location and helpers

- `config/koel.php` — `image_storage_dir` is now `'storage/images'` (relative to `public/`), down from a hard-coded absolute filesystem path. Both the filesystem location and the public URL derive from this one value.
- `app/Helpers.php`:
  - `image_storage_path()` wraps with `public_path(...)` → resolves to the real file via the `storage:link` symlink.
  - `image_storage_url()` wraps with `static_url(...)` → produces the `/storage/images/{file}` URL served via the same symlink.

### koel:init

- New `linkStorage()` task runs `php artisan storage:link`, mirroring the `tryInstallingScheduler()` pattern (warning on failure, continues otherwise).
- New `migrateLegacyImages()` task automatically moves any files from `public/img/storage/` to `storage_path('app/public/images/')` on install or upgrade. Idempotent — no-ops on fresh installs and on repeat runs. Handles the partial-migration case (files already at the destination) by dropping the source duplicate rather than clobbering.

### Misc

- `tests/TestCase.php` — sandbox uses the new relative-path semantics so test isolation continues to work.
- `docs/environment-variables.md` — adds a `LARAVEL_STORAGE_PATH` row documenting the env var.

## Upgrade impact

Existing installs with files in `public/img/storage/` get migrated to `storage/app/public/images/` automatically the next time `php artisan koel:init` runs — no manual `rsync` needed. If you're already running `koel:init` as part of your deploy script (the documented upgrade path), album/artist/avatar images keep working after pulling this change without any extra steps.

## Test plan

- [x] `composer cs` clean
- [x] `composer lint` clean
- [x] `composer analyze` clean (1089 files, no errors)
- [x] `php artisan test` on the image surface — 16 tests pass:
  - `tests/Feature/AlbumThumbnailTest.php`
  - `tests/Unit/Services/Image/ImageStorageTest.php`
  - `tests/Unit/Services/Image/ModelImageObserverTest.php`
  - `tests/Unit/Jobs/GenerateAlbumThumbnailJobTest.php`
  - `tests/Feature/HomeTest.php`
  - `tests/Feature/InitialDataTest.php`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic migration of legacy images to the new storage location.
  * Setup now attempts to create the public storage link, warning if it cannot.
  * Support for a new environment variable to customize storage paths.

* **Bug Fixes**
  * Fixed image path/URL construction to prevent malformed paths.

* **Documentation**
  * Added storage configuration docs and upgrade/migration guidance for image relocation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2479?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->