### PR TITLE
chore: gitignore the public/storage symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,4 +91,5 @@ docs/.vitepress/cache
 demo-credits.json
 
 public/sandbox
+public/storage
 build/


### PR DESCRIPTION
Stops the `Warning: 1 uncommitted change` warning that's been appearing on every `gh pr create`.

`public/storage` is a Laravel-generated symlink (created by `php artisan storage:link`) that points at `storage/app/public`. It's a runtime artifact regenerated by `composer koel:init` and never something a contributor should commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to exclude a storage directory from version control.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2503?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->