### PR TITLE
fix: canonicalize media_path and enforce boundary check in media browser

### DIFF
--- a/app/Services/MediaBrowser.php
+++ b/app/Services/MediaBrowser.php
@@ -8,6 +8,7 @@ use App\Facades\License;
 use App\Models\Folder;
 use App\Models\Setting;
 use App\Models\Song;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 
 class MediaBrowser
@@ -41,6 +42,19 @@ class MediaBrowser
         self::$mediaPath ??= Setting::get('media_path');
 
         throw_unless(self::$mediaPath, MediaPathNotSetException::class);
+
+        $prefix = rtrim(self::$mediaPath, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+
+        if (!str_starts_with($song->path, $prefix)) {
+            Log::warning(sprintf(
+                'Skipping folder structure for song %s: path %s is outside media_path %s',
+                $song->id,
+                $song->path,
+                self::$mediaPath,
+            ));
+
+            return;
+        }
 
         $parentId = null;
         $currentPath = '';

--- a/app/Services/SettingService.php
+++ b/app/Services/SettingService.php
@@ -23,10 +23,21 @@ class SettingService
 
     public function updateMediaPath(string $path): string
     {
-        $path = rtrim($path, DIRECTORY_SEPARATOR);
+        $path = self::canonicalizeMediaPath($path);
         Setting::set('media_path', $path);
 
         return $path;
+    }
+
+    private static function canonicalizeMediaPath(string $path): string
+    {
+        $sep = preg_quote(DIRECTORY_SEPARATOR, '#');
+        $path = preg_replace('#' . $sep . '+#', DIRECTORY_SEPARATOR, $path);
+        $path = rtrim($path, DIRECTORY_SEPARATOR);
+
+        $real = realpath($path);
+
+        return $real ?: $path;
     }
 
     public function updateBranding(string $name, ?string $logo, ?string $cover): void

--- a/app/Services/SettingService.php
+++ b/app/Services/SettingService.php
@@ -34,6 +34,11 @@ class SettingService
         $path = str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $path);
         $sep = preg_quote(DIRECTORY_SEPARATOR, '#');
         $path = preg_replace('#' . $sep . '+#', DIRECTORY_SEPARATOR, $path);
+
+        if ($path === DIRECTORY_SEPARATOR) {
+            return DIRECTORY_SEPARATOR;
+        }
+
         $path = rtrim($path, DIRECTORY_SEPARATOR);
 
         $real = realpath($path);

--- a/app/Services/SettingService.php
+++ b/app/Services/SettingService.php
@@ -31,6 +31,7 @@ class SettingService
 
     private static function canonicalizeMediaPath(string $path): string
     {
+        $path = str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $path);
         $sep = preg_quote(DIRECTORY_SEPARATOR, '#');
         $path = preg_replace('#' . $sep . '+#', DIRECTORY_SEPARATOR, $path);
         $path = rtrim($path, DIRECTORY_SEPARATOR);

--- a/tests/Integration/Services/MediaBrowserTest.php
+++ b/tests/Integration/Services/MediaBrowserTest.php
@@ -60,4 +60,24 @@ class MediaBrowserTest extends TestCase
 
         self::assertNull($songInRootPath->folder);
     }
+
+    #[Test]
+    public function skipsSongOutsideMediaPath(): void
+    {
+        Setting::set('media_path', $this->mediaPath);
+
+        // Simulates a song whose path predates a media_path normalization fix, or any path
+        // that doesn't sit under the configured media_path. The folder structure must NOT
+        // be created — otherwise the media browser would expose host directories.
+        $song = Song::factory()->createOne([
+            'path' => '/etc/passwd-themed/album/track.mp3',
+            'storage' => SongStorageType::LOCAL,
+        ]);
+
+        $this->browser->maybeCreateFolderStructureForSong($song);
+
+        self::assertNull($song->folder);
+        self::assertSame(0, Folder::query()->where('path', 'etc')->count());
+        self::assertSame(0, Folder::query()->where('path', 'etc/passwd-themed')->count());
+    }
 }

--- a/tests/Integration/Services/SettingServiceTest.php
+++ b/tests/Integration/Services/SettingServiceTest.php
@@ -44,4 +44,12 @@ class SettingServiceTest extends TestCase
 
         self::assertSame('/foo/bar', Setting::get('media_path'));
     }
+
+    #[Test]
+    public function updateMediaPathCollapsesRepeatedSeparators(): void
+    {
+        $this->service->updateMediaPath('//foo///bar//');
+
+        self::assertSame('/foo/bar', Setting::get('media_path'));
+    }
 }

--- a/tests/Integration/Services/SettingServiceTest.php
+++ b/tests/Integration/Services/SettingServiceTest.php
@@ -52,4 +52,12 @@ class SettingServiceTest extends TestCase
 
         self::assertSame('/foo/bar', Setting::get('media_path'));
     }
+
+    #[Test]
+    public function updateMediaPathPreservesRoot(): void
+    {
+        $this->service->updateMediaPath('///');
+
+        self::assertSame('/', Setting::get('media_path'));
+    }
 }


### PR DESCRIPTION
## Summary

Closes a media-browser path-traversal bug. A malformed `media_path` like `//Users/foo/media` (repeated separator) saved as-is would defeat the `Str::after($song->path, $mediaPath)` prefix match used to build the folder hierarchy — `Str::after` silently returned the full absolute song path, and folder records were created for every parent directory all the way up to the filesystem root. Admin users could then browse the host filesystem tree through the media browser UI.

## Changes

- `SettingService::updateMediaPath` — collapse repeated separators, then `realpath()` when available. Falls back to the normalized string if `realpath()` returns false (e.g. in tests with non-existent paths).
- `MediaBrowser::maybeCreateFolderStructureForSong` — strict prefix check: if `$song->path` doesn't start with `media_path + DIRECTORY_SEPARATOR`, skip and log instead of creating folder rows.
- Tests: `updateMediaPathCollapsesRepeatedSeparators` (settings) + `skipsSongOutsideMediaPath` (browser).

## Severity

Authenticated; requires `MANAGE_SETTINGS` (admin / Plus). Read-only directory-name disclosure via the browser UI — does not expose file contents (those still go through normal stream auth). Worth a security advisory after merge.

## Cleanup for affected installs

If an install already has polluted folder rows from a previous bad `media_path`, the new code only prevents *future* pollution. Wipe and re-extract:

```bash
php artisan tinker --execute="DB::table('songs')->update(['folder_id' => null]); DB::table('folders')->delete();"
php artisan koel:extract-folders
```

## Test plan

- [x] `composer cs && composer lint && composer analyze` — clean.
- [x] `php artisan test --compact tests/Integration/Services/SettingServiceTest.php tests/Integration/Services/MediaBrowserTest.php` — 5/5 passed.
- [x] Manually reproduced the bug, ran the cleanup, re-extracted folders — media browser now stops at the configured `media_path` root.
- [ ] CI green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Songs with paths outside the configured media directory are now skipped during folder structure creation, preventing incorrect processing.
  * Media paths are normalized by collapsing repeated directory separators and canonicalizing input, ensuring consistent path handling.

* **Tests**
  * Added integration tests to verify exclusion of out-of-directory songs and correct normalization of media path inputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2492?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->