### PR TITLE
test: harden proxy-auth coverage + Caddy E2E in CI

### DIFF
--- a/.github/workflows/test-proxy-auth-e2e.yml
+++ b/.github/workflows/test-proxy-auth-e2e.yml
@@ -130,15 +130,15 @@ jobs:
       - name: Wait for services
         run: |
           for attempt in $(seq 1 30); do
-              koel_ok=$(curl -fsS -o /dev/null -w '%{http_code}' http://127.0.0.1:8000/ || echo 0)
-              caddy_ok=$(curl -fsS -o /dev/null -w '%{http_code}' http://127.0.0.1:8001/ || echo 0)
+              koel_ok=$(curl -sS -o /dev/null -w '%{http_code}' http://127.0.0.1:8000/ 2>/dev/null || echo 0)
+              caddy_ok=$(curl -sS -o /dev/null -w '%{http_code}' http://127.0.0.1:8001/ 2>/dev/null || echo 0)
               if [ "$koel_ok" = "200" ] && [ "$caddy_ok" = "401" ]; then
                   echo "Koel ready on :8000, Caddy ready on :8001 (challenging basic auth as expected)"
                   exit 0
               fi
               sleep 1
           done
-          echo "Services did not come up in time. Koel log:"
+          echo "Services did not come up in time (last koel=$koel_ok caddy=$caddy_ok). Koel log:"
           cat /tmp/koel.log
           echo "Caddy log:"
           cat /tmp/caddy.log

--- a/.github/workflows/test-proxy-auth-e2e.yml
+++ b/.github/workflows/test-proxy-auth-e2e.yml
@@ -1,0 +1,192 @@
+name: Proxy Auth E2E
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - app/Services/Auth/ProxyAuthService.php
+      - app/Values/User/SsoUser.php
+      - app/Exceptions/ProxyAuth*.php
+      - app/Http/Controllers/IndexController.php
+      - config/koel.php
+      - tests/Feature/KoelPlus/ProxyAuthTest.php
+      - .github/workflows/test-proxy-auth-e2e.yml
+  push:
+    branches:
+      - master
+    paths:
+      - app/Services/Auth/ProxyAuthService.php
+      - app/Values/User/SsoUser.php
+      - app/Exceptions/ProxyAuth*.php
+      - app/Http/Controllers/IndexController.php
+      - config/koel.php
+      - tests/Feature/KoelPlus/ProxyAuthTest.php
+      - .github/workflows/test-proxy-auth-e2e.yml
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    name: Caddy reverse-proxy auth flow
+    runs-on: ubuntu-latest
+    # Skip on fork PRs — secrets.KOEL_PLUS_LICENSE_KEY isn't available there.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.3
+          tools: composer:v2
+          extensions: pdo_sqlite, sqlite3, zip, gd
+
+      - name: Install PHP dependencies
+        uses: ramsey/composer-install@v2
+        with:
+          composer-options: --prefer-dist
+
+      - name: Configure Koel for proxy auth
+        run: |
+          cp .env.example .env
+          php artisan key:generate --quiet
+          touch database/database.sqlite
+          sed -i 's|^DB_CONNECTION=.*|DB_CONNECTION=sqlite|' .env
+          sed -i '/^DB_HOST=/d;/^DB_PORT=/d;/^DB_DATABASE=/d;/^DB_USERNAME=/d;/^DB_PASSWORD=/d' .env
+          sed -i 's|^PROXY_AUTH_ENABLED=.*|PROXY_AUTH_ENABLED=true|' .env
+          sed -i 's|^PROXY_AUTH_USER_HEADER=.*|PROXY_AUTH_USER_HEADER=remote-user|' .env
+          sed -i 's|^PROXY_AUTH_PREFERRED_NAME_HEADER=.*|PROXY_AUTH_PREFERRED_NAME_HEADER=remote-preferred-name|' .env
+          sed -i 's|^PROXY_AUTH_ALLOW_LIST=.*|PROXY_AUTH_ALLOW_LIST=127.0.0.1|' .env
+          php artisan migrate --force
+
+      - name: Stub Vite manifest
+        # We don't need a real frontend build for this test — just enough manifest entries so blade's @vite()
+        # call resolves and the HTML response renders without throwing.
+        run: |
+          mkdir -p public/build
+          cat > public/build/manifest.json <<'EOF'
+          {
+            "resources/assets/js/app.ts": {
+              "file": "assets/app.js",
+              "src": "resources/assets/js/app.ts",
+              "isEntry": true
+            }
+          }
+          EOF
+
+      - name: Activate Koel Plus license
+        env:
+          KOEL_PLUS_LICENSE_KEY: ${{ secrets.KOEL_PLUS_LICENSE_KEY }}
+        # Output is swallowed because the command prints the licensee's name and email on success.
+        # The secret value itself is auto-masked by GitHub Actions in any log output.
+        run: |
+          if [ -z "$KOEL_PLUS_LICENSE_KEY" ]; then
+              echo "KOEL_PLUS_LICENSE_KEY secret is not set."
+              exit 1
+          fi
+          php artisan koel:license:activate "$KOEL_PLUS_LICENSE_KEY" >/dev/null 2>&1 || {
+              echo "License activation failed (network or invalid key)."
+              exit 1
+          }
+
+      - name: Install Caddy
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends debian-keyring debian-archive-keyring apt-transport-https curl
+          curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+          curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-stable.list >/dev/null
+          sudo apt-get update -qq
+          sudo apt-get install -y caddy
+          sudo systemctl stop caddy || true
+
+      - name: Write Caddyfile
+        run: |
+          PASS_HASH=$(caddy hash-password --plaintext 'koeltest')
+          cat > /tmp/Caddyfile <<EOF
+          {
+              admin off
+              auto_https off
+          }
+          :8001 {
+              basic_auth {
+                  alice ${PASS_HASH}
+              }
+              reverse_proxy 127.0.0.1:8000 {
+                  header_up remote-user {http.auth.user.id}
+                  header_up remote-preferred-name "Alice (CI)"
+              }
+          }
+          EOF
+
+      - name: Start Koel
+        run: nohup php artisan serve --host=127.0.0.1 --port=8000 > /tmp/koel.log 2>&1 &
+
+      - name: Start Caddy
+        run: nohup caddy run --config /tmp/Caddyfile > /tmp/caddy.log 2>&1 &
+
+      - name: Wait for services
+        run: |
+          for attempt in $(seq 1 30); do
+              koel_ok=$(curl -fsS -o /dev/null -w '%{http_code}' http://127.0.0.1:8000/ || echo 0)
+              caddy_ok=$(curl -fsS -o /dev/null -w '%{http_code}' http://127.0.0.1:8001/ || echo 0)
+              if [ "$koel_ok" = "200" ] && [ "$caddy_ok" = "401" ]; then
+                  echo "Koel ready on :8000, Caddy ready on :8001 (challenging basic auth as expected)"
+                  exit 0
+              fi
+              sleep 1
+          done
+          echo "Services did not come up in time. Koel log:"
+          cat /tmp/koel.log
+          echo "Caddy log:"
+          cat /tmp/caddy.log
+          exit 1
+
+      - name: Verify proxy-auth round-trip
+        run: |
+          set -e
+          # Wrong password — Caddy must reject before reaching Koel.
+          status=$(curl -s -o /dev/null -w '%{http_code}' -u 'alice:wrong' http://127.0.0.1:8001/)
+          if [ "$status" != "401" ]; then
+              echo "Expected 401 for wrong credentials, got $status"
+              exit 1
+          fi
+          echo "✓ Caddy rejects wrong credentials"
+
+          # Correct password — Caddy forwards with remote-user header set.
+          status=$(curl -s -o /dev/null -w '%{http_code}' -u 'alice:koeltest' http://127.0.0.1:8001/)
+          if [ "$status" != "200" ]; then
+              echo "Expected 200 from successful basic auth + proxy forward, got $status"
+              exit 1
+          fi
+          echo "✓ Caddy forwards authenticated request to Koel"
+
+          # Koel must have provisioned the user via proxy auth.
+          row=$(sqlite3 database/database.sqlite "select email, name, sso_provider from users where sso_provider = 'Reverse Proxy';")
+          expected="alice@reverse.proxy|Alice (CI)|Reverse Proxy"
+          if [ "$row" != "$expected" ]; then
+              echo "User row mismatch. Expected: '$expected', got: '$row'"
+              echo "Koel log tail:"
+              tail -50 storage/logs/laravel.log 2>/dev/null || true
+              exit 1
+          fi
+          echo "✓ Koel provisioned user $row"
+
+          # Hitting Koel directly (bypassing Caddy) with the same header but from a non-allowlisted IP must NOT trigger provisioning.
+          # We can't easily forge REMOTE_ADDR, so instead assert the allow-list rejection by sending without the header through Caddy is impossible
+          # (Caddy always sets it), so we cover this in the unit/feature tests.
+
+      - name: Deactivate Koel Plus license
+        if: always()
+        # Free up the activation slot on LemonSqueezy so repeated CI runs don't exhaust the license's seat limit.
+        # `yes |` feeds the interactive confirm prompt; `|| true` ensures cleanup failures don't fail the job.
+        run: yes | php artisan koel:license:deactivate >/dev/null 2>&1 || true
+
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: proxy-auth-e2e-logs-${{ github.run_id }}
+          path: |
+            storage/logs
+            /tmp/koel.log
+            /tmp/caddy.log

--- a/.github/workflows/test-proxy-auth-e2e.yml
+++ b/.github/workflows/test-proxy-auth-e2e.yml
@@ -25,6 +25,9 @@ on:
       - .github/workflows/test-proxy-auth-e2e.yml
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   e2e:
     name: Caddy reverse-proxy auth flow

--- a/.github/workflows/test-proxy-auth-e2e.yml
+++ b/.github/workflows/test-proxy-auth-e2e.yml
@@ -36,6 +36,8 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
@@ -54,12 +56,25 @@ jobs:
           cp .env.example .env
           php artisan key:generate --quiet
           touch database/database.sqlite
-          sed -i 's|^DB_CONNECTION=.*|DB_CONNECTION=sqlite|' .env
+
+          # Replace the key if present, otherwise append. Defends against the test silently
+          # no-op'ing if .env.example ever loses one of these lines.
+          set_env() {
+              local key=$1 value=$2
+              if grep -q "^${key}=" .env; then
+                  sed -i "s|^${key}=.*|${key}=${value}|" .env
+              else
+                  echo "${key}=${value}" >> .env
+              fi
+          }
+
+          set_env DB_CONNECTION sqlite
           sed -i '/^DB_HOST=/d;/^DB_PORT=/d;/^DB_DATABASE=/d;/^DB_USERNAME=/d;/^DB_PASSWORD=/d' .env
-          sed -i 's|^PROXY_AUTH_ENABLED=.*|PROXY_AUTH_ENABLED=true|' .env
-          sed -i 's|^PROXY_AUTH_USER_HEADER=.*|PROXY_AUTH_USER_HEADER=remote-user|' .env
-          sed -i 's|^PROXY_AUTH_PREFERRED_NAME_HEADER=.*|PROXY_AUTH_PREFERRED_NAME_HEADER=remote-preferred-name|' .env
-          sed -i 's|^PROXY_AUTH_ALLOW_LIST=.*|PROXY_AUTH_ALLOW_LIST=127.0.0.1|' .env
+          set_env PROXY_AUTH_ENABLED true
+          set_env PROXY_AUTH_USER_HEADER remote-user
+          set_env PROXY_AUTH_PREFERRED_NAME_HEADER remote-preferred-name
+          set_env PROXY_AUTH_ALLOW_LIST 127.0.0.1
+
           php artisan migrate --force
 
       - name: Stub Vite manifest

--- a/docs/plus/proxy-auth.md
+++ b/docs/plus/proxy-auth.md
@@ -2,14 +2,10 @@
 description: Configuring reverse proxy authentication via headers and IP allow-lists for Koel Plus.
 ---
 
-# Proxy Authentication <sup>Beta</sup>
+# Proxy Authentication
 
 Koel can be configured to authenticate users via a reverse proxy.
 Proxy authentication is useful in environments where users are already authenticated by a proxy server.
-
-:::warning Beta Feature
-This feature is currently in beta. Expect bugs and rough edges.
-:::
 
 :::danger Caution
 Proxy authentication bypasses Koel's built-in authentication system and relies on the proxy server to authenticate users.
@@ -33,11 +29,3 @@ If proxy authentication isn't logging users in (you keep landing on Koel's passw
 * **`Remote address not in allow list`** — the request reached Koel from an IP not covered by `PROXY_AUTH_ALLOW_LIST`. The log line includes both the observed `remote_addr` and the configured allow list. If your proxy runs in a Docker network or behind another layer, the address Koel sees may not be the one you expect — adjust the allow list or your `TrustProxies` config accordingly.
 * **`User header not present on request`** — Koel got the request but the configured `PROXY_AUTH_USER_HEADER` was missing. This usually means the proxy isn't propagating the header to the upstream request. Caddy users: double-check the `copy_headers` directive in your `forward_auth` block. Traefik / nginx users: confirm the header is in the forward-auth response and isn't being stripped before the upstream call.
 * **`Failed to create or update user from SSO headers`** — Koel received the header but failed to provision the user. The log entry includes the full exception; common causes are organization-membership constraints or invalid email derivation from the identifier.
-
-<style>
-sup {
-  font-size: 0.8rem;
-  text-transform: uppercase;
-  opacity: .8;
-}
-</style>

--- a/tests/Feature/KoelPlus/ProxyAuthTest.php
+++ b/tests/Feature/KoelPlus/ProxyAuthTest.php
@@ -3,9 +3,12 @@
 namespace Tests\Feature\KoelPlus;
 
 use App\Models\User;
+use App\Services\UserService;
 use Illuminate\Support\Facades\Log;
 use Laravel\Sanctum\PersonalAccessToken;
+use Mockery;
 use PHPUnit\Framework\Attributes\Test;
+use RuntimeException;
 use Tests\PlusTestCase;
 
 use function Tests\create_user;
@@ -129,6 +132,88 @@ class ProxyAuthTest extends PlusTestCase
                 static fn (string $message, array $context) => (
                     str_contains($message, 'User header not present')
                     && $context['expected_header'] === 'remote-user'
+                ),
+            )
+            ->once();
+    }
+
+    #[Test]
+    public function proxyAuthenticationIsDisabledWhenAllowListEmpty(): void
+    {
+        config(['koel.proxy_auth.allow_list' => ['']]);
+        Log::spy();
+
+        $response = $this->get('/', [
+            'REMOTE_ADDR' => '192.168.1.127',
+            'remote-user' => '123456',
+        ]);
+
+        $response->assertOk();
+        self::assertNull($response->viewData('token'));
+
+        Log::shouldHaveReceived('warning')
+            ->withArgs(static fn (string $message) => str_contains($message, 'Remote address not in allow list'))
+            ->once();
+    }
+
+    #[Test]
+    public function proxyAuthenticationPreservesEmailWhenIdentifierIsValidEmail(): void
+    {
+        $response = $this->get('/', [
+            'REMOTE_ADDR' => '192.168.1.127',
+            'remote-user' => 'bruce@iron.com',
+            'remote-preferred-name' => 'Bruce Dickinson',
+        ]);
+
+        $response->assertOk();
+        $this->assertDatabaseHas(User::class, [
+            'email' => 'bruce@iron.com',
+            'name' => 'Bruce Dickinson',
+            'sso_id' => 'bruce@iron.com',
+            'sso_provider' => 'Reverse Proxy',
+        ]);
+    }
+
+    #[Test]
+    public function proxyAuthenticationFallsBackToIdentifierWhenPreferredNameMissing(): void
+    {
+        $response = $this->get('/', [
+            'REMOTE_ADDR' => '192.168.1.127',
+            'remote-user' => 'alice',
+        ]);
+
+        $response->assertOk();
+        $this->assertDatabaseHas(User::class, [
+            'email' => 'alice@reverse.proxy',
+            'name' => 'alice',
+            'sso_id' => 'alice',
+            'sso_provider' => 'Reverse Proxy',
+        ]);
+    }
+
+    #[Test]
+    public function proxyAuthenticationLogsErrorWhenProvisioningThrows(): void
+    {
+        Log::spy();
+
+        $this->mock(UserService::class, static function (Mockery\MockInterface $mock): void {
+            $mock->shouldReceive('createOrUpdateUserFromSso')->andThrow(new RuntimeException('provisioning blew up'));
+        });
+
+        $response = $this->get('/', [
+            'REMOTE_ADDR' => '192.168.1.127',
+            'remote-user' => 'alice',
+        ]);
+
+        $response->assertOk();
+        self::assertNull($response->viewData('token'));
+
+        Log::shouldHaveReceived('error')
+            ->withArgs(
+                static fn (string $message, array $context) => (
+                    str_contains($message, 'Failed to create or update user from SSO headers')
+                    && $context['expected_header'] === 'remote-user'
+                    && $context['remote_addr'] === '192.168.1.127'
                 ),
             )
             ->once();


### PR DESCRIPTION
Closes the testability gap that's been holding **Proxy Authentication** in beta. Graduates the feature to GA in the same PR.

## Summary

Three complementary additions:

1. **Four new feature tests** in `tests/Feature/KoelPlus/ProxyAuthTest.php` covering paths the existing suite didn't exercise.
2. **A new CI workflow** (`Reverse-proxy auth flow`) that brings up Caddy as a sidecar reverse proxy and asserts the full round-trip works.
3. **Beta tag removed** from `docs/plus/proxy-auth.md`.

## New PHPUnit feature tests

| Test | Why it matters |
|---|---|
| `proxyAuthenticationIsDisabledWhenAllowListEmpty` | Pins the safety property that an unset `PROXY_AUTH_ALLOW_LIST` env var does NOT auto-allow any request. Without this test, a future "cleanup" of the parsing logic could silently turn every request into a successful proxy auth — a complete bypass. |
| `proxyAuthenticationPreservesEmailWhenIdentifierIsValidEmail` | Verifies that `remote-user: bruce@iron.com` stays as-is (no `@reverse.proxy` suffix appended). |
| `proxyAuthenticationFallsBackToIdentifierWhenPreferredNameMissing` | Confirms the optional `remote-preferred-name` header falls back to the identifier as the display name. |
| `proxyAuthenticationLogsErrorWhenProvisioningThrows` | Exercises the third failure mode documented in `docs/plus/proxy-auth.md` — a `Throwable` during `UserService::createOrUpdateUserFromSso` ends up at `Log::error('Failed to create or update user from SSO headers', …)`. |

## CI E2E workflow

`.github/workflows/test-proxy-auth-e2e.yml` — runs only when proxy-auth-related files change (or on `workflow_dispatch`). Steps:

1. PHP + composer, configure Koel `.env` for proxy auth with sqlite DB (using a `set_env` helper that handles append-if-missing for `.env.example` drift resilience).
2. Stub `public/build/manifest.json` so `@vite()` resolves without a real `pnpm run build`.
3. Install Caddy via the official apt repo, write a Caddyfile with `basic_auth` + `reverse_proxy`, forwarding the `remote-user` header.
4. Start koel (`:8000`) and Caddy (`:8001`) as background sidecars.
5. Three assertions:
   - Wrong basic-auth credentials get a `401` from Caddy.
   - Correct credentials get `200`.
   - The `users` table contains the expected SSO-provisioned row.
6. Cleanup runs in an `if: always()` step.

The job skips on fork PRs via a job-level `if`, uses `persist-credentials: false` on checkout, and runs with `permissions: contents: read`.

## Test plan

- [ ] Trigger the workflow via `workflow_dispatch` or push
- [ ] Verify all three "✓" log lines (Caddy rejects wrong creds, forwards correct creds, koel provisioned the user)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end testing for proxy-based authentication.
  * Expanded test coverage with new proxy-auth scenarios, edge cases and error handling validation.
* **Documentation**
  * Updated Proxy Authentication docs — removed the “Beta” label and related markup for a cleaner guide.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2496?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->