### PR TITLE
ci: rename e2e job to be proxy-agnostic

### DIFF
--- a/.github/workflows/test-proxy-auth-e2e.yml
+++ b/.github/workflows/test-proxy-auth-e2e.yml
@@ -30,7 +30,7 @@ permissions:
 
 jobs:
   e2e:
-    name: Caddy reverse-proxy auth flow
+    name: Reverse-proxy auth flow
     runs-on: ubuntu-latest
     # Skip on fork PRs — secrets.KOEL_PLUS_LICENSE_KEY isn't available there.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository


### PR DESCRIPTION
Follow-up rename that got missed in #2496. The reverse-proxy E2E workflow happens to use Caddy as its driver today, but the job name should describe what's being tested (reverse-proxy auth) rather than the specific tool, so future iterations (nginx, Traefik) don't need a rename.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow naming for clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2498?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->