### PR TITLE
docs: advertise WebDAV on the Koel Plus landing page

### DIFF
--- a/docs/plus/what-is-koel-plus.md
+++ b/docs/plus/what-is-koel-plus.md
@@ -11,7 +11,7 @@ Koel Plus is the premium version of Koel. It offers additional features and enha
 - **Multi-library Support**: Each user has their own library, which they populate by uploading their own music.
 - **Music Sharing**: By default, uploaded music is private to the user who uploaded it. However, users can choose to share their music with others by marking songs as public.
 - **[Collaboration](./collaboration)**: Invite other users to collaborate on playlists, allowing them to add, remove, and reorder songs.
-- **[Cloud Storage Support](./cloud-storage-support)**: Remote and cloud storage drivers like SFTP, Amazon S3 (or any S3-compatible service), and Dropbox, are supported in addition to local storage.
+- **[Cloud Storage Support](./cloud-storage-support)**: Remote and cloud storage drivers like SFTP, Amazon S3 (or any S3-compatible service), Dropbox, and WebDAV (NextCloud, Owncloud, …) are supported in addition to local storage.
 - **[Single Sign-On (SSO) Support](./sso)**: Log in with your existing credentials from another service like Google.
 - **[Authentication via Proxy-Authorization Header](./proxy-auth)**: Seamlessly log in users already authenticated via a proxy server, allowing Koel to be used in a corporate environment.
 - **[Media Browser](./media-browser)**: A file-explorer-like interface that allows browsing music directly at a file level, useful for libraries without proper ID3 tagging.


### PR DESCRIPTION
WebDAV storage shipped in #2495 and is fully documented in `docs/plus/cloud-storage-support.md`, but the Koel Plus landing page (`docs/plus/what-is-koel-plus.md`) was never updated — the cloud-storage bullet still only listed SFTP, S3, and Dropbox. This adds WebDAV (with NextCloud/Owncloud named to match the subpage heading) so the feature isn't invisible to anyone reading the overview.

One-line doc change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Koel Plus documentation to explicitly clarify support for WebDAV-based cloud storage solutions, including NextCloud and Owncloud, as supported remote storage drivers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2504?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->