### PR TITLE
fix: align sqlite connection with Laravel 12 defaults

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -35,8 +35,16 @@ return [
     'connections' => [
         'sqlite' => [
             'driver' => 'sqlite',
-            'database' => env('DB_DATABASE', ':memory:'),
+            'url' => env('DB_URL'),
+            'database' => env('DB_DATABASE', database_path('database.sqlite')),
             'prefix' => '',
+            'prefix_indexes' => null,
+            'foreign_key_constraints' => env('DB_FOREIGN_KEYS', true),
+            'busy_timeout' => null,
+            'journal_mode' => null,
+            'synchronous' => null,
+            'transaction_mode' => 'DEFERRED',
+            'pragmas' => [],
         ],
 
         'sqlite-e2e' => [

--- a/config/database.php
+++ b/config/database.php
@@ -4,38 +4,38 @@ use Illuminate\Support\Str;
 
 return [
     /*
-    |--------------------------------------------------------------------------
-    | Default Database Connection Name
-    |--------------------------------------------------------------------------
-    |
-    | Here you may specify which of the database connections below you wish
-    | to use as your default connection for all database work. Of course
-    | you may use many connections at once using the Database library.
-    |
-    */
+     |--------------------------------------------------------------------------
+     | Default Database Connection Name
+     |--------------------------------------------------------------------------
+     |
+     | Here you may specify which of the database connections below you wish
+     | to use as your default connection for all database work. Of course
+     | you may use many connections at once using the Database library.
+     |
+     */
 
     'default' => env('DB_CONNECTION', 'mysql'),
 
     /*
-    |--------------------------------------------------------------------------
-    | Database Connections
-    |--------------------------------------------------------------------------
-    |
-    | Here are each of the database connections setup for your application.
-    | Of course, examples of configuring each database platform that is
-    | supported by Laravel is shown below to make development simple.
-    |
-    |
-    | All database work in Laravel is done through the PHP PDO facilities
-    | so make sure you have the driver for your particular database of
-    | choice installed on your machine before you begin development.
-    |
-    */
+     |--------------------------------------------------------------------------
+     | Database Connections
+     |--------------------------------------------------------------------------
+     |
+     | Here are each of the database connections setup for your application.
+     | Of course, examples of configuring each database platform that is
+     | supported by Laravel is shown below to make development simple.
+     |
+     |
+     | All database work in Laravel is done through the PHP PDO facilities
+     | so make sure you have the driver for your particular database of
+     | choice installed on your machine before you begin development.
+     |
+     */
 
     'connections' => [
         'sqlite' => [
             'driver' => 'sqlite',
-            'database' => ':memory:',
+            'database' => env('DB_DATABASE', ':memory:'),
             'prefix' => '',
         ],
 
@@ -66,9 +66,10 @@ return [
             'prefix_indexes' => true,
             'strict' => false, // setting this to true will cause IncreaseStringColumnsLength migration to fail
             'engine' => null,
-            'options' => extension_loaded('pdo_mysql') ? array_filter([
-                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
-            ]) : [],
+            'options' => extension_loaded('pdo_mysql')
+                ? array_filter([
+                    PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                ]) : [],
         ],
 
         'mariadb' => [
@@ -86,9 +87,10 @@ return [
             'prefix_indexes' => true,
             'strict' => false,
             'engine' => null,
-            'options' => extension_loaded('pdo_mysql') ? array_filter([
-                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
-            ]) : [],
+            'options' => extension_loaded('pdo_mysql')
+                ? array_filter([
+                    PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                ]) : [],
         ],
 
         'pgsql' => [
@@ -148,31 +150,30 @@ return [
     ],
 
     /*
-    |--------------------------------------------------------------------------
-    | Migration Repository Table
-    |--------------------------------------------------------------------------
-    |
-    | This table keeps track of all the migrations that have already run for
-    | your application. Using this information, we can determine which of
-    | the migrations on disk haven't actually been run in the database.
-    |
-    */
+     |--------------------------------------------------------------------------
+     | Migration Repository Table
+     |--------------------------------------------------------------------------
+     |
+     | This table keeps track of all the migrations that have already run for
+     | your application. Using this information, we can determine which of
+     | the migrations on disk haven't actually been run in the database.
+     |
+     */
 
     'migrations' => 'migrations',
 
     /*
-    |--------------------------------------------------------------------------
-    | Redis Databases
-    |--------------------------------------------------------------------------
-    |
-    | Redis is an open source, fast, and advanced key-value store that also
-    | provides a richer set of commands than a typical key-value systems
-    | such as APC or Memcached. Laravel makes it easy to dig right in.
-    |
-    */
+     |--------------------------------------------------------------------------
+     | Redis Databases
+     |--------------------------------------------------------------------------
+     |
+     | Redis is an open source, fast, and advanced key-value store that also
+     | provides a richer set of commands than a typical key-value systems
+     | such as APC or Memcached. Laravel makes it easy to dig right in.
+     |
+     */
 
     'redis' => [
-
         'client' => env('REDIS_CLIENT', 'phpredis'),
 
         'options' => [
@@ -197,6 +198,5 @@ return [
             'port' => env('REDIS_PORT', '6379'),
             'database' => env('REDIS_CACHE_DB', '1'),
         ],
-
     ],
 ];

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -24,6 +24,7 @@
         <env name="QUEUE_DRIVER" value="sync"/>
         <env name="BROADCAST_CONNECTION" value="log"/>
         <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
         <env name="LASTFM_API_KEY" value="foo"/>
         <env name="LASTFM_API_SECRET" value="bar"/>
         <!-- Spotify integration during tests must be opt-in -->


### PR DESCRIPTION
## Summary

Aligns the `sqlite` connection in `config/database.php` with Laravel 12's [stock shape](https://github.com/laravel/framework/blob/12.x/config/database.php). Was missing every Laravel-12 sqlite knob plus the `database` env-var wiring.

Old:

```php
'sqlite' => [
    'driver' => 'sqlite',
    'database' => ':memory:',
    'prefix' => '',
],
```

New (verbatim from Laravel 12):

```php
'sqlite' => [
    'driver' => 'sqlite',
    'url' => env('DB_URL'),
    'database' => env('DB_DATABASE', database_path('database.sqlite')),
    'prefix' => '',
    'prefix_indexes' => null,
    'foreign_key_constraints' => env('DB_FOREIGN_KEYS', true),
    'busy_timeout' => null,
    'journal_mode' => null,
    'synchronous' => null,
    'transaction_mode' => 'DEFERRED',
    'pragmas' => [],
],
```

## Why this matters

Users who set `DB_CONNECTION=sqlite` + `DB_DATABASE=/path/to/file.sqlite` in `.env` were getting:

- Artisan-side migrations running against the CLI process's in-memory database and vanishing on exit (the on-disk SQLite file stays at 0 bytes — no error, just no tables).
- HTTP requests booting their own fresh in-memory database, finding no table, and 500ing with:
  ```
  SQLSTATE[HY000]: General error: 1 no such table: licenses
  (Connection: sqlite, Database: :memory:, …)
  ```

The hardcoded `:memory:` was ignoring `DB_DATABASE` entirely. Beyond just fixing that one line, pulling in the rest of Laravel 12's sqlite options (`busy_timeout`, `journal_mode`, `synchronous`, `transaction_mode`, `pragmas`, `foreign_key_constraints`) gives users the same tuning knobs that any stock Laravel 12 app would have. The `sqlite-e2e` connection remains untouched — it's a different beast (used by the `koel:init` wizard's "SQLite" option, with its own path semantics).

## Knock-on: phpunit config

Laravel 12's default for the `database` key is `database_path('database.sqlite')` (a file path) rather than `:memory:`. Koel's test suite uses in-memory SQLite for speed/isolation, and `phpunit.xml.dist` was relying on the *connection's* default being `:memory:`. With the new shape that default is a file path, so the test suite would either pollute the filesystem with a `database/database.sqlite` or fail.

Mirroring Laravel's own `phpunit.xml.dist` pattern, this PR adds `<env name="DB_DATABASE" value=":memory:"/>` to make the test suite's intent explicit. No tests change behavior.

## Why this surfaced now

Discovered while smoke-testing the upcoming [koel/franken](https://github.com/koel/franken) standalone-binary distribution. The bundle's launcher writes `DB_CONNECTION=sqlite` + `DB_DATABASE=$HOME/.koel/db.sqlite` to its `.env` and expects Koel to honor it. With the old config it can't, so every request 500s.

The `koel:init` wizard normally steers users toward the `sqlite-e2e` connection (offered as "SQLite") for file-based databases, which is why this bug hasn't bitten typical installs. The plain `sqlite` connection should still respect `DB_DATABASE` for anyone who picks it directly — which is now the case.

## About the noisy diff on `config/database.php`

The diff also includes whitespace adjustments to two block comments at the top of `config/database.php`. `config/` isn't in `mago.toml`'s source paths, so `composer cs` doesn't lint it — but the lint-staged pre-commit hook does, and it found pre-existing formatting drift. Applying `mago format` to satisfy the hook was the smallest way past it; the only *semantic* changes are the `sqlite` connection block and the `phpunit.xml.dist` `DB_DATABASE` env entry.

## Test plan

- [x] `composer cs` clean
- [x] `composer lint` clean
- [x] `composer analyze` clean (1089 files, no errors)
- [x] `php artisan test tests/Feature/HomeTest.php tests/Feature/InitialDataTest.php tests/Feature/AlbumThumbnailTest.php tests/Unit/Services/Image/ImageStorageTest.php` — 6 tests pass with the new `phpunit.xml.dist` `DB_DATABASE=:memory:` override.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted database configuration comments and whitespace for consistency and readability.
* **Chores**
  * Expanded SQLite configuration with additional options and sensible defaults.
* **Tests**
  * Test environment now uses an in-memory SQLite database for faster, isolated test runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2480?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->