### PR TITLE
docs: clarify scheduler is auto-installed by koel:init

### DIFF
--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -302,6 +302,10 @@ php artisan koel:tags:collect
 Some commands, such as `koel:scan`, `koel:prune`, and `koel:clean-up-temp-files` can be scheduled to run at regular intervals.
 Instead of setting up individual cron jobs, you can use Koel’s built-in scheduler to automatically handle the commands for you.
 
+::: tip Standalone Binary users
+The launcher installs the cron entry for you on every `./koel php-server` start — nothing to set up by hand. You can skip the rest of this section.
+:::
+
 To set up the scheduler, run the `koel:scheduler:install` command as the web server user (e.g. `www-data` or `nginx`):
 
 ```bash

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -302,7 +302,9 @@ php artisan koel:tags:collect
 Some commands, such as `koel:scan`, `koel:prune`, and `koel:clean-up-temp-files` can be scheduled to run at regular intervals.
 Instead of setting up individual cron jobs, you can use Koel’s built-in scheduler to handle them automatically.
 
-`koel:init` installs the scheduler for you, so most installations have nothing more to do — including the [Standalone Binary](/guide/standalone-binary). If you ran `koel:init` with `--no-scheduler`, install it on its own as the web server user (e.g. `www-data` or `nginx`):
+Every install method sets the scheduler up for you, so most users have nothing more to do. `koel:init` runs `koel:scheduler:install` for the pre-compiled archive and build-from-source paths; the [Standalone Binary](/guide/standalone-binary) launcher writes its own cron entry on every `./koel php-server` start.
+
+If you ran `koel:init` with `--no-scheduler` and want to install it on its own, run as the web server user (e.g. `www-data` or `nginx`):
 
 ```bash
 php artisan koel:scheduler:install

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -300,26 +300,19 @@ php artisan koel:tags:collect
 ## Command Scheduling
 
 Some commands, such as `koel:scan`, `koel:prune`, and `koel:clean-up-temp-files` can be scheduled to run at regular intervals.
-Instead of setting up individual cron jobs, you can use Koel’s built-in scheduler to automatically handle the commands for you.
+Instead of setting up individual cron jobs, you can use Koel’s built-in scheduler to handle them automatically.
 
-::: tip Standalone Binary users
-The launcher installs the cron entry for you on every `./koel php-server` start — nothing to set up by hand. You can skip the rest of this section.
-:::
-
-To set up the scheduler, run the `koel:scheduler:install` command as the web server user (e.g. `www-data` or `nginx`):
+`koel:init` installs the scheduler for you, so most installations have nothing more to do — including the [Standalone Binary](/guide/standalone-binary). If you ran `koel:init` with `--no-scheduler`, install it on its own as the web server user (e.g. `www-data` or `nginx`):
 
 ```bash
 php artisan koel:scheduler:install
 ```
 
-Alternatively, you can manually add the following cron entry into the crontab of the webserver user (for example, if it's `www-data`, run `sudo crontab -u www-data -e`):
+If you'd rather edit the crontab directly (for example, with `sudo crontab -u www-data -e`), add this line:
 
 ```bash
 * * * * * cd /path-to-koel-installation && php artisan schedule:run >> /dev/null 2>&1
 ```
 
-Either way, the scheduler will run every minute once installed, executing any scheduled commands as needed.
-By default, `koel:scan`, `koel:prune`, and `koel:podcasts:sync` are set to run every day at midnight.
-
-Though you can still manually set up cron jobs for individual commands, the scheduler is the recommended approach to do command scheduling in Koel,
-as it will automatically cover any commands that may be added in the future.
+Either way, the scheduler runs every minute and executes any scheduled commands as needed.
+By default, `koel:scan`, `koel:prune`, and `koel:podcasts:sync` run every day at midnight.


### PR DESCRIPTION
## Summary

The **Command Scheduling** section was framed as if running `koel:scheduler:install` is required. It isn't — `koel:init` runs it automatically (`InitCommand::tryInstallingScheduler`, gated only by `--no-scheduler`). That covers pre-compiled archive, build-from-source, and the Standalone Binary alike.

This change:

- Reframes the section so `koel:init` is the default path ("most installations have nothing more to do"), with the standalone install explicitly called out as covered.
- Positions `php artisan koel:scheduler:install` as the path for users who opted out via `--no-scheduler`.
- Drops the trailing "this is the recommended approach" paragraph (judgment language flagged by the new doc-tone rule).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rewrote the Command Scheduling section to clarify that the built-in scheduler is installed by default and will handle periodic tasks for most setups.
  * Added conditional guidance to run the manual scheduler install only when the installer was run with the "no scheduler" option.
  * Reworded manual crontab instructions and confirmed default daily-midnight schedules for scan, prune, and podcast sync.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2487?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->