### PR TITLE
fix: validate redirect targets when downloading podcast episodes

### DIFF
--- a/app/Values/Podcast/EpisodePlayable.php
+++ b/app/Values/Podcast/EpisodePlayable.php
@@ -41,11 +41,25 @@ final class EpisodePlayable implements Arrayable, Jsonable
         $file = artifact_path("episodes/{$episode->id}.mp3");
 
         if (!File::exists($file)) {
-            if (!Network::isSafeUrl((string) $episode->path)) {
-                throw UnsafeUrlException::forUrl((string) $episode->path);
+            $url = (string) $episode->path;
+
+            if (!Network::isSafeUrl($url)) {
+                throw UnsafeUrlException::forUrl($url);
             }
 
-            Http::sink($file)->get($episode->path)->throw();
+            Http::sink($file)
+                ->withOptions([
+                    'allow_redirects' => [
+                        'max' => 5,
+                        'on_redirect' => static function ($request, $response, $uri): void {
+                            if (!Network::isSafeUrl((string) $uri)) {
+                                throw UnsafeUrlException::forUrl((string) $uri);
+                            }
+                        },
+                    ],
+                ])
+                ->get($url)
+                ->throw();
         }
 
         $playable = new self($file, File::hash($file));

--- a/tests/Integration/Values/EpisodePlayableTest.php
+++ b/tests/Integration/Values/EpisodePlayableTest.php
@@ -61,4 +61,26 @@ class EpisodePlayableTest extends TestCase
             Http::assertNothingSent();
         }
     }
+
+    #[Test]
+    public function refusesToFollowRedirectToUnsafeUrl(): void
+    {
+        Http::fake([
+            'https://public.example.com/episode.mp3' => Http::response('', 302, [
+                'Location' => 'http://169.254.169.254/latest/meta-data/iam/security-credentials/',
+            ]),
+            'http://169.254.169.254/*' => Http::response('credentials-should-not-be-fetched'),
+        ]);
+
+        $episode = Song::factory()->asEpisode()->createOne(['path' => 'https://public.example.com/episode.mp3']);
+
+        self::expectException(UnsafeUrlException::class);
+
+        try {
+            EpisodePlayable::getForEpisode($episode);
+        } finally {
+            // The redirect target must never be requested.
+            Http::assertNotSent(static fn ($request) => str_contains($request->url(), '169.254.169.254'));
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Follow-up to #2485 (GHSA-7j2f-6h2r-6cqc): `EpisodePlayable::createForEpisode()` validated the **initial** episode URL via `Network::isSafeUrl()`, but the actual fetch — `Http::sink($file)->get(...)` — follows redirects by default (Guzzle `RedirectMiddleware`, max 5 hops). A malicious podcast feed could reflect a public bait URL that 302s to `169.254.169.254` (or any internal service); the safe-URL check on the original URL passed, the redirect was followed silently, and the internal response was streamed back via sink.

This change wires Guzzle's `allow_redirects.on_redirect` callback to re-run `Network::isSafeUrl()` against every redirect target. The first unsafe hop throws `UnsafeUrlException` — the request is aborted before the internal endpoint is contacted at all.

## Findings addressed

- **Redirect bypass in `EpisodePlayable::createForEpisode`** — VALID, fixed.
- **`PodcastService::synchronizeEpisodes` logs full `$enclosureUrl` including query/fragment** — SKIPPED. The URL is attacker-supplied to begin with (the attacker authors the malicious feed), so query-string "redaction" has no real signal to protect. Keeping the full URL in the log is more useful for operators diagnosing skipped episodes than a shortened form.

## Test plan

- [x] New test `refusesToFollowRedirectToUnsafeUrl` — `Http::fake` returns 302 from a public URL to `169.254.169.254`; asserts `UnsafeUrlException` is thrown **and** the redirect target is never requested (`Http::assertNotSent`).
- [x] Existing `refusesToFetchUnsafeUrl` still covers direct-unsafe-URL case.
- [x] `composer cs && composer lint && composer analyze` clean.
- [x] Full affected suites: 56 passed, 88 assertions.

## Note on `getStreamableUrl`

`PodcastService::getStreamableUrl` has the same pattern — initial URL validated, redirects followed unvalidated via Guzzle's `track_redirects: true`. Impact is narrower there (response body is not relayed; only an OPTIONS/HEAD probe is issued, and the final URL is handed back to the browser to fetch directly). Out of scope for this PR per the "minimal changes" directive, but worth a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened URL validation for podcast episode downloads
  * Enhanced HTTP redirect handling with safety verification during episode file retrieval
  * Prevented unsafe redirects when downloading episode files

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2486?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->