### PR TITLE
ci: pin DB_DATABASE to :memory: in release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,11 +33,12 @@ jobs:
         run: |
           sudo apt install pngquant zip unzip
           sed -i 's/DB_CONNECTION=mysql/DB_CONNECTION=sqlite/' .env
+          sed -i 's/DB_DATABASE=koel/DB_DATABASE=:memory:/' .env
           php artisan koel:init --no-interaction
       - name: Create archives
         run: |
           sed -i 's/DB_CONNECTION=sqlite/DB_CONNECTION=sqlite-persistent/' .env
-          sed -i 's/DB_DATABASE=koel/DB_DATABASE=koel.db/' .env
+          sed -i 's|DB_DATABASE=:memory:|DB_DATABASE=koel.db|' .env
           rm -rf .git ./node_modules ./storage/search-indexes/*.index ./koel.db ./.env
           cd ../
           zip -r /tmp/koel-${{ steps.get_version.outputs.VERSION }}.zip koel/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,12 +33,12 @@ jobs:
         run: |
           sudo apt install pngquant zip unzip
           sed -i 's/DB_CONNECTION=mysql/DB_CONNECTION=sqlite/' .env
-          sed -i 's/DB_DATABASE=koel/DB_DATABASE=:memory:/' .env
+          sed -i 's|^DB_DATABASE=.*$|DB_DATABASE=:memory:|' .env
           php artisan koel:init --no-interaction
       - name: Create archives
         run: |
           sed -i 's/DB_CONNECTION=sqlite/DB_CONNECTION=sqlite-persistent/' .env
-          sed -i 's|DB_DATABASE=:memory:|DB_DATABASE=koel.db|' .env
+          sed -i 's|^DB_DATABASE=.*$|DB_DATABASE=koel.db|' .env
           rm -rf .git ./node_modules ./storage/search-indexes/*.index ./koel.db ./.env
           cd ../
           zip -r /tmp/koel-${{ steps.get_version.outputs.VERSION }}.zip koel/


### PR DESCRIPTION
## Summary

#2480 made the `sqlite` connection in `config/database.php` honor `DB_DATABASE`. The Upload Release Assets workflow had been relying on the previously-hardcoded `:memory:` behavior — it sets `DB_CONNECTION=sqlite` but leaves `DB_DATABASE=koel` (the mysql-style default from `.env.example`). With the fix in place, the build step now tries to connect to a sqlite file called `koel` and fails:

```
Database file at path [koel] does not exist.
(Connection: sqlite, Database: koel, SQL: PRAGMA foreign_keys = ON)
```

This surfaced when cutting v9.3.1 — the tag pushed, the workflow ran, the build step died. No draft release got created.

## Changes

- Build step adds `sed -i 's/DB_DATABASE=koel/DB_DATABASE=:memory:/' .env` so koel:init runs against in-memory sqlite (the previous behavior, now explicit instead of accidental).
- The "Create archives" step's second sed (`s/DB_DATABASE=koel/DB_DATABASE=koel.db/`) was now a no-op (the env line had become `:memory:` upstream). Updated to `s|DB_DATABASE=:memory:|DB_DATABASE=koel.db|` so the shipped `.env` ends up with the same `DB_DATABASE=koel.db` it did pre-#2480.

Net effect: the release tarball/zip ships unchanged, the build itself now works.

## Test plan

- [ ] After merge, cut a v9.3.2 patch release (`php artisan koel:release patch`). The release workflow should complete and create a draft.
- [ ] The v9.3.1 tag exists upstream with no associated release (workflow failed). Plan to leave it as a dead tag, or delete + retag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release workflow now initializes using an in-memory database to speed and isolate setup.
  * Archive creation step switches to a persistent database for packaging.
  * Improved how the database file/location is set during the release process for more reliable rewrites.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2481?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->