### PR TITLE
docs: document the koel/franken standalone-binary install method

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -55,6 +55,7 @@ export default defineConfig({
         items: [
           { text: 'What Is Koel?', link: '/guide/what-is-koel' },
           { text: 'Getting Started', link: '/guide/getting-started' },
+          { text: 'Standalone Binary', link: '/guide/standalone-binary' },
           { text: 'Running with FrankenPHP', link: '/guide/running-with-frankenphp' },
         ],
       },

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -10,8 +10,9 @@ These commands are available via Laravel’s `artisan` command line interface.
 
 ::: tip Standalone Binary users
 If you installed Koel via the [Standalone Binary](/guide/standalone-binary), replace `php artisan` with
-`./koel php-cli artisan` (run from the bundle directory) in every command below. The bundle ships its own PHP
-runtime; `php-cli` is the launcher's bridge to it. Otherwise the commands below are identical.
+`./artisan` (run from the bundle directory) in every command below. `./artisan` is a thin shortcut for
+`./koel php-cli artisan` that re-execs the launcher so the bundle's PHP runtime stays in scope.
+Otherwise the commands below are identical.
 :::
 
 You can run `php artisan list` from your Koel installation directory and pipe the output to `grep` to filter out those under the `koel` namespace:

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -8,6 +8,12 @@ description: Reference for all Koel artisan CLI commands including scanning, syn
 Koel comes with a set of handy CLI commands to help you manage your installation.
 These commands are available via Laravel’s `artisan` command line interface.
 
+::: tip Standalone Binary users
+If you installed Koel via the [Standalone Binary](/guide/standalone-binary), replace `php artisan` with
+`./koel php-cli artisan` (run from the bundle directory) in every command below. The bundle ships its own PHP
+runtime; `php-cli` is the launcher's bridge to it. Otherwise the commands below are identical.
+:::
+
 You can run `php artisan list` from your Koel installation directory and pipe the output to `grep` to filter out those under the `koel` namespace:
 
 ```bash

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -25,7 +25,22 @@ The requirements for each part are as follows:
 
 ## Installation
 
-There are three methods to install and start using Koel:
+There are four methods to install and start using Koel:
+
+### Using the Standalone Binary
+
+The single-archive distribution from [koel/franken](https://github.com/koel/franken/releases) bundles
+[FrankenPHP](https://frankenphp.dev) (Caddy + the PHP runtime) with the compiled Koel application code.
+No Composer, Node, or system PHP needed on the host. SQLite by default for zero-setup operation.
+
+```bash
+tar -xzf koel-franken-v9.3.2-linux-x86_64.tar.gz
+cd koel-franken-v9.3.2-linux-x86_64
+./koel php-server --listen :8000
+```
+
+See the [Standalone Binary](/guide/standalone-binary) page for the full setup, conventions, MySQL/Postgres
+override, and systemd service unit.
 
 ### Using a Pre-Compiled Archive
 

--- a/docs/guide/running-with-frankenphp.md
+++ b/docs/guide/running-with-frankenphp.md
@@ -8,6 +8,14 @@ description: Install FrankenPHP, configure Koel's Caddyfile, run artisan command
 runtime into a single binary — replacing the typical nginx + PHP-FPM pair with one process and giving you automatic
 HTTPS out of the box. Koel ships a `Caddyfile.example` at the project root that wires it up correctly.
 
+::: tip Looking for a one-download experience?
+If you'd rather not install FrankenPHP separately and pair it with Koel by hand, the
+[Standalone Binary](/guide/getting-started#using-the-standalone-binary) distribution from
+[koel/franken](https://github.com/koel/franken/releases) packages FrankenPHP + Koel + a launcher into a single
+archive. This page is for users who want to install FrankenPHP themselves and use it as the runtime for an existing
+Koel install.
+:::
+
 Note that FrankenPHP is only the runtime — Koel itself still needs to be installed first, with `vendor/` populated and the
 frontend built into `public/build/`. As such, a
 [pre-compiled archive](/guide/getting-started#using-a-pre-compiled-archive) is the recommended path when pairing with

--- a/docs/guide/standalone-binary.md
+++ b/docs/guide/standalone-binary.md
@@ -56,13 +56,17 @@ The bundle itself is conceptually immutable — anything you'd want to back up o
 
 ## Running Artisan commands
 
+The bundle ships an `./artisan` shortcut next to `./koel`:
+
 ```bash
-./koel php-cli artisan koel:sync
-./koel php-cli artisan tinker
+./artisan koel:sync
+./artisan tinker
 ```
 
-See [Running with FrankenPHP](/guide/running-with-frankenphp#running-artisan-commands) for the full set of
-caveats (notably the PHP 8.5 / `DB_HOST=localhost` gotcha when using MySQL).
+It's a thin wrapper that re-execs the launcher (`./koel php-cli artisan …`), so all the bundle's PHP runtime
+and env wiring stays in scope. See
+[Running with FrankenPHP](/guide/running-with-frankenphp#running-artisan-commands) for the full set of
+caveats (notably the `DB_HOST=localhost` MySQL-socket gotcha).
 
 ## Customization and migration
 
@@ -73,7 +77,7 @@ yet exist**. If you want a different database or other custom configuration, you
   corresponding credentials, plus any other settings) *before* the first `./koel` invocation. The launcher
   will see the file already exists, skip the SQLite seeding, and run migrations against your DB.
 - **Override after the fact**: let the bundle auto-init, then edit `$HOME/.koel/.env` to point at your DB
-  and re-run `./koel php-cli artisan migrate --force` against the new connection.
+  and re-run `./artisan migrate --force` against the new connection.
 
 Migrating an existing Koel install into the bundle isn't a turnkey path: beyond `.env`, you'd need to copy
 your media files (or repoint `MEDIA_PATH`), uploaded images (`storage/app/public/images/`), search indexes,
@@ -106,7 +110,7 @@ WantedBy=multi-user.target
 ```
 
 Adjust `WorkingDirectory`, `User`, and the `--domain` (or `--listen`) flag to match your host. The
-`AmbientCapabilities` line lets the unrooted service bind to ports 80/443 for automatic HTTPS. The
+`AmbientCapabilities` line lets the non-root service bind to ports 80/443 for automatic HTTPS. The
 launcher will provision `~koel/.koel/` (the service user's `$HOME/.koel/`) on first start.
 
 Then enable and start it:

--- a/docs/guide/standalone-binary.md
+++ b/docs/guide/standalone-binary.md
@@ -1,0 +1,129 @@
+---
+description: Install Koel from the single-archive standalone bundle (FrankenPHP + Caddy + PHP + Koel app), customize the database, and run as a systemd service.
+---
+
+# Standalone Binary
+
+The [koel/franken](https://github.com/koel/franken/releases) distribution bundles
+[FrankenPHP](https://frankenphp.dev) (Caddy + the PHP runtime) with the compiled Koel application code into a
+single archive — no Composer, Node, or system PHP needed on the host. Uses SQLite by default for zero-setup
+operation. The easiest way to get Koel running.
+
+## Install and run
+
+Download the archive matching your platform from the
+[releases page](https://github.com/koel/franken/releases) — available for `linux-x86_64`, `linux-aarch64`,
+`mac-x86_64`, and `mac-arm64`. Extract it and run:
+
+```bash
+tar -xzf koel-franken-v9.3.2-linux-x86_64.tar.gz
+cd koel-franken-v9.3.2-linux-x86_64
+./koel php-server --listen :8000           # plain HTTP on :8000
+# or, with a real domain (auto-HTTPS via Let's Encrypt):
+./koel php-server --domain koel.example.com
+```
+
+::: warning On macOS
+The bundled FrankenPHP binary isn't code-signed, so Gatekeeper blocks it on first run with a
+"frankenphp can't be verified" dialog. Strip the quarantine flag from the extracted bundle once and
+the binary will run on subsequent invocations:
+
+```bash
+xattr -dr com.apple.quarantine .
+```
+
+Run this from inside the extract directory before `./koel php-server …`.
+:::
+
+On first run, the launcher provisions `$HOME/.koel/` with the conventional layout, generates an `APP_KEY`,
+and runs database migrations against a fresh SQLite database. Then FrankenPHP serves Koel on the chosen
+port or domain.
+
+## What lives where
+
+Everything writable lives under `$HOME/.koel/`:
+
+| Path | What |
+|---|---|
+| `$HOME/.koel/.env` | Environment file (Koel's config) |
+| `$HOME/.koel/db.sqlite` | SQLite database |
+| `$HOME/.koel/storage/` | Laravel storage path (logs, sessions, cache, uploaded images) |
+| `$HOME/.koel/storage/app/artifacts/` | Transcodes, downloaded podcasts, temp downloads |
+| `$HOME/.koel/php.d/koel.ini` | PHP-INI overrides (display_errors off, error_reporting mask, 512M uploads) |
+
+The bundle itself is conceptually immutable — anything you'd want to back up or migrate lives in
+`$HOME/.koel/`.
+
+## Running Artisan commands
+
+```bash
+./koel php-cli artisan koel:sync
+./koel php-cli artisan tinker
+```
+
+See [Running with FrankenPHP](/guide/running-with-frankenphp#running-artisan-commands) for the full set of
+caveats (notably the PHP 8.5 / `DB_HOST=localhost` gotcha when using MySQL).
+
+## Customization and migration
+
+The launcher only auto-writes the SQLite-flavored `.env` on **first run, when `$HOME/.koel/.env` does not
+yet exist**. If you want a different database or other custom configuration, you have two paths:
+
+- **Bring your own `.env`**: create `$HOME/.koel/.env` (with `DB_CONNECTION=mysql` or `pgsql` + the
+  corresponding credentials, plus any other settings) *before* the first `./koel` invocation. The launcher
+  will see the file already exists, skip the SQLite seeding, and run migrations against your DB.
+- **Override after the fact**: let the bundle auto-init, then edit `$HOME/.koel/.env` to point at your DB
+  and re-run `./koel php-cli artisan migrate --force` against the new connection.
+
+Migrating an existing Koel install into the bundle isn't a turnkey path: beyond `.env`, you'd need to copy
+your media files (or repoint `MEDIA_PATH`), uploaded images (`storage/app/public/images/`), search indexes,
+and so on into `$HOME/.koel/storage/`. For an existing production install,
+[Pre-Compiled Archive](/guide/getting-started#using-a-pre-compiled-archive) or
+[Building from Source](/guide/getting-started#building-from-source) is usually less work.
+
+## Running as a systemd service (Ubuntu)
+
+For a production deployment, run the bundle under `systemd` so it starts on boot and restarts on failure.
+Place the extracted bundle somewhere stable (e.g. `/opt/koel`) and create
+`/etc/systemd/system/koel.service`:
+
+```ini
+[Unit]
+Description=Koel (standalone bundle)
+After=network.target
+
+[Service]
+Type=simple
+User=koel
+WorkingDirectory=/opt/koel
+ExecStart=/opt/koel/koel php-server --domain koel.example.com
+Restart=on-failure
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Adjust `WorkingDirectory`, `User`, and the `--domain` (or `--listen`) flag to match your host. The
+`AmbientCapabilities` line lets the unrooted service bind to ports 80/443 for automatic HTTPS. The
+launcher will provision `~koel/.koel/` (the service user's `$HOME/.koel/`) on first start.
+
+Then enable and start it:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now koel
+sudo journalctl -u koel -f
+```
+
+## Behind a reverse proxy
+
+If you're already running nginx (or another reverse proxy) in front of Koel, the bundle's launcher accepts
+the same FrankenPHP arguments as the standalone setup. Bind to a loopback port:
+
+```bash
+./koel php-server --listen 127.0.0.1:8001
+```
+
+Then point your existing reverse proxy at `127.0.0.1:8001` and let it terminate TLS as before.


### PR DESCRIPTION
## Summary

Documents the new koel/franken standalone-binary distribution as a first-class install method in Koel's getting-started flow.

## Changes

### `docs/guide/standalone-binary.md` (new)

Dedicated page covering the full bundle setup:

- **Install and run** — download, extract, `./koel php-server --listen :8000` (or `--domain` for auto-HTTPS).
- **What lives where** — table of the `$HOME/.koel/` conventional layout (`.env`, `db.sqlite`, `storage/`, `storage/app/artifacts/`, `php.d/koel.ini`).
- **Running Artisan commands** — `./koel php-cli artisan <cmd>`, with a cross-link to `running-with-frankenphp.md#running-artisan-commands` for the FrankenPHP CLI caveats that are shared between bundle and standalone-FrankenPHP setups.
- **Customization and migration** — covers both the "bring your own `.env` before first run" and "edit after the fact" paths for MySQL/Postgres, plus a note that migrating an existing Koel install isn't a turnkey path (media files, search indexes, etc.).
- **Running as a systemd service (Ubuntu)** — bundle-specific unit (`/opt/koel`, `AmbientCapabilities=CAP_NET_BIND_SERVICE` for port 80/443 binding).
- **Behind a reverse proxy** — bind to loopback, point nginx/etc. at it.
- A `::: warning On macOS` callout documents the unsigned-binary Gatekeeper issue — the bundled FrankenPHP isn't code-signed, so first run is blocked with "frankenphp can't be verified". `xattr -dr com.apple.quarantine .` from the extract dir unblocks it. (Future improvement: notarize via the koel/franken release workflow.)

### `docs/guide/getting-started.md`

- The header "There are three methods to install and start using Koel" becomes "four".
- `### Using the Standalone Binary` is now the **first** install method (lowest-friction path — single download, no host deps), with a tight 8-line stub: intro paragraph, 3-line snippet, link to the dedicated page for the full setup.
- The other three install methods keep their existing order (Pre-Compiled Archive, Building from Source, Using Docker).

### `docs/guide/running-with-frankenphp.md`

Adds a `::: tip` callout at the top redirecting "one-download experience" readers to `/guide/standalone-binary`. Clarifies that the rest of this page is for users who want to install FrankenPHP themselves and pair it with an existing Koel install.

### `docs/.vitepress/config.mts`

Adds `Standalone Binary` to the Introduction sidebar group, immediately after `Getting Started` and before `Running with FrankenPHP`. Both FrankenPHP-flavored pages now sit adjacent in the nav.

## Test plan

- [x] `bash docs/.vitepress/check-frontmatter.sh` — all doc pages (including the new one) have a `description` in frontmatter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive Standalone Binary installation guide covering one-download setup, first-run provisioning, filesystem locations, macOS Gatekeeper, CLI wrapper usage, and systemd deployment
  * Updated Getting Started to include the new Standalone Binary installation method
  * Added a tip about the Standalone Binary in the FrankenPHP guide and CLI docs (how to run CLI commands with the bundle)
  * Added a sidebar link to the Standalone Binary guide under Introduction

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2483?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->