### PR TITLE
feat: add WebDAV storage support for Koel Plus

### DIFF
--- a/.cursor/rules/laravel-boost.mdc
+++ b/.cursor/rules/laravel-boost.mdc
@@ -23,7 +23,7 @@ This application is a Laravel application and its main Laravel ecosystems packag
 - phpunit/phpunit (PHPUNIT) - v11
 - vue (VUE) - v3
 - laravel-echo (ECHO) - v2
-- tailwindcss (TAILWINDCSS) - v3
+- tailwindcss (TAILWINDCSS) - v4
 
 ## Conventions
 - You must follow all existing code conventions used in this application. When creating or editing a file, check sibling files for the correct structure, approach, and naming.
@@ -227,9 +227,44 @@ protected function isAccessible(User $user, ?string $path = null): bool
 ### Dark Mode
 - If existing pages and components support dark mode, new pages and components must support dark mode in a similar way, typically using `dark:`.
 
-=== tailwindcss/v3 rules ===
+=== tailwindcss/v4 rules ===
 
-## Tailwind CSS 3
+## Tailwind CSS 4
 
-- Always use Tailwind CSS v3; verify you're using only classes supported by this version.
+- Always use Tailwind CSS v4; do not use the deprecated utilities.
+- `corePlugins` is not supported in Tailwind v4.
+- In Tailwind v4, configuration is CSS-first using the `@theme` directive — no separate `tailwind.config.js` file is needed.
+
+<code-snippet name="Extending Theme in CSS" lang="css">
+@theme {
+  --color-brand: oklch(0.72 0.11 178);
+}
+</code-snippet>
+
+- In Tailwind v4, you import Tailwind using a regular CSS `@import` statement, not using the `@tailwind` directives used in v3:
+
+<code-snippet name="Tailwind v4 Import Tailwind Diff" lang="diff">
+   - @tailwind base;
+   - @tailwind components;
+   - @tailwind utilities;
+   + @import "tailwindcss";
+</code-snippet>
+
+### Replaced Utilities
+- Tailwind v4 removed deprecated utilities. Do not use the deprecated option; use the replacement.
+- Opacity values are still numeric.
+
+| Deprecated |	Replacement |
+|------------+--------------|
+| bg-opacity-* | bg-black/* |
+| text-opacity-* | text-black/* |
+| border-opacity-* | border-black/* |
+| divide-opacity-* | divide-black/* |
+| ring-opacity-* | ring-black/* |
+| placeholder-opacity-* | placeholder-black/* |
+| flex-shrink-* | shrink-* |
+| flex-grow-* | grow-* |
+| overflow-ellipsis | text-ellipsis |
+| decoration-slice | box-decoration-slice |
+| decoration-clone | box-decoration-clone |
 </laravel-boost-guidelines>

--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,7 @@ MYSQL_ATTR_SSL_CA=
 # sftp: Store files on an SFTP server.
 # s3: Store files on Amazon S3 or a S3-compatible service (e.g. Cloudflare R2 or DigitalOcean Spaces). Koel Plus only.
 # dropbox: Store files on Dropbox. Koel Plus only.
+# webdav: Store files on a WebDAV server (e.g. NextCloud, Owncloud). Koel Plus only.
 # See https://docs.koel.dev/plus/cloud-storage-support
 STORAGE_DRIVER=local
 
@@ -90,6 +91,18 @@ SFTP_PASSWORD=
 # …or private key authentication:
 SFTP_PRIVATE_KEY=
 SFTP_PASSPHRASE=
+
+
+# WebDAV settings. Required if you're using a WebDAV server (e.g. NextCloud, Owncloud)
+# to store your media (STORAGE_DRIVER=webdav).
+# For NextCloud, the base URI looks like https://your-nextcloud.example/remote.php/dav/files/<username>/
+WEBDAV_BASE_URL=
+WEBDAV_USERNAME=
+WEBDAV_PASSWORD=
+
+# Optional path prefix beneath the base URI where Koel stores its media (no leading or trailing slash).
+# For example: Music
+WEBDAV_PATH_PREFIX=
 
 
 # Ticketmaster integration suggests relevant upcoming tours and concerts nearby.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,7 +20,7 @@ This application is a Laravel application and its main Laravel ecosystems packag
 - phpunit/phpunit (PHPUNIT) - v11
 - vue (VUE) - v3
 - laravel-echo (ECHO) - v2
-- tailwindcss (TAILWINDCSS) - v3
+- tailwindcss (TAILWINDCSS) - v4
 
 ## Conventions
 - You must follow all existing code conventions used in this application. When creating or editing a file, check sibling files for the correct structure, approach, and naming.
@@ -224,9 +224,44 @@ protected function isAccessible(User $user, ?string $path = null): bool
 ### Dark Mode
 - If existing pages and components support dark mode, new pages and components must support dark mode in a similar way, typically using `dark:`.
 
-=== tailwindcss/v3 rules ===
+=== tailwindcss/v4 rules ===
 
-## Tailwind CSS 3
+## Tailwind CSS 4
 
-- Always use Tailwind CSS v3; verify you're using only classes supported by this version.
+- Always use Tailwind CSS v4; do not use the deprecated utilities.
+- `corePlugins` is not supported in Tailwind v4.
+- In Tailwind v4, configuration is CSS-first using the `@theme` directive — no separate `tailwind.config.js` file is needed.
+
+<code-snippet name="Extending Theme in CSS" lang="css">
+@theme {
+  --color-brand: oklch(0.72 0.11 178);
+}
+</code-snippet>
+
+- In Tailwind v4, you import Tailwind using a regular CSS `@import` statement, not using the `@tailwind` directives used in v3:
+
+<code-snippet name="Tailwind v4 Import Tailwind Diff" lang="diff">
+   - @tailwind base;
+   - @tailwind components;
+   - @tailwind utilities;
+   + @import "tailwindcss";
+</code-snippet>
+
+### Replaced Utilities
+- Tailwind v4 removed deprecated utilities. Do not use the deprecated option; use the replacement.
+- Opacity values are still numeric.
+
+| Deprecated |	Replacement |
+|------------+--------------|
+| bg-opacity-* | bg-black/* |
+| text-opacity-* | text-black/* |
+| border-opacity-* | border-black/* |
+| divide-opacity-* | divide-black/* |
+| ring-opacity-* | ring-black/* |
+| placeholder-opacity-* | placeholder-black/* |
+| flex-shrink-* | shrink-* |
+| flex-grow-* | grow-* |
+| overflow-ellipsis | text-ellipsis |
+| decoration-slice | box-decoration-slice |
+| decoration-clone | box-decoration-clone |
 </laravel-boost-guidelines>

--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -20,7 +20,7 @@ This application is a Laravel application and its main Laravel ecosystems packag
 - phpunit/phpunit (PHPUNIT) - v11
 - vue (VUE) - v3
 - laravel-echo (ECHO) - v2
-- tailwindcss (TAILWINDCSS) - v3
+- tailwindcss (TAILWINDCSS) - v4
 
 ## Conventions
 - You must follow all existing code conventions used in this application. When creating or editing a file, check sibling files for the correct structure, approach, and naming.
@@ -224,9 +224,44 @@ protected function isAccessible(User $user, ?string $path = null): bool
 ### Dark Mode
 - If existing pages and components support dark mode, new pages and components must support dark mode in a similar way, typically using `dark:`.
 
-=== tailwindcss/v3 rules ===
+=== tailwindcss/v4 rules ===
 
-## Tailwind CSS 3
+## Tailwind CSS 4
 
-- Always use Tailwind CSS v3; verify you're using only classes supported by this version.
+- Always use Tailwind CSS v4; do not use the deprecated utilities.
+- `corePlugins` is not supported in Tailwind v4.
+- In Tailwind v4, configuration is CSS-first using the `@theme` directive — no separate `tailwind.config.js` file is needed.
+
+<code-snippet name="Extending Theme in CSS" lang="css">
+@theme {
+  --color-brand: oklch(0.72 0.11 178);
+}
+</code-snippet>
+
+- In Tailwind v4, you import Tailwind using a regular CSS `@import` statement, not using the `@tailwind` directives used in v3:
+
+<code-snippet name="Tailwind v4 Import Tailwind Diff" lang="diff">
+   - @tailwind base;
+   - @tailwind components;
+   - @tailwind utilities;
+   + @import "tailwindcss";
+</code-snippet>
+
+### Replaced Utilities
+- Tailwind v4 removed deprecated utilities. Do not use the deprecated option; use the replacement.
+- Opacity values are still numeric.
+
+| Deprecated |	Replacement |
+|------------+--------------|
+| bg-opacity-* | bg-black/* |
+| text-opacity-* | text-black/* |
+| border-opacity-* | border-black/* |
+| divide-opacity-* | divide-black/* |
+| ring-opacity-* | ring-black/* |
+| placeholder-opacity-* | placeholder-black/* |
+| flex-shrink-* | shrink-* |
+| flex-grow-* | grow-* |
+| overflow-ellipsis | text-ellipsis |
+| decoration-slice | box-decoration-slice |
+| decoration-clone | box-decoration-clone |
 </laravel-boost-guidelines>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -278,7 +278,7 @@ protected function isAccessible(User $user, ?string $path = null): bool
 
 ## Self-Explanatory Code
 - Code should read on its own. If a piece of code needs a comment to be understood, that's a signal the code is wrong, not that the comment is needed — refactor it: extract a named helper, rename a variable to encode intent, lift a condition into a named flag, pull a block into a small function. Use a comment only when refactoring genuinely can't carry the intent (a hidden invariant, a workaround tied to a specific external bug, behaviour a reader would otherwise misjudge). Never write comments that narrate the next line, summarise the surrounding block, or restate what well-named identifiers already say.
-- Don't use single-letter variable names. The only allowed ones are `i` / `j` for loop counters and `h` for the test harness. For everything else (callback params, destructured fields, lambda args, etc.) pick a name that says what it is.
+- Don't use single-letter variable names. The only allowed ones are `i` / `j` for loop counters, `h` for the test harness, and `$e` for the exception variable in `catch (Throwable|Exception|Error $e)` blocks (PHP's universal idiom — analogous to `e` for events in JS/TS event handlers). For everything else (callback params, destructured fields, lambda args, etc.) pick a name that says what it is.
 - Never combine assignment with return. Always `$x = expr;` then `return $x;` on a separate line — `return $x = expr;` cramming two effects into one statement is forbidden in PHP, TS, and JS.
 
 ## PHP Conventions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,6 @@ This application is a Laravel application and its main Laravel ecosystems packag
 - tailwindcss (TAILWINDCSS) - v4
 
 ## Conventions
-- **Always infer from the existing codebase before writing — and ask when no precedent exists.** Before any new identifier, mock/test pattern, store/service call shape, form wiring, helper choice, spelling, or file layout, grep `app/` and `resources/assets/js/` for how it has been done before, and copy the existing shape exactly. If no precedent exists in the repo, **stop and ask the user** instead of defaulting to whatever you'd write from training data or personal habit. The codebase is the source of truth for *how things are done*, not just *what exists*. "I should have looked" is the symptom; not looking first is the root cause.
 - You must follow all existing code conventions used in this application. When creating or editing a file, check sibling files for the correct structure, approach, and naming.
 - Use descriptive names for variables and methods. For example, `isRegisteredForDiscounts`, not `discount()`.
 - Check for existing components to reuse before writing a new one.
@@ -229,14 +228,42 @@ protected function isAccessible(User $user, ?string $path = null): bool
 
 ## Tailwind CSS 4
 
-- Always use Tailwind CSS v4; verify you're using only classes supported by this version. Remember v4 utility renames (e.g. `rounded-sm` is the old `rounded`, `shadow-sm` is the old `shadow`, `outline-hidden` replaces `outline-none`, `ring` is now 1px not 3px).
-- The important modifier goes after the class, not before: `text-red-500!`, never `!text-red-500`.
-- Opacity modifiers replace the deprecated `*-opacity-*` utilities: `bg-black/50` not `bg-black bg-opacity-50`.
-- `@apply` inside Vue scoped `<style>` blocks **must** be preceded by `@reference '@css/app.pcss';` so v4 can resolve theme tokens — the `@css` alias is rewritten to an absolute path by the small custom postcss plugin in `postcss.config.cjs`. Never write relative paths to `app.pcss` in `@reference` directives.
-- Theme tokens (custom colors etc.) live in `tailwind.config.js`'s `theme.extend.colors`, linked from `resources/assets/css/app.pcss` via `@config`. Prefer CSS variables on the koel side (defined in `partials/vars.pcss`) over hardcoded colors.
-- Layer order is pinned globally by `public/css/layer-order.css` (`@layer theme, base, components, utilities;`) loaded from `base.blade.php` **before** any Vite-emitted CSS. Don't remove that `<link>`: Vite chunks scoped Vue CSS files load before the main app CSS, and several of them declare `@layer utilities { ... }` without first declaring `@layer base`, which would establish utilities as a low-priority layer and let `@layer base` rules win over utility classes. The static pre-load locks the canonical order.
-- Partial pcss imports (`vars.pcss` aside) use the `layer(base)` modifier in `app.pcss`/`remote.pcss` — e.g. `@import './partials/shared.pcss' layer(base);`. Don't wrap rules in `@layer base { ... }` *inside* a partial that's already imported via `layer(base)`; that creates a `base.base` sub-layer with weird precedence. Either use the import modifier OR an internal `@layer base { }` block, never both. **Exception**: partials that contain `@utility` directives (like `scroll-mask.pcss`) must be imported unlayered. v4 forbids `@utility` from being nested inside any at-rule (including `@layer base`), so adding `layer(base)` to such an import wraps the whole file in `@layer base { … }` and the build fails with "`@utility` cannot be nested".
-- `shared.pcss` element-default rules wrap their selectors in `:where()` (e.g. `:where(a) { color: var(--color-fg); }`) to drop specificity to 0. This is defense-in-depth so utility classes always win on specificity even when layer cascade gets confused by load order.
+- Always use Tailwind CSS v4; do not use the deprecated utilities.
+- `corePlugins` is not supported in Tailwind v4.
+- In Tailwind v4, configuration is CSS-first using the `@theme` directive — no separate `tailwind.config.js` file is needed.
+
+<code-snippet name="Extending Theme in CSS" lang="css">
+@theme {
+  --color-brand: oklch(0.72 0.11 178);
+}
+</code-snippet>
+
+- In Tailwind v4, you import Tailwind using a regular CSS `@import` statement, not using the `@tailwind` directives used in v3:
+
+<code-snippet name="Tailwind v4 Import Tailwind Diff" lang="diff">
+   - @tailwind base;
+   - @tailwind components;
+   - @tailwind utilities;
+   + @import "tailwindcss";
+</code-snippet>
+
+### Replaced Utilities
+- Tailwind v4 removed deprecated utilities. Do not use the deprecated option; use the replacement.
+- Opacity values are still numeric.
+
+| Deprecated |	Replacement |
+|------------+--------------|
+| bg-opacity-* | bg-black/* |
+| text-opacity-* | text-black/* |
+| border-opacity-* | border-black/* |
+| divide-opacity-* | divide-black/* |
+| ring-opacity-* | ring-black/* |
+| placeholder-opacity-* | placeholder-black/* |
+| flex-shrink-* | shrink-* |
+| flex-grow-* | grow-* |
+| overflow-ellipsis | text-ellipsis |
+| decoration-slice | box-decoration-slice |
+| decoration-clone | box-decoration-clone |
 </laravel-boost-guidelines>
 
 ## Architecture

--- a/app/Enums/SongStorageType.php
+++ b/app/Enums/SongStorageType.php
@@ -10,6 +10,7 @@ enum SongStorageType: string
     case S3_LAMBDA = 's3-lambda';
     case DROPBOX = 'dropbox';
     case SFTP = 'sftp';
+    case WEBDAV = 'webdav';
     case LOCAL = '';
 
     public function supported(): bool

--- a/app/Models/Concerns/Songs/HasSongAttributes.php
+++ b/app/Models/Concerns/Songs/HasSongAttributes.php
@@ -10,6 +10,7 @@ use App\Values\SongStorageMetadata\S3CompatibleMetadata;
 use App\Values\SongStorageMetadata\S3LambdaMetadata;
 use App\Values\SongStorageMetadata\SftpMetadata;
 use App\Values\SongStorageMetadata\SongStorageMetadata;
+use App\Values\SongStorageMetadata\WebDAVMetadata;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Support\Facades\File;
 use Throwable;
@@ -47,6 +48,10 @@ trait HasSongAttributes
                     case SongStorageType::DROPBOX:
                         preg_match('/^dropbox:\\/\\/(.*)/', $this->path, $matches);
                         return DropboxMetadata::make($matches[1]);
+
+                    case SongStorageType::WEBDAV:
+                        preg_match('/^webdav:\\/\\/(.*)/', $this->path, $matches);
+                        return WebDAVMetadata::make($matches[1]);
 
                     default:
                         return LocalMetadata::make($this->path);

--- a/app/Providers/SongStorageServiceProvider.php
+++ b/app/Providers/SongStorageServiceProvider.php
@@ -8,6 +8,7 @@ use App\Services\SongStorages\S3CompatibleStorage;
 use App\Services\SongStorages\SftpStorage;
 use App\Services\SongStorages\SongStorage;
 use App\Services\SongStorages\WebDAVStorage;
+use Illuminate\Contracts\Container\Container;
 use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\ServiceProvider;
@@ -34,7 +35,7 @@ class SongStorageServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
-        Storage::extend('webdav', static function ($app, array $config): FilesystemAdapter {
+        Storage::extend('webdav', static function (Container $app, array $config): FilesystemAdapter {
             $client = new WebDAVClient([
                 'baseUri' => (string) ($config['baseUri'] ?? ''),
                 'userName' => (string) ($config['userName'] ?? ''),

--- a/app/Providers/SongStorageServiceProvider.php
+++ b/app/Providers/SongStorageServiceProvider.php
@@ -7,7 +7,13 @@ use App\Services\SongStorages\LocalStorage;
 use App\Services\SongStorages\S3CompatibleStorage;
 use App\Services\SongStorages\SftpStorage;
 use App\Services\SongStorages\SongStorage;
+use App\Services\SongStorages\WebDAVStorage;
+use Illuminate\Filesystem\FilesystemAdapter;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\ServiceProvider;
+use League\Flysystem\Filesystem;
+use League\Flysystem\WebDAV\WebDAVAdapter;
+use Sabre\DAV\Client as WebDAVClient;
 
 class SongStorageServiceProvider extends ServiceProvider
 {
@@ -18,10 +24,26 @@ class SongStorageServiceProvider extends ServiceProvider
                 's3' => S3CompatibleStorage::class,
                 'dropbox' => DropboxStorage::class,
                 'sftp' => SftpStorage::class,
+                'webdav' => WebDAVStorage::class,
                 default => LocalStorage::class,
             };
 
             return $this->app->make($concrete);
+        });
+    }
+
+    public function boot(): void
+    {
+        Storage::extend('webdav', static function ($app, array $config): FilesystemAdapter {
+            $client = new WebDAVClient([
+                'baseUri' => (string) ($config['baseUri'] ?? ''),
+                'userName' => (string) ($config['userName'] ?? ''),
+                'password' => (string) ($config['password'] ?? ''),
+            ]);
+
+            $adapter = new WebDAVAdapter($client, (string) ($config['pathPrefix'] ?? ''));
+
+            return new FilesystemAdapter(new Filesystem($adapter, $config), $adapter, $config);
         });
     }
 }

--- a/app/Services/SongStorages/SftpStorage.php
+++ b/app/Services/SongStorages/SftpStorage.php
@@ -14,6 +14,7 @@ use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use RuntimeException;
 
 class SftpStorage extends SongStorage implements MustDeleteTemporaryLocalFileAfterUpload
 {
@@ -55,8 +56,15 @@ class SftpStorage extends SongStorage implements MustDeleteTemporaryLocalFileAft
     public function copyToLocal(string $path): string
     {
         $localPath = artifact_path(sprintf('tmp/%s_%s', Ulid::generate(), basename($path)));
+        $stream = $this->disk->readStream($path);
 
-        file_put_contents($localPath, $this->disk->readStream($path));
+        throw_unless($stream, new RuntimeException("Failed to open remote stream for $path."));
+
+        try {
+            File::put($localPath, stream_get_contents($stream));
+        } finally {
+            fclose($stream);
+        }
 
         return $localPath;
     }

--- a/app/Services/SongStorages/SftpStorage.php
+++ b/app/Services/SongStorages/SftpStorage.php
@@ -61,9 +61,15 @@ class SftpStorage extends SongStorage implements MustDeleteTemporaryLocalFileAft
         throw_unless($stream, new RuntimeException("Failed to open remote stream for $path."));
 
         try {
-            file_put_contents($localPath, $stream);
+            $bytes = file_put_contents($localPath, $stream);
         } finally {
             fclose($stream);
+        }
+
+        if ($bytes === false) {
+            File::delete($localPath);
+
+            throw new RuntimeException("Failed to write remote stream to $localPath.");
         }
 
         return $localPath;

--- a/app/Services/SongStorages/SftpStorage.php
+++ b/app/Services/SongStorages/SftpStorage.php
@@ -61,7 +61,7 @@ class SftpStorage extends SongStorage implements MustDeleteTemporaryLocalFileAft
         throw_unless($stream, new RuntimeException("Failed to open remote stream for $path."));
 
         try {
-            File::put($localPath, stream_get_contents($stream));
+            file_put_contents($localPath, $stream);
         } finally {
             fclose($stream);
         }

--- a/app/Services/SongStorages/SongStorageFactory.php
+++ b/app/Services/SongStorages/SongStorageFactory.php
@@ -14,6 +14,7 @@ class SongStorageFactory
             SongStorageType::S3 => app(S3CompatibleStorage::class),
             SongStorageType::S3_LAMBDA => app(S3LambdaStorage::class),
             SongStorageType::DROPBOX => app(DropboxStorage::class),
+            SongStorageType::WEBDAV => app(WebDAVStorage::class),
         };
     }
 }

--- a/app/Services/SongStorages/WebDAVStorage.php
+++ b/app/Services/SongStorages/WebDAVStorage.php
@@ -14,6 +14,7 @@ use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use RuntimeException;
 
 class WebDAVStorage extends SongStorage implements MustDeleteTemporaryLocalFileAfterUpload
 {
@@ -54,8 +55,15 @@ class WebDAVStorage extends SongStorage implements MustDeleteTemporaryLocalFileA
     public function copyToLocal(string $path): string
     {
         $localPath = artifact_path(sprintf('tmp/%s_%s', Ulid::generate(), basename($path)));
+        $stream = $this->disk->readStream($path);
 
-        file_put_contents($localPath, $this->disk->readStream($path));
+        throw_unless($stream, new RuntimeException("Failed to open remote stream for $path."));
+
+        try {
+            File::put($localPath, stream_get_contents($stream));
+        } finally {
+            fclose($stream);
+        }
 
         return $localPath;
     }

--- a/app/Services/SongStorages/WebDAVStorage.php
+++ b/app/Services/SongStorages/WebDAVStorage.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Services\SongStorages;
+
+use App\Enums\SongStorageType;
+use App\Helpers\Ulid;
+use App\Models\User;
+use App\Services\SongStorages\Concerns\DeletesUsingFilesystem;
+use App\Services\SongStorages\Concerns\MovesUploadedFile;
+use App\Services\SongStorages\Contracts\MustDeleteTemporaryLocalFileAfterUpload;
+use App\Values\UploadReference;
+use Closure;
+use Illuminate\Contracts\Filesystem\Filesystem;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+class WebDAVStorage extends SongStorage implements MustDeleteTemporaryLocalFileAfterUpload
+{
+    use DeletesUsingFilesystem;
+    use MovesUploadedFile;
+
+    private Filesystem $disk;
+
+    public function __construct()
+    {
+        $this->disk = Storage::disk('webdav');
+    }
+
+    public function storeUploadedFile(string $uploadedFilePath, User $uploader): UploadReference
+    {
+        $path = $this->generateRemotePath(basename($uploadedFilePath), $uploader);
+        // Buffer in memory so the PUT carries a fixed Content-Length; streaming PUTs trip
+        // HTTP/2 INTERNAL_ERROR on Cloudflare-fronted NextCloud.
+        $this->disk->put($path, File::get($uploadedFilePath));
+
+        return UploadReference::make(location: "webdav://$path", localPath: $uploadedFilePath);
+    }
+
+    public function undoUpload(UploadReference $reference): void
+    {
+        File::delete($reference->localPath);
+        $this->delete(location: Str::after($reference->location, 'webdav://'), backup: false);
+    }
+
+    public function delete(string $location, bool $backup = false): void
+    {
+        $this->deleteFileUnderPath(
+            $location,
+            $backup ? static fn (Filesystem $fs, string $path) => $fs->copy($path, "$path.bak") : false,
+        );
+    }
+
+    public function copyToLocal(string $path): string
+    {
+        $localPath = artifact_path(sprintf('tmp/%s_%s', Ulid::generate(), basename($path)));
+
+        file_put_contents($localPath, $this->disk->readStream($path));
+
+        return $localPath;
+    }
+
+    public function testSetup(): void
+    {
+        $this->disk->put('test.txt', 'Koel test file');
+        $this->disk->delete('test.txt');
+    }
+
+    public function getLocalPath(string $location): string
+    {
+        return $this->copyToLocal(Str::after($location, 'webdav://'));
+    }
+
+    public function deleteFileUnderPath(string $path, bool|Closure $backup): void
+    {
+        $this->deleteUsingFilesystem($this->disk, $path, $backup);
+    }
+
+    public function getStorageType(): SongStorageType
+    {
+        return SongStorageType::WEBDAV;
+    }
+
+    private function generateRemotePath(string $filename, User $uploader): string
+    {
+        return sprintf('%s__%s__%s', $uploader->id, Ulid::generate(), $filename);
+    }
+}

--- a/app/Services/SongStorages/WebDAVStorage.php
+++ b/app/Services/SongStorages/WebDAVStorage.php
@@ -60,7 +60,7 @@ class WebDAVStorage extends SongStorage implements MustDeleteTemporaryLocalFileA
         throw_unless($stream, new RuntimeException("Failed to open remote stream for $path."));
 
         try {
-            File::put($localPath, stream_get_contents($stream));
+            file_put_contents($localPath, $stream);
         } finally {
             fclose($stream);
         }

--- a/app/Services/SongStorages/WebDAVStorage.php
+++ b/app/Services/SongStorages/WebDAVStorage.php
@@ -60,9 +60,15 @@ class WebDAVStorage extends SongStorage implements MustDeleteTemporaryLocalFileA
         throw_unless($stream, new RuntimeException("Failed to open remote stream for $path."));
 
         try {
-            file_put_contents($localPath, $stream);
+            $bytes = file_put_contents($localPath, $stream);
         } finally {
             fclose($stream);
+        }
+
+        if ($bytes === false) {
+            File::delete($localPath);
+
+            throw new RuntimeException("Failed to write remote stream to $localPath.");
         }
 
         return $localPath;

--- a/app/Services/Streamer/Adapters/WebDAVStreamerAdapter.php
+++ b/app/Services/Streamer/Adapters/WebDAVStreamerAdapter.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Services\Streamer\Adapters;
+
+use App\Models\Song;
+use App\Services\SongStorages\WebDAVStorage;
+use App\Services\Streamer\Adapters\Concerns\StreamsLocalPath;
+use App\Values\RequestedStreamingConfig;
+
+class WebDAVStreamerAdapter implements StreamerAdapter
+{
+    use StreamsLocalPath;
+
+    public function __construct(
+        private readonly WebDAVStorage $storage,
+    ) {}
+
+    public function stream(Song $song, ?RequestedStreamingConfig $config = null): void
+    {
+        $this->storage->assertSupported();
+        $this->streamLocalPath($this->storage->copyToLocal($song->storage_metadata->getPath()));
+    }
+}

--- a/app/Services/Streamer/Streamer.php
+++ b/app/Services/Streamer/Streamer.php
@@ -12,6 +12,7 @@ use App\Services\Streamer\Adapters\S3CompatibleStreamerAdapter;
 use App\Services\Streamer\Adapters\SftpStreamerAdapter;
 use App\Services\Streamer\Adapters\StreamerAdapter;
 use App\Services\Streamer\Adapters\TranscodingStreamerAdapter;
+use App\Services\Streamer\Adapters\WebDAVStreamerAdapter;
 use App\Values\RequestedStreamingConfig;
 
 class Streamer
@@ -41,6 +42,7 @@ class Streamer
             SongStorageType::SFTP => app(SftpStreamerAdapter::class),
             SongStorageType::S3, SongStorageType::S3_LAMBDA => app(S3CompatibleStreamerAdapter::class),
             SongStorageType::DROPBOX => app(DropboxStreamerAdapter::class),
+            SongStorageType::WEBDAV => app(WebDAVStreamerAdapter::class),
         };
     }
 

--- a/app/Services/Transcoding/SftpTranscodingStrategy.php
+++ b/app/Services/Transcoding/SftpTranscodingStrategy.php
@@ -32,7 +32,7 @@ class SftpTranscodingStrategy extends TranscodingStrategy
         $destination = artifact_path(sprintf('transcodes/%d/%s.m4a', $bitRate, Ulid::generate()));
 
         try {
-            $this->transcodeAndRecord($song, $tmpSource, $destination, $bitRate);
+            $this->transcodeAndUpsert($song, $tmpSource, $destination, $bitRate);
         } catch (Throwable $e) {
             File::delete($destination);
 

--- a/app/Services/Transcoding/SftpTranscodingStrategy.php
+++ b/app/Services/Transcoding/SftpTranscodingStrategy.php
@@ -27,29 +27,28 @@ class SftpTranscodingStrategy extends TranscodingStrategy
         $storage = app(SftpStorage::class);
         $tmpSource = $storage->copyToLocal($song->storage_metadata->getPath());
 
-        // (Re)Transcode the song to the specified bit rate and either create a new transcode record or
-        // update the existing one.
-        $destination = artifact_path(sprintf('transcodes/%d/%s.m4a', $bitRate, Ulid::generate()));
-        $this->transcoder->transcode($tmpSource, $destination, $bitRate);
+        try {
+            // (Re)Transcode the song to the specified bit rate and either create a new transcode record or
+            // update the existing one.
+            $destination = artifact_path(sprintf('transcodes/%d/%s.m4a', $bitRate, Ulid::generate()));
+            $this->transcoder->transcode($tmpSource, $destination, $bitRate);
 
-        $this->createOrUpdateTranscode(
-            $song,
-            $destination,
-            $bitRate,
-            File::hash($destination),
-            File::size($destination),
-        );
-
-        File::delete($tmpSource);
+            $this->createOrUpdateTranscode(
+                $song,
+                $destination,
+                $bitRate,
+                File::hash($destination),
+                File::size($destination),
+            );
+        } finally {
+            File::delete($tmpSource);
+        }
 
         return $destination;
     }
 
     public function deleteTranscodeFile(string $location, SongStorageType $storageType): void
     {
-        /** @var SftpStorage $storage */
-        $storage = app(SftpStorage::class);
-
-        $storage->deleteFileUnderPath(path: $location, backup: false);
+        File::delete($location);
     }
 }

--- a/app/Services/Transcoding/SftpTranscodingStrategy.php
+++ b/app/Services/Transcoding/SftpTranscodingStrategy.php
@@ -7,6 +7,7 @@ use App\Helpers\Ulid;
 use App\Models\Song;
 use App\Services\SongStorages\SftpStorage;
 use Illuminate\Support\Facades\File;
+use Throwable;
 
 class SftpTranscodingStrategy extends TranscodingStrategy
 {
@@ -27,10 +28,9 @@ class SftpTranscodingStrategy extends TranscodingStrategy
         $storage = app(SftpStorage::class);
         $tmpSource = $storage->copyToLocal($song->storage_metadata->getPath());
 
+        $destination = artifact_path(sprintf('transcodes/%d/%s.m4a', $bitRate, Ulid::generate()));
+
         try {
-            // (Re)Transcode the song to the specified bit rate and either create a new transcode record or
-            // update the existing one.
-            $destination = artifact_path(sprintf('transcodes/%d/%s.m4a', $bitRate, Ulid::generate()));
             $this->transcoder->transcode($tmpSource, $destination, $bitRate);
 
             $this->createOrUpdateTranscode(
@@ -40,6 +40,10 @@ class SftpTranscodingStrategy extends TranscodingStrategy
                 File::hash($destination),
                 File::size($destination),
             );
+        } catch (Throwable $e) {
+            File::delete($destination);
+
+            throw $e;
         } finally {
             File::delete($tmpSource);
         }

--- a/app/Services/Transcoding/SftpTranscodingStrategy.php
+++ b/app/Services/Transcoding/SftpTranscodingStrategy.php
@@ -8,6 +8,7 @@ use App\Models\Song;
 use App\Services\SongStorages\SftpStorage;
 use Illuminate\Support\Facades\File;
 use Throwable;
+use Webmozart\Assert\Assert;
 
 class SftpTranscodingStrategy extends TranscodingStrategy
 {
@@ -31,15 +32,7 @@ class SftpTranscodingStrategy extends TranscodingStrategy
         $destination = artifact_path(sprintf('transcodes/%d/%s.m4a', $bitRate, Ulid::generate()));
 
         try {
-            $this->transcoder->transcode($tmpSource, $destination, $bitRate);
-
-            $this->createOrUpdateTranscode(
-                $song,
-                $destination,
-                $bitRate,
-                File::hash($destination),
-                File::size($destination),
-            );
+            $this->transcodeAndRecord($song, $tmpSource, $destination, $bitRate);
         } catch (Throwable $e) {
             File::delete($destination);
 
@@ -53,6 +46,8 @@ class SftpTranscodingStrategy extends TranscodingStrategy
 
     public function deleteTranscodeFile(string $location, SongStorageType $storageType): void
     {
+        Assert::eq($storageType, SongStorageType::SFTP);
+
         File::delete($location);
     }
 }

--- a/app/Services/Transcoding/TranscodeStrategyFactory.php
+++ b/app/Services/Transcoding/TranscodeStrategyFactory.php
@@ -15,6 +15,7 @@ class TranscodeStrategyFactory
             SongStorageType::DROPBOX,
                 => app(CloudTranscodingStrategy::class),
             SongStorageType::SFTP => app(SftpTranscodingStrategy::class),
+            SongStorageType::WEBDAV => app(WebDAVTranscodingStrategy::class),
         };
     }
 }

--- a/app/Services/Transcoding/TranscodingStrategy.php
+++ b/app/Services/Transcoding/TranscodingStrategy.php
@@ -6,6 +6,7 @@ use App\Enums\SongStorageType;
 use App\Models\Song;
 use App\Models\Transcode;
 use App\Repositories\TranscodeRepository;
+use Illuminate\Support\Facades\File;
 
 abstract class TranscodingStrategy
 {
@@ -42,6 +43,19 @@ abstract class TranscodingStrategy
         );
 
         return $this->findTranscodeBySongAndBitRate($song, $bitRate); // @phpstan-ignore-line
+    }
+
+    protected function transcodeAndRecord(Song $song, string $tmpSource, string $destination, int $bitRate): void
+    {
+        $this->transcoder->transcode($tmpSource, $destination, $bitRate);
+
+        $this->createOrUpdateTranscode(
+            $song,
+            $destination,
+            $bitRate,
+            File::hash($destination),
+            File::size($destination),
+        );
     }
 
     abstract public function getTranscodeLocation(Song $song, int $bitRate): string;

--- a/app/Services/Transcoding/TranscodingStrategy.php
+++ b/app/Services/Transcoding/TranscodingStrategy.php
@@ -45,7 +45,7 @@ abstract class TranscodingStrategy
         return $this->findTranscodeBySongAndBitRate($song, $bitRate); // @phpstan-ignore-line
     }
 
-    protected function transcodeAndRecord(Song $song, string $tmpSource, string $destination, int $bitRate): void
+    protected function transcodeAndUpsert(Song $song, string $tmpSource, string $destination, int $bitRate): void
     {
         $this->transcoder->transcode($tmpSource, $destination, $bitRate);
 

--- a/app/Services/Transcoding/WebDAVTranscodingStrategy.php
+++ b/app/Services/Transcoding/WebDAVTranscodingStrategy.php
@@ -7,6 +7,7 @@ use App\Helpers\Ulid;
 use App\Models\Song;
 use App\Services\SongStorages\WebDAVStorage;
 use Illuminate\Support\Facades\File;
+use Throwable;
 
 class WebDAVTranscodingStrategy extends TranscodingStrategy
 {
@@ -26,8 +27,9 @@ class WebDAVTranscodingStrategy extends TranscodingStrategy
         $storage = app(WebDAVStorage::class);
         $tmpSource = $storage->copyToLocal($song->storage_metadata->getPath());
 
+        $destination = artifact_path(sprintf('transcodes/%d/%s.m4a', $bitRate, Ulid::generate()));
+
         try {
-            $destination = artifact_path(sprintf('transcodes/%d/%s.m4a', $bitRate, Ulid::generate()));
             $this->transcoder->transcode($tmpSource, $destination, $bitRate);
 
             $this->createOrUpdateTranscode(
@@ -37,6 +39,10 @@ class WebDAVTranscodingStrategy extends TranscodingStrategy
                 File::hash($destination),
                 File::size($destination),
             );
+        } catch (Throwable $e) {
+            File::delete($destination);
+
+            throw $e;
         } finally {
             File::delete($tmpSource);
         }

--- a/app/Services/Transcoding/WebDAVTranscodingStrategy.php
+++ b/app/Services/Transcoding/WebDAVTranscodingStrategy.php
@@ -26,27 +26,26 @@ class WebDAVTranscodingStrategy extends TranscodingStrategy
         $storage = app(WebDAVStorage::class);
         $tmpSource = $storage->copyToLocal($song->storage_metadata->getPath());
 
-        $destination = artifact_path(sprintf('transcodes/%d/%s.m4a', $bitRate, Ulid::generate()));
-        $this->transcoder->transcode($tmpSource, $destination, $bitRate);
+        try {
+            $destination = artifact_path(sprintf('transcodes/%d/%s.m4a', $bitRate, Ulid::generate()));
+            $this->transcoder->transcode($tmpSource, $destination, $bitRate);
 
-        $this->createOrUpdateTranscode(
-            $song,
-            $destination,
-            $bitRate,
-            File::hash($destination),
-            File::size($destination),
-        );
-
-        File::delete($tmpSource);
+            $this->createOrUpdateTranscode(
+                $song,
+                $destination,
+                $bitRate,
+                File::hash($destination),
+                File::size($destination),
+            );
+        } finally {
+            File::delete($tmpSource);
+        }
 
         return $destination;
     }
 
     public function deleteTranscodeFile(string $location, SongStorageType $storageType): void
     {
-        /** @var WebDAVStorage $storage */
-        $storage = app(WebDAVStorage::class);
-
-        $storage->deleteFileUnderPath(path: $location, backup: false);
+        File::delete($location);
     }
 }

--- a/app/Services/Transcoding/WebDAVTranscodingStrategy.php
+++ b/app/Services/Transcoding/WebDAVTranscodingStrategy.php
@@ -31,7 +31,7 @@ class WebDAVTranscodingStrategy extends TranscodingStrategy
         $destination = artifact_path(sprintf('transcodes/%d/%s.m4a', $bitRate, Ulid::generate()));
 
         try {
-            $this->transcodeAndRecord($song, $tmpSource, $destination, $bitRate);
+            $this->transcodeAndUpsert($song, $tmpSource, $destination, $bitRate);
         } catch (Throwable $e) {
             File::delete($destination);
 

--- a/app/Services/Transcoding/WebDAVTranscodingStrategy.php
+++ b/app/Services/Transcoding/WebDAVTranscodingStrategy.php
@@ -8,6 +8,7 @@ use App\Models\Song;
 use App\Services\SongStorages\WebDAVStorage;
 use Illuminate\Support\Facades\File;
 use Throwable;
+use Webmozart\Assert\Assert;
 
 class WebDAVTranscodingStrategy extends TranscodingStrategy
 {
@@ -30,15 +31,7 @@ class WebDAVTranscodingStrategy extends TranscodingStrategy
         $destination = artifact_path(sprintf('transcodes/%d/%s.m4a', $bitRate, Ulid::generate()));
 
         try {
-            $this->transcoder->transcode($tmpSource, $destination, $bitRate);
-
-            $this->createOrUpdateTranscode(
-                $song,
-                $destination,
-                $bitRate,
-                File::hash($destination),
-                File::size($destination),
-            );
+            $this->transcodeAndRecord($song, $tmpSource, $destination, $bitRate);
         } catch (Throwable $e) {
             File::delete($destination);
 
@@ -52,6 +45,8 @@ class WebDAVTranscodingStrategy extends TranscodingStrategy
 
     public function deleteTranscodeFile(string $location, SongStorageType $storageType): void
     {
+        Assert::eq($storageType, SongStorageType::WEBDAV);
+
         File::delete($location);
     }
 }

--- a/app/Services/Transcoding/WebDAVTranscodingStrategy.php
+++ b/app/Services/Transcoding/WebDAVTranscodingStrategy.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Services\Transcoding;
+
+use App\Enums\SongStorageType;
+use App\Helpers\Ulid;
+use App\Models\Song;
+use App\Services\SongStorages\WebDAVStorage;
+use Illuminate\Support\Facades\File;
+
+class WebDAVTranscodingStrategy extends TranscodingStrategy
+{
+    public function getTranscodeLocation(Song $song, int $bitRate): string
+    {
+        $transcode = $this->findTranscodeBySongAndBitRate($song, $bitRate);
+
+        if ($transcode?->isValid()) {
+            return $transcode->location;
+        }
+
+        if ($transcode) {
+            File::delete($transcode->location);
+        }
+
+        /** @var WebDAVStorage $storage */
+        $storage = app(WebDAVStorage::class);
+        $tmpSource = $storage->copyToLocal($song->storage_metadata->getPath());
+
+        $destination = artifact_path(sprintf('transcodes/%d/%s.m4a', $bitRate, Ulid::generate()));
+        $this->transcoder->transcode($tmpSource, $destination, $bitRate);
+
+        $this->createOrUpdateTranscode(
+            $song,
+            $destination,
+            $bitRate,
+            File::hash($destination),
+            File::size($destination),
+        );
+
+        File::delete($tmpSource);
+
+        return $destination;
+    }
+
+    public function deleteTranscodeFile(string $location, SongStorageType $storageType): void
+    {
+        /** @var WebDAVStorage $storage */
+        $storage = app(WebDAVStorage::class);
+
+        $storage->deleteFileUnderPath(path: $location, backup: false);
+    }
+}

--- a/app/Values/SongStorageMetadata/WebDAVMetadata.php
+++ b/app/Values/SongStorageMetadata/WebDAVMetadata.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Values\SongStorageMetadata;
+
+final class WebDAVMetadata extends SongStorageMetadata
+{
+    private function __construct(
+        public string $path,
+    ) {}
+
+    public static function make(string $key): self
+    {
+        return new self($key);
+    }
+
+    public function getPath(): string
+    {
+        return $this->path;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,8 @@
     "spatie/laravel-permission": "^6.21",
     "enshrined/svg-sanitize": "^0.22.0",
     "phanan/poddle": "^1.2",
-    "laravel/ai": "^0.2.6"
+    "laravel/ai": "^0.2.6",
+    "league/flysystem-webdav": "^3.0"
   },
   "require-dev": {
     "roave/security-advisories": "dev-latest",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e768912310af48ecbbe8b01fb0d42f4e",
+    "content-hash": "a7fd1591f4e0cb5d3eb0466dc0da0e02",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
@@ -3673,6 +3673,54 @@
             "time": "2026-01-23T15:30:45+00:00"
         },
         {
+            "name": "league/flysystem-webdav",
+            "version": "3.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/flysystem-webdav.git",
+                "reference": "1705b5d4aab6d755a78ea850e523dda9c58ad20f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/flysystem-webdav/zipball/1705b5d4aab6d755a78ea850e523dda9c58ad20f",
+                "reference": "1705b5d4aab6d755a78ea850e523dda9c58ad20f",
+                "shasum": ""
+            },
+            "require": {
+                "league/flysystem": "^3.6.0",
+                "php": "^8.0.2",
+                "sabre/dav": "^4.6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\Flysystem\\WebDAV\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frankdejonge.nl"
+                }
+            ],
+            "description": "WebDAV filesystem adapter for Flysystem.",
+            "keywords": [
+                "Flysystem",
+                "WebDAV",
+                "file",
+                "files",
+                "filesystem"
+            ],
+            "support": {
+                "source": "https://github.com/thephpleague/flysystem-webdav/tree/3.31.0"
+            },
+            "time": "2026-01-23T15:30:45+00:00"
+        },
+        {
             "name": "league/mime-type-detection",
             "version": "1.16.0",
             "source": {
@@ -6686,6 +6734,451 @@
                 "source": "https://github.com/revoltphp/event-loop/tree/v1.0.8"
             },
             "time": "2025-08-27T21:33:23+00:00"
+        },
+        {
+            "name": "sabre/dav",
+            "version": "4.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sabre-io/dav.git",
+                "reference": "074373bcd689a30bcf5aaa6bbb20a3395964ce7a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sabre-io/dav/zipball/074373bcd689a30bcf5aaa6bbb20a3395964ce7a",
+                "reference": "074373bcd689a30bcf5aaa6bbb20a3395964ce7a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-date": "*",
+                "ext-dom": "*",
+                "ext-iconv": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "ext-pcre": "*",
+                "ext-simplexml": "*",
+                "ext-spl": "*",
+                "lib-libxml": ">=2.7.0",
+                "php": "^7.1.0 || ^8.0",
+                "psr/log": "^1.0 || ^2.0 || ^3.0",
+                "sabre/event": "^5.0",
+                "sabre/http": "^5.0.5",
+                "sabre/uri": "^2.0",
+                "sabre/vobject": "^4.2.1",
+                "sabre/xml": "^2.0.1"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.19",
+                "monolog/monolog": "^1.27 || ^2.0",
+                "phpstan/phpstan": "^0.12 || ^1.0",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6"
+            },
+            "suggest": {
+                "ext-curl": "*",
+                "ext-imap": "*",
+                "ext-pdo": "*"
+            },
+            "bin": [
+                "bin/sabredav",
+                "bin/naturalselection"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Sabre\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Evert Pot",
+                    "email": "me@evertpot.com",
+                    "homepage": "http://evertpot.com/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "WebDAV Framework for PHP",
+            "homepage": "http://sabre.io/",
+            "keywords": [
+                "CalDAV",
+                "CardDAV",
+                "WebDAV",
+                "framework",
+                "iCalendar"
+            ],
+            "support": {
+                "forum": "https://groups.google.com/group/sabredav-discuss",
+                "issues": "https://github.com/sabre-io/dav/issues",
+                "source": "https://github.com/fruux/sabre-dav"
+            },
+            "time": "2024-10-29T11:46:02+00:00"
+        },
+        {
+            "name": "sabre/event",
+            "version": "5.1.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sabre-io/event.git",
+                "reference": "1dd5f55421b0092006510264131a4d632d02d2c1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sabre-io/event/zipball/1dd5f55421b0092006510264131a4d632d02d2c1",
+                "reference": "1dd5f55421b0092006510264131a4d632d02d2c1",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "~2.17.1||^3.95",
+                "phpstan/phpstan": "^0.12",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/coroutine.php",
+                    "lib/Loop/functions.php",
+                    "lib/Promise/functions.php"
+                ],
+                "psr-4": {
+                    "Sabre\\Event\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Evert Pot",
+                    "email": "me@evertpot.com",
+                    "homepage": "http://evertpot.com/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "sabre/event is a library for lightweight event-based programming",
+            "homepage": "http://sabre.io/event/",
+            "keywords": [
+                "EventEmitter",
+                "async",
+                "coroutine",
+                "eventloop",
+                "events",
+                "hooks",
+                "plugin",
+                "promise",
+                "reactor",
+                "signal"
+            ],
+            "support": {
+                "forum": "https://groups.google.com/group/sabredav-discuss",
+                "issues": "https://github.com/sabre-io/event/issues",
+                "source": "https://github.com/fruux/sabre-event"
+            },
+            "time": "2026-04-27T04:19:36+00:00"
+        },
+        {
+            "name": "sabre/http",
+            "version": "5.1.13",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sabre-io/http.git",
+                "reference": "7c2a14097d1a0de2347dcbdc91a02f38e338f4db"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sabre-io/http/zipball/7c2a14097d1a0de2347dcbdc91a02f38e338f4db",
+                "reference": "7c2a14097d1a0de2347dcbdc91a02f38e338f4db",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-curl": "*",
+                "ext-mbstring": "*",
+                "php": "^7.1 || ^8.0",
+                "sabre/event": ">=4.0 <6.0",
+                "sabre/uri": "^2.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "~2.17.1||3.63.2",
+                "phpstan/phpstan": "^0.12",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6"
+            },
+            "suggest": {
+                "ext-curl": " to make http requests with the Client class"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/functions.php"
+                ],
+                "psr-4": {
+                    "Sabre\\HTTP\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Evert Pot",
+                    "email": "me@evertpot.com",
+                    "homepage": "http://evertpot.com/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "The sabre/http library provides utilities for dealing with http requests and responses. ",
+            "homepage": "https://github.com/fruux/sabre-http",
+            "keywords": [
+                "http"
+            ],
+            "support": {
+                "forum": "https://groups.google.com/group/sabredav-discuss",
+                "issues": "https://github.com/sabre-io/http/issues",
+                "source": "https://github.com/fruux/sabre-http"
+            },
+            "time": "2025-09-09T10:21:47+00:00"
+        },
+        {
+            "name": "sabre/uri",
+            "version": "2.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sabre-io/uri.git",
+                "reference": "b76524c22de90d80ca73143680a8e77b1266c291"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sabre-io/uri/zipball/b76524c22de90d80ca73143680a8e77b1266c291",
+                "reference": "b76524c22de90d80ca73143680a8e77b1266c291",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.63",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^1.12",
+                "phpstan/phpstan-phpunit": "^1.4",
+                "phpstan/phpstan-strict-rules": "^1.6",
+                "phpunit/phpunit": "^9.6"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/functions.php"
+                ],
+                "psr-4": {
+                    "Sabre\\Uri\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Evert Pot",
+                    "email": "me@evertpot.com",
+                    "homepage": "http://evertpot.com/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Functions for making sense out of URIs.",
+            "homepage": "http://sabre.io/uri/",
+            "keywords": [
+                "rfc3986",
+                "uri",
+                "url"
+            ],
+            "support": {
+                "forum": "https://groups.google.com/group/sabredav-discuss",
+                "issues": "https://github.com/sabre-io/uri/issues",
+                "source": "https://github.com/fruux/sabre-uri"
+            },
+            "time": "2024-08-27T12:18:16+00:00"
+        },
+        {
+            "name": "sabre/vobject",
+            "version": "4.5.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sabre-io/vobject.git",
+                "reference": "d554eb24d64232922e1eab5896cc2f84b3b9ffb1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sabre-io/vobject/zipball/d554eb24d64232922e1eab5896cc2f84b3b9ffb1",
+                "reference": "d554eb24d64232922e1eab5896cc2f84b3b9ffb1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^7.1 || ^8.0",
+                "sabre/xml": "^2.1 || ^3.0 || ^4.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "~2.17.1",
+                "phpstan/phpstan": "^0.12 || ^1.12 || ^2.0",
+                "phpunit/php-invoker": "^2.0 || ^3.1",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6"
+            },
+            "suggest": {
+                "hoa/bench": "If you would like to run the benchmark scripts"
+            },
+            "bin": [
+                "bin/vobject",
+                "bin/generate_vcards"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Sabre\\VObject\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Evert Pot",
+                    "email": "me@evertpot.com",
+                    "homepage": "http://evertpot.com/",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Dominik Tobschall",
+                    "email": "dominik@fruux.com",
+                    "homepage": "http://tobschall.de/",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Ivan Enderlin",
+                    "email": "ivan.enderlin@hoa-project.net",
+                    "homepage": "http://mnt.io/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "The VObject library for PHP allows you to easily parse and manipulate iCalendar and vCard objects",
+            "homepage": "http://sabre.io/vobject/",
+            "keywords": [
+                "availability",
+                "freebusy",
+                "iCalendar",
+                "ical",
+                "ics",
+                "jCal",
+                "jCard",
+                "recurrence",
+                "rfc2425",
+                "rfc2426",
+                "rfc2739",
+                "rfc4770",
+                "rfc5545",
+                "rfc5546",
+                "rfc6321",
+                "rfc6350",
+                "rfc6351",
+                "rfc6474",
+                "rfc6638",
+                "rfc6715",
+                "rfc6868",
+                "vCalendar",
+                "vCard",
+                "vcf",
+                "xCal",
+                "xCard"
+            ],
+            "support": {
+                "forum": "https://groups.google.com/group/sabredav-discuss",
+                "issues": "https://github.com/sabre-io/vobject/issues",
+                "source": "https://github.com/fruux/sabre-vobject"
+            },
+            "time": "2026-01-12T10:45:19+00:00"
+        },
+        {
+            "name": "sabre/xml",
+            "version": "2.2.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sabre-io/xml.git",
+                "reference": "01a7927842abf3e10df3d9c2d9b0cc9d813a3fcc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sabre-io/xml/zipball/01a7927842abf3e10df3d9c2d9b0cc9d813a3fcc",
+                "reference": "01a7927842abf3e10df3d9c2d9b0cc9d813a3fcc",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-xmlreader": "*",
+                "ext-xmlwriter": "*",
+                "lib-libxml": ">=2.6.20",
+                "php": "^7.1 || ^8.0",
+                "sabre/uri": ">=1.0,<3.0.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "~2.17.1||3.63.2",
+                "phpstan/phpstan": "^0.12",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/Deserializer/functions.php",
+                    "lib/Serializer/functions.php"
+                ],
+                "psr-4": {
+                    "Sabre\\Xml\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Evert Pot",
+                    "email": "me@evertpot.com",
+                    "homepage": "http://evertpot.com/",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Markus Staab",
+                    "email": "markus.staab@redaxo.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "sabre/xml is an XML library that you may not hate.",
+            "homepage": "https://sabre.io/xml/",
+            "keywords": [
+                "XMLReader",
+                "XMLWriter",
+                "dom",
+                "xml"
+            ],
+            "support": {
+                "forum": "https://groups.google.com/group/sabredav-discuss",
+                "issues": "https://github.com/sabre-io/xml/issues",
+                "source": "https://github.com/fruux/sabre-xml"
+            },
+            "time": "2024-09-06T07:37:46+00:00"
         },
         {
             "name": "saloonphp/laravel-plugin",

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -2,43 +2,43 @@
 
 return [
     /*
-    |--------------------------------------------------------------------------
-    | Default Filesystem Disk
-    |--------------------------------------------------------------------------
-    |
-    | Here you may specify the default filesystem disk that should be used
-    | by the framework. A "local" driver, as well as a variety of cloud
-    | based drivers are available for your choosing. Just store away!
-    |
-    | Supported: "local", "ftp", "s3", "rackspace"
-    |
-    */
+     |--------------------------------------------------------------------------
+     | Default Filesystem Disk
+     |--------------------------------------------------------------------------
+     |
+     | Here you may specify the default filesystem disk that should be used
+     | by the framework. A "local" driver, as well as a variety of cloud
+     | based drivers are available for your choosing. Just store away!
+     |
+     | Supported: "local", "ftp", "s3", "rackspace"
+     |
+     */
 
     'default' => 'local',
 
     /*
-    |--------------------------------------------------------------------------
-    | Default Cloud Filesystem Disk
-    |--------------------------------------------------------------------------
-    |
-    | Many applications store files both locally and in the cloud. For this
-    | reason, you may specify a default "cloud" driver here. This driver
-    | will be bound as the Cloud disk implementation in the container.
-    |
-    */
+     |--------------------------------------------------------------------------
+     | Default Cloud Filesystem Disk
+     |--------------------------------------------------------------------------
+     |
+     | Many applications store files both locally and in the cloud. For this
+     | reason, you may specify a default "cloud" driver here. This driver
+     | will be bound as the Cloud disk implementation in the container.
+     |
+     */
 
     'cloud' => 's3',
 
     /*
-    |--------------------------------------------------------------------------
-    | Filesystem Disks
-    |--------------------------------------------------------------------------
-    |
-    | Here you may configure as many filesystem "disks" as you wish, and you
-    | may even configure multiple disks of the same driver. Defaults have
-    | been setup for each driver as an example of the required options.
-    |
-    */
+     |--------------------------------------------------------------------------
+     | Filesystem Disks
+     |--------------------------------------------------------------------------
+     |
+     | Here you may configure as many filesystem "disks" as you wish, and you
+     | may even configure multiple disks of the same driver. Defaults have
+     | been setup for each driver as an example of the required options.
+     |
+     */
 
     'disks' => [
         'local' => [
@@ -91,6 +91,15 @@ return [
 
             'privateKey' => env('SFTP_PRIVATE_KEY'),
             'passphrase' => env('SFTP_PASSPHRASE'),
+            'throw' => true,
+        ],
+
+        'webdav' => [
+            'driver' => 'webdav',
+            'baseUri' => rtrim((string) env('WEBDAV_BASE_URL', ''), '/') . '/',
+            'userName' => env('WEBDAV_USERNAME', ''),
+            'password' => env('WEBDAV_PASSWORD', ''),
+            'pathPrefix' => trim((string) env('WEBDAV_PATH_PREFIX', ''), '/'),
             'throw' => true,
         ],
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -84,7 +84,7 @@ Required when `STORAGE_DRIVER=webdav`.
 | Variable | Description | Default |
 |---|---|---|
 | `WEBDAV_BASE_URL` | The WebDAV base URL. For NextCloud, this looks like `https://your-nextcloud.example/remote.php/dav/files/<username>/`. | _(empty)_ |
-| `WEBDAV_USERNAME` | The WebDAV username. For NextCloud, use a dedicated [app password](https://docs.nextcloud.com/server/latest/user_manual/en/session_management.html#managing-devices) rather than the account password. | _(empty)_ |
+| `WEBDAV_USERNAME` | The WebDAV username. For NextCloud, use a dedicated app password rather than the account password. | _(empty)_ |
 | `WEBDAV_PASSWORD` | The WebDAV password (or NextCloud app password). | _(empty)_ |
 | `WEBDAV_PATH_PREFIX` | Optional path prefix beneath the base URL where Koel stores its media (no leading or trailing slash). For example: `Music`. | _(empty)_ |
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -84,7 +84,7 @@ Required when `STORAGE_DRIVER=webdav`.
 | Variable | Description | Default |
 |---|---|---|
 | `WEBDAV_BASE_URL` | The WebDAV base URL. For NextCloud, this looks like `https://your-nextcloud.example/remote.php/dav/files/<username>/`. | _(empty)_ |
-| `WEBDAV_USERNAME` | The WebDAV username. For NextCloud, use a dedicated [app password](https://docs.nextcloud.com/server/latest/user_manual/en/session_management.html#device-specific-passwords-and-password-changes) rather than the account password. | _(empty)_ |
+| `WEBDAV_USERNAME` | The WebDAV username. For NextCloud, use a dedicated [app password](https://docs.nextcloud.com/server/latest/user_manual/en/session_management.html#managing-devices) rather than the account password. | _(empty)_ |
 | `WEBDAV_PASSWORD` | The WebDAV password (or NextCloud app password). | _(empty)_ |
 | `WEBDAV_PATH_PREFIX` | Optional path prefix beneath the base URL where Koel stores its media (no leading or trailing slash). For example: `Music`. | _(empty)_ |
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -18,7 +18,7 @@ for details.
 
 | Variable | Description | Default |
 |---|---|---|
-| `STORAGE_DRIVER` | The storage driver for your media files. Valid values: `local`, `sftp`, `s3` (Koel Plus), `dropbox` (Koel Plus). See [Cloud Storage Support](plus/cloud-storage-support). | `local` |
+| `STORAGE_DRIVER` | The storage driver for your media files. Valid values: `local`, `sftp`, `s3` (Koel Plus), `dropbox` (Koel Plus), `webdav` (Koel Plus). See [Cloud Storage Support](plus/cloud-storage-support). | `local` |
 | `MEDIA_PATH` | The absolute path to your media directory. Required when using `STORAGE_DRIVER=local`. Can also be changed via the web interface. | _(empty)_ |
 | `ARTIFACTS_PATH` | The absolute path to store Koel artifacts (transcoded files, podcast episodes, temporary downloads, etc.). If empty, uses the system's temporary directory. | _(empty)_ |
 | `LARAVEL_STORAGE_PATH` | Absolute path Koel uses for writable runtime data — album/artist images (under `app/public/images`), logs, search indexes, framework cache, sessions. Set this to keep mutable state outside the application directory (read-only deploys, multi-instance setups, etc.). After setting it, run `php artisan storage:link` (or `composer koel:init`) so `public/storage` symlinks to `LARAVEL_STORAGE_PATH/app/public`. | `<app>/storage` |
@@ -76,6 +76,10 @@ Required when `STORAGE_DRIVER=sftp`.
 | `SFTP_PASSWORD` | The SFTP password. | _(empty)_ |
 | `SFTP_PRIVATE_KEY` | Path to the private key for key-based authentication (alternative to password). | _(empty)_ |
 | `SFTP_PASSPHRASE` | The passphrase for the private key. | _(empty)_ |
+| `WEBDAV_BASE_URL` | The WebDAV base URL. For NextCloud, this looks like `https://your-nextcloud.example/remote.php/dav/files/<username>/`. Required when `STORAGE_DRIVER=webdav`. | _(empty)_ |
+| `WEBDAV_USERNAME` | The WebDAV username. For NextCloud, use a dedicated [app password](https://docs.nextcloud.com/server/latest/user_manual/en/session_management.html#managing-devices) rather than the account password. | _(empty)_ |
+| `WEBDAV_PASSWORD` | The WebDAV password (or NextCloud app password). | _(empty)_ |
+| `WEBDAV_PATH_PREFIX` | Optional path prefix beneath the base URI where Koel stores its media (no leading or trailing slash). For example: `Music`. | _(empty)_ |
 
 ## Media Scanning
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -76,10 +76,17 @@ Required when `STORAGE_DRIVER=sftp`.
 | `SFTP_PASSWORD` | The SFTP password. | _(empty)_ |
 | `SFTP_PRIVATE_KEY` | Path to the private key for key-based authentication (alternative to password). | _(empty)_ |
 | `SFTP_PASSPHRASE` | The passphrase for the private key. | _(empty)_ |
-| `WEBDAV_BASE_URL` | The WebDAV base URL. For NextCloud, this looks like `https://your-nextcloud.example/remote.php/dav/files/<username>/`. Required when `STORAGE_DRIVER=webdav`. | _(empty)_ |
+
+### WebDAV
+
+Required when `STORAGE_DRIVER=webdav`.
+
+| Variable | Description | Default |
+|---|---|---|
+| `WEBDAV_BASE_URL` | The WebDAV base URL. For NextCloud, this looks like `https://your-nextcloud.example/remote.php/dav/files/<username>/`. | _(empty)_ |
 | `WEBDAV_USERNAME` | The WebDAV username. For NextCloud, use a dedicated [app password](https://docs.nextcloud.com/server/latest/user_manual/en/session_management.html#managing-devices) rather than the account password. | _(empty)_ |
 | `WEBDAV_PASSWORD` | The WebDAV password (or NextCloud app password). | _(empty)_ |
-| `WEBDAV_PATH_PREFIX` | Optional path prefix beneath the base URI where Koel stores its media (no leading or trailing slash). For example: `Music`. | _(empty)_ |
+| `WEBDAV_PATH_PREFIX` | Optional path prefix beneath the base URL where Koel stores its media (no leading or trailing slash). For example: `Music`. | _(empty)_ |
 
 ## Media Scanning
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -84,7 +84,7 @@ Required when `STORAGE_DRIVER=webdav`.
 | Variable | Description | Default |
 |---|---|---|
 | `WEBDAV_BASE_URL` | The WebDAV base URL. For NextCloud, this looks like `https://your-nextcloud.example/remote.php/dav/files/<username>/`. | _(empty)_ |
-| `WEBDAV_USERNAME` | The WebDAV username. For NextCloud, use a dedicated app password rather than the account password. | _(empty)_ |
+| `WEBDAV_USERNAME` | The WebDAV username. For NextCloud, use a dedicated [app password](https://docs.nextcloud.com/server/latest/user_manual/en/session_management.html#device-specific-passwords-and-password-changes) rather than the account password. | _(empty)_ |
 | `WEBDAV_PASSWORD` | The WebDAV password (or NextCloud app password). | _(empty)_ |
 | `WEBDAV_PATH_PREFIX` | Optional path prefix beneath the base URL where Koel stores its media (no leading or trailing slash). For example: `Music`. | _(empty)_ |
 

--- a/docs/plus/cloud-storage-support.md
+++ b/docs/plus/cloud-storage-support.md
@@ -168,7 +168,7 @@ WEBDAV_PATH_PREFIX=
 ```
 
 :::warning Use an app password
-For NextCloud, consider creating a dedicated app password instead of using your account password, so you can revoke Koel's access without affecting other clients.
+For NextCloud, consider creating a dedicated [app password](https://docs.nextcloud.com/server/latest/user_manual/en/session_management.html#device-specific-passwords-and-password-changes) instead of using your account password, so you can revoke Koel's access without affecting other clients.
 :::
 
 <script lang="ts" setup>

--- a/docs/plus/cloud-storage-support.md
+++ b/docs/plus/cloud-storage-support.md
@@ -168,7 +168,7 @@ WEBDAV_PATH_PREFIX=
 ```
 
 :::warning Use an app password
-For NextCloud, consider creating a dedicated [app password](https://docs.nextcloud.com/server/latest/user_manual/en/session_management.html#device-specific-passwords-and-password-changes) instead of using your account password, so you can revoke Koel's access without affecting other clients.
+For NextCloud, consider creating a dedicated [app password](https://docs.nextcloud.com/server/latest/user_manual/en/session_management.html#managing-devices) instead of using your account password, so you can revoke Koel's access without affecting other clients.
 :::
 
 <script lang="ts" setup>

--- a/docs/plus/cloud-storage-support.md
+++ b/docs/plus/cloud-storage-support.md
@@ -168,7 +168,7 @@ WEBDAV_PATH_PREFIX=
 ```
 
 :::warning Use an app password
-For NextCloud, consider creating a dedicated [app password](https://docs.nextcloud.com/server/latest/user_manual/en/session_management.html#managing-devices) instead of using your account password, so you can revoke Koel's access without affecting other clients.
+For NextCloud, consider creating a dedicated app password instead of using your account password, so you can revoke Koel's access without affecting other clients.
 :::
 
 <script lang="ts" setup>

--- a/docs/plus/cloud-storage-support.md
+++ b/docs/plus/cloud-storage-support.md
@@ -153,7 +153,7 @@ Koel Plus can use any WebDAV server as a storage backend, including [NextCloud](
 
 Add the following to your `.env` file:
 
-```
+```dotenv
 STORAGE_DRIVER=webdav
 
 # For NextCloud, the base URL looks like:
@@ -162,7 +162,7 @@ WEBDAV_BASE_URL=
 WEBDAV_USERNAME=
 WEBDAV_PASSWORD=
 
-# Optional path prefix beneath the base URI where Koel stores its media (no leading or trailing slash).
+# Optional path prefix beneath the base URL where Koel stores its media (no leading or trailing slash).
 # For example: Music
 WEBDAV_PATH_PREFIX=
 ```

--- a/docs/plus/cloud-storage-support.md
+++ b/docs/plus/cloud-storage-support.md
@@ -1,11 +1,11 @@
 ---
-description: Setting up SFTP, Amazon S3, DigitalOcean Spaces, Cloudflare R2, and Dropbox as Koel storage drivers.
+description: Setting up SFTP, Amazon S3, DigitalOcean Spaces, Cloudflare R2, Dropbox, and WebDAV (NextCloud, Owncloud) as Koel storage drivers.
 ---
 
 # Cloud Storage Support
 
 In addition to storing your music on the same server as Koel’s installation via the `local` storage drivers,
-Koel Plus offers several different file storage options, including SFTP, Amazon S3, S3-compatible services, Dropbox, and likely more in the future.
+Koel Plus offers several different file storage options, including SFTP, Amazon S3, S3-compatible services, Dropbox, WebDAV, and likely more in the future.
 This page will guide you through the process of setting up these storage options.
 
 :::warning Warning
@@ -145,6 +145,30 @@ Now when you upload music files to Koel, they'll be stored in your Dropbox app's
 
 :::warning Two-way sync not supported
 Koel does not support two-way sync with Dropbox — at least not yet. This means manual changes made to your Dropbox folder will not be reflected in Koel.
+:::
+
+## WebDAV (NextCloud, Owncloud, …)
+
+Koel Plus can use any WebDAV server as a storage backend, including [NextCloud](https://nextcloud.com/), [Owncloud](https://owncloud.com/), or a plain WebDAV server.
+
+Add the following to your `.env` file:
+
+```
+STORAGE_DRIVER=webdav
+
+# For NextCloud, the base URL looks like:
+#   https://your-nextcloud.example/remote.php/dav/files/<username>/
+WEBDAV_BASE_URL=
+WEBDAV_USERNAME=
+WEBDAV_PASSWORD=
+
+# Optional path prefix beneath the base URI where Koel stores its media (no leading or trailing slash).
+# For example: Music
+WEBDAV_PATH_PREFIX=
+```
+
+:::warning Use an app password
+For NextCloud, consider creating a dedicated [app password](https://docs.nextcloud.com/server/latest/user_manual/en/session_management.html#managing-devices) instead of using your account password, so you can revoke Koel's access without affecting other clients.
 :::
 
 <script lang="ts" setup>

--- a/tests/Integration/KoelPlus/Services/SongStorages/WebDAVStorageTest.php
+++ b/tests/Integration/KoelPlus/Services/SongStorages/WebDAVStorageTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Integration\KoelPlus\Services\SongStorages;
+
+use App\Helpers\Ulid;
+use App\Services\SongStorages\WebDAVStorage;
+use App\Values\UploadReference;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PlusTestCase;
+
+use function Tests\create_user;
+use function Tests\test_path;
+
+class WebDAVStorageTest extends PlusTestCase
+{
+    private WebDAVStorage $service;
+    private string $uploadedFilePath;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Storage::fake('webdav');
+        $this->service = app(WebDAVStorage::class);
+        File::copy(test_path('songs/full.mp3'), artifact_path('tmp/random/song.mp3'));
+        $this->uploadedFilePath = artifact_path('tmp/random/song.mp3');
+    }
+
+    #[Test]
+    public function storeUploadedFile(): void
+    {
+        Ulid::freeze('random');
+        $user = create_user();
+        $reference = $this->service->storeUploadedFile($this->uploadedFilePath, $user);
+
+        Storage::disk('webdav')->assertExists(Str::after($reference->location, 'webdav://'));
+
+        self::assertSame("webdav://{$user->id}__random__song.mp3", $reference->location);
+        self::assertSame(artifact_path('tmp/random/song.mp3'), $reference->localPath);
+    }
+
+    #[Test]
+    public function undoUpload(): void
+    {
+        Storage::disk('webdav')->put('123__random__song.mp3', 'fake content');
+        File::expects('delete')->with('/tmp/random/song.mp3');
+
+        $reference = UploadReference::make(
+            location: 'webdav://123__random__song.mp3',
+            localPath: '/tmp/random/song.mp3',
+        );
+
+        $this->service->undoUpload($reference);
+    }
+
+    #[Test]
+    public function deleteSong(): void
+    {
+        $reference = $this->service->storeUploadedFile($this->uploadedFilePath, create_user());
+        $remotePath = Str::after($reference->location, 'webdav://');
+        Storage::disk('webdav')->assertExists($remotePath);
+
+        $this->service->delete($remotePath);
+
+        Storage::disk('webdav')->assertMissing($remotePath);
+    }
+
+    #[Test]
+    public function copyToLocal(): void
+    {
+        Storage::disk('webdav')->put('music/test-song.mp3', 'fake mp3 content');
+
+        $localPath = $this->service->copyToLocal('music/test-song.mp3');
+
+        self::assertStringEqualsFile($localPath, 'fake mp3 content');
+    }
+}

--- a/tests/Integration/KoelPlus/Services/Streamer/StreamerTest.php
+++ b/tests/Integration/KoelPlus/Services/Streamer/StreamerTest.php
@@ -8,6 +8,7 @@ use App\Services\Streamer\Adapters\DropboxStreamerAdapter;
 use App\Services\Streamer\Adapters\LocalStreamerAdapter;
 use App\Services\Streamer\Adapters\S3CompatibleStreamerAdapter;
 use App\Services\Streamer\Adapters\SftpStreamerAdapter;
+use App\Services\Streamer\Adapters\WebDAVStreamerAdapter;
 use App\Services\Streamer\Streamer;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\Integration\KoelPlus\Services\TestingDropboxStorage;
@@ -45,6 +46,10 @@ class StreamerTest extends PlusTestCase
 
                 case SongStorageType::SFTP:
                     self::assertInstanceOf(SftpStreamerAdapter::class, $streamer->getAdapter());
+                    break;
+
+                case SongStorageType::WEBDAV:
+                    self::assertInstanceOf(WebDAVStreamerAdapter::class, $streamer->getAdapter());
                     break;
 
                 default:


### PR DESCRIPTION
Closes #2209.

## Summary

Adds **WebDAV** as a Koel Plus storage backend, supporting NextCloud, Owncloud, and any plain WebDAV server.

## Configuration

```
STORAGE_DRIVER=webdav

# For NextCloud, looks like https://your-nextcloud.example/remote.php/dav/files/<username>/
WEBDAV_BASE_URL=
WEBDAV_USERNAME=
WEBDAV_PASSWORD=

# Optional subfolder inside the base URL where Koel stores its media
WEBDAV_PATH_PREFIX=
```

NextCloud users should pair this with a dedicated [app password](https://docs.nextcloud.com/server/latest/user_manual/en/session_management.html#managing-devices) rather than the account password — covered in the docs callout.

## Implementation

Slots into koel's existing storage abstraction via a new `SongStorageType::WEBDAV` case wired through the four established factories:

- `SongStorageFactory` → `WebDAVStorage` (Flysystem-backed upload/delete/copy-to-local, mirrors `SftpStorage`)
- `Streamer::resolveAdapter` → `WebDAVStreamerAdapter` (copy-to-local then range-aware local stream via the existing `StreamsLocalPath` trait)
- `TranscodeStrategyFactory` → `WebDAVTranscodingStrategy` (mirrors `SftpTranscodingStrategy`)
- `HasSongAttributes::storageMetadata()` → `WebDAVMetadata` (parses `webdav://...` storage URIs)

The disk driver itself isn't shipped by Laravel out of the box, so `SongStorageServiceProvider::boot()` registers `Storage::extend('webdav', ...)` that wires Sabre DAV's `Client` through `league/flysystem-webdav`'s adapter into Laravel's filesystem facade.

One non-obvious workaround in `WebDAVStorage::storeUploadedFile`: the PUT buffers in memory (via `File::get`) rather than streaming with `fopen`, because Cloudflare-fronted NextCloud terminates streaming PUTs with HTTP/2 `INTERNAL_ERROR` when `Content-Length` isn't fixed up-front. Comment in code explains why.

## Streaming behavior

Streams use a copy-to-local approach (download to `artifact_path('tmp/…')` then range-serve from disk) identical to the existing SFTP behavior. This is a deliberate v1 choice — a true stream-proxy (forwarding bytes through Koel without touching disk) was attempted but the Laravel HTTP client + StreamedResponse path didn't reliably surface chunks to the client. Worth revisiting as a follow-up optimization.

## Composer dependency

Adds `league/flysystem-webdav: ^3.0` (which pulls in `sabre/dav: ^4.6`). Matches the version family of the existing `league/flysystem-aws-s3-v3` and `league/flysystem-sftp-v3`.

## Tests

- `tests/Integration/KoelPlus/Services/SongStorages/WebDAVStorageTest.php` — store/undo/delete/copy-to-local against `Storage::fake('webdav')`
- `tests/Integration/KoelPlus/Services/Streamer/StreamerTest.php` — extended to cover the new `WEBDAV` case in the adapter-resolver matrix

## Test plan

- [x] Set up a NextCloud instance (or use any WebDAV server)
- [x] Configure the four `WEBDAV_*` env vars in `.env`, `STORAGE_DRIVER=webdav`, run `php artisan config:clear`
- [x] Upload a track via the Koel UI — verify file lands in the configured NextCloud folder
- [x] Play the uploaded track — confirm playback with seeking works
- [x] Delete a track — verify removal from NextCloud


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added WebDAV storage support for uploads, streaming, and transcoding (Nextcloud/Owncloud-compatible).

* **Documentation**
  * Documented WebDAV configuration in environment and cloud-storage docs.
  * Standardized project guidelines and tooling docs to Tailwind CSS v4.

* **Bug Fixes**
  * Improved SFTP stream handling and ensured temporary files are always cleaned up during transcoding.

* **Tests**
  * Added integration tests for WebDAV storage and streamer adapter resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2495?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->