### PR TITLE
refactor: make Network helper injectable so tests don't need internet

### DIFF
--- a/app/Helpers/Network.php
+++ b/app/Helpers/Network.php
@@ -14,7 +14,7 @@ class Network
      * Does NOT perform any network calls beyond DNS resolution.
      * For full validation including effective-URL-after-redirect, use the SafeUrl validation rule.
      */
-    public static function isSafeUrl(string $url): bool
+    public function isSafeUrl(string $url): bool
     {
         try {
             $uri = Uri::of($url);
@@ -28,14 +28,14 @@ class Network
 
         $host = $uri->host();
 
-        return $host !== '' && self::isPublicHost($host);
+        return $host !== '' && $this->isPublicHost($host);
     }
 
     /**
      * Check if a host resolves only to public (non-private, non-reserved) IP addresses.
      * Validates both A (IPv4) and AAAA (IPv6) records. All resolved IPs must be public.
      */
-    public static function isPublicHost(string $host): bool
+    public function isPublicHost(string $host): bool
     {
         if (filter_var($host, FILTER_VALIDATE_IP)) {
             return (

--- a/app/Rules/SafeUrl.php
+++ b/app/Rules/SafeUrl.php
@@ -19,6 +19,13 @@ class SafeUrl implements ValidationRule
 {
     private const array ALLOWED_SCHEMES = ['http', 'https'];
 
+    private Network $network;
+
+    public function __construct(?Network $network = null)
+    {
+        $this->network = $network ?? app(Network::class);
+    }
+
     /** @param Closure(string, ?string=): PotentiallyTranslatedString $fail */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
@@ -36,7 +43,7 @@ class SafeUrl implements ValidationRule
             return;
         }
 
-        if (!Network::isPublicHost($uri->host())) {
+        if (!$this->network->isPublicHost($uri->host())) {
             $fail('The :attribute must point to a public URL.');
 
             return;
@@ -57,7 +64,7 @@ class SafeUrl implements ValidationRule
 
         $effectiveHost = $response->effectiveUri()?->getHost();
 
-        if ($effectiveHost && !Network::isPublicHost($effectiveHost)) {
+        if ($effectiveHost && !$this->network->isPublicHost($effectiveHost)) {
             $fail('The :attribute must point to a public URL.');
         }
     }

--- a/app/Rules/SafeUrl.php
+++ b/app/Rules/SafeUrl.php
@@ -19,11 +19,10 @@ class SafeUrl implements ValidationRule
 {
     private const array ALLOWED_SCHEMES = ['http', 'https'];
 
-    private Network $network;
-
-    public function __construct(?Network $network = null)
-    {
-        $this->network = $network ?? app(Network::class);
+    public function __construct(
+        private ?Network $network = null,
+    ) {
+        $this->network ??= app(Network::class);
     }
 
     /** @param Closure(string, ?string=): PotentiallyTranslatedString $fail */

--- a/app/Services/Podcast/PodcastService.php
+++ b/app/Services/Podcast/PodcastService.php
@@ -34,6 +34,7 @@ class PodcastService
     public function __construct(
         private readonly PodcastRepository $podcastRepository,
         private readonly SongRepository $songRepository,
+        private readonly Network $network,
         private ?ClientInterface $client = null,
     ) {}
 
@@ -139,7 +140,7 @@ class PodcastService
 
             $enclosureUrl = (string) $episodeValue->enclosure->url;
 
-            if (!Network::isSafeUrl($enclosureUrl)) {
+            if (!$this->network->isSafeUrl($enclosureUrl)) {
                 Log::warning(sprintf(
                     'Skipping podcast episode "%s" with unsafe enclosure URL: %s',
                     $episodeValue->title,
@@ -240,7 +241,7 @@ class PodcastService
     {
         $url = $url instanceof Episode ? $url->path : $url;
 
-        if (!Network::isSafeUrl($url)) {
+        if (!$this->network->isSafeUrl($url)) {
             return null;
         }
 

--- a/app/Values/Podcast/EpisodePlayable.php
+++ b/app/Values/Podcast/EpisodePlayable.php
@@ -10,6 +10,9 @@ use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Http;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\UriInterface;
 
 final class EpisodePlayable implements Arrayable, Jsonable
 {
@@ -25,7 +28,7 @@ final class EpisodePlayable implements Arrayable, Jsonable
 
     public function valid(): bool
     {
-        return File::isReadable($this->path) && $this->checksum === md5_file($this->path);
+        return File::isReadable($this->path) && $this->checksum === File::hash($this->path);
     }
 
     public static function getForEpisode(Episode $episode): self
@@ -52,7 +55,11 @@ final class EpisodePlayable implements Arrayable, Jsonable
                 ->withOptions([
                     'allow_redirects' => [
                         'max' => 5,
-                        'on_redirect' => static function ($request, $response, $uri) use ($network): void {
+                        'on_redirect' => static function (
+                            RequestInterface $request,
+                            ResponseInterface $response,
+                            UriInterface $uri,
+                        ) use ($network): void {
                             if (!$network->isSafeUrl((string) $uri)) {
                                 throw UnsafeUrlException::forUrl((string) $uri);
                             }

--- a/app/Values/Podcast/EpisodePlayable.php
+++ b/app/Values/Podcast/EpisodePlayable.php
@@ -41,9 +41,10 @@ final class EpisodePlayable implements Arrayable, Jsonable
         $file = artifact_path("episodes/{$episode->id}.mp3");
 
         if (!File::exists($file)) {
+            $network = app(Network::class);
             $url = (string) $episode->path;
 
-            if (!Network::isSafeUrl($url)) {
+            if (!$network->isSafeUrl($url)) {
                 throw UnsafeUrlException::forUrl($url);
             }
 
@@ -51,8 +52,8 @@ final class EpisodePlayable implements Arrayable, Jsonable
                 ->withOptions([
                     'allow_redirects' => [
                         'max' => 5,
-                        'on_redirect' => static function ($request, $response, $uri): void {
-                            if (!Network::isSafeUrl((string) $uri)) {
+                        'on_redirect' => static function ($request, $response, $uri) use ($network): void {
+                            if (!$network->isSafeUrl((string) $uri)) {
                                 throw UnsafeUrlException::forUrl((string) $uri);
                             }
                         },

--- a/tests/Fakes/FakeNetwork.php
+++ b/tests/Fakes/FakeNetwork.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Fakes;
+
+use App\Helpers\Network;
+use Illuminate\Support\Uri;
+use Throwable;
+
+/**
+ * Skips DNS resolution so tests don't need real internet connectivity.
+ * Format checks (scheme, host presence, literal-IP privacy) still run so any
+ * test that exercises the SSRF guard against a known-private IP still works.
+ */
+class FakeNetwork extends Network
+{
+    private const array SAFE_SCHEMES = ['http', 'https'];
+
+    public function isSafeUrl(string $url): bool
+    {
+        try {
+            $uri = Uri::of($url);
+        } catch (Throwable) {
+            return false;
+        }
+
+        if (!in_array($uri->scheme(), self::SAFE_SCHEMES, true)) {
+            return false;
+        }
+
+        $host = $uri->host();
+
+        return $host !== '' && $this->isPublicHost($host);
+    }
+
+    public function isPublicHost(string $host): bool
+    {
+        if (filter_var($host, FILTER_VALIDATE_IP)) {
+            return (
+                filter_var($host, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) !== false
+            );
+        }
+
+        return $host !== '';
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,6 +3,7 @@
 namespace Tests;
 
 use App\Facades\License;
+use App\Helpers\Network;
 use App\Helpers\Ulid;
 use App\Helpers\Uuid;
 use App\Models\Album;
@@ -16,6 +17,7 @@ use Illuminate\Support\Facades\File;
 use Tests\Concerns\AssertsArraySubset;
 use Tests\Concerns\CreatesApplication;
 use Tests\Concerns\MakesHttpRequests;
+use Tests\Fakes\FakeNetwork;
 
 abstract class TestCase extends BaseTestCase
 {
@@ -36,6 +38,7 @@ abstract class TestCase extends BaseTestCase
         parent::setUp();
 
         License::swap($this->app->make(CommunityLicenseService::class));
+        $this->app->instance(Network::class, new FakeNetwork());
         $this->fileSystem = File::getFacadeRoot();
 
         // Replace the AlbumObserver with a partial that skips the `saved` event (which dispatches

--- a/tests/Unit/Helpers/NetworkTest.php
+++ b/tests/Unit/Helpers/NetworkTest.php
@@ -9,6 +9,15 @@ use Tests\TestCase;
 
 class NetworkTest extends TestCase
 {
+    private Network $network;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->network = new Network();
+    }
+
     /** @return array<string, array{string}> */
     public static function providePrivateHosts(): array
     {
@@ -24,27 +33,27 @@ class NetworkTest extends TestCase
     #[Test, DataProvider('providePrivateHosts')]
     public function rejectsPrivateIps(string $host): void
     {
-        self::assertFalse(Network::isPublicHost($host));
+        self::assertFalse($this->network->isPublicHost($host));
     }
 
     #[Test]
     public function acceptsPublicHost(): void
     {
         // example.com is IANA-reserved and always resolves to a public IP
-        self::assertTrue(Network::isPublicHost('example.com'));
+        self::assertTrue($this->network->isPublicHost('example.com'));
     }
 
     #[Test]
     public function rejectsUnresolvableHost(): void
     {
-        self::assertFalse(Network::isPublicHost('this-host-does-not-exist.invalid'));
+        self::assertFalse($this->network->isPublicHost('this-host-does-not-exist.invalid'));
     }
 
     #[Test]
     public function isSafeUrlAcceptsPublicHttpUrl(): void
     {
-        self::assertTrue(Network::isSafeUrl('https://example.com/feed.xml'));
-        self::assertTrue(Network::isSafeUrl('http://example.com/feed.xml'));
+        self::assertTrue($this->network->isSafeUrl('https://example.com/feed.xml'));
+        self::assertTrue($this->network->isSafeUrl('http://example.com/feed.xml'));
     }
 
     /** @return array<string, array{string}> */
@@ -69,6 +78,6 @@ class NetworkTest extends TestCase
     #[Test, DataProvider('provideUnsafeUrls')]
     public function isSafeUrlRejectsUnsafeUrl(string $url): void
     {
-        self::assertFalse(Network::isSafeUrl($url));
+        self::assertFalse($this->network->isSafeUrl($url));
     }
 }


### PR DESCRIPTION
## Summary

`Tests\Integration\Services\Podcast\PodcastServiceTest` and `Tests\Integration\Values\EpisodePlayableTest` both fail on a machine without internet because they transitively call `App\Helpers\Network::isPublicHost()`, which uses `dns_get_record()` to verify a URL's host resolves only to public IPs (an SSRF defense). With no network, DNS lookups fail outright → `isPublicHost` returns false → `isSafeUrl` rejects URLs like `https://example.com/feed.xml` → tests fail at the validation step before they ever reach the mocked HTTP call.

This PR refactors `Network` into an injectable service so tests can bind a `FakeNetwork` that skips DNS without disturbing production behavior.

## Changes

- **`App\Helpers\Network`**: methods are no longer `static`. The class is now an injectable instance.
- **`App\Rules\SafeUrl`**: takes `?Network $network = null` in its constructor, defaulting to `app(Network::class)`. Existing `new SafeUrl()` callers in Form Requests continue to work — they pick up whatever's bound in the container.
- **`App\Services\Podcast\PodcastService`**: constructor-injects `Network`; calls become `$this->network->isSafeUrl(...)`.
- **`App\Values\Podcast\EpisodePlayable`**: `getForEpisode($episode)` signature is unchanged. The static factory internally resolves `$network = app(Network::class)` once at the top of `createForEpisode`. This is the koel-memory-rule exception for a Value class's static factory — passing `Network` as a parameter through every caller (`DownloadService`, `PodcastStreamerAdapter`) was rejected as ugly plumbing for what is conceptually a single internal helper lookup.
- **`tests/Fakes/FakeNetwork`** (new): extends `Network`, skips DNS resolution but keeps scheme and literal-IP-privacy checks so the existing SSRF-defense tests (private/loopback/metadata IPs, non-HTTP schemes, garbage strings) still exercise the same rejection paths.
- **`tests/TestCase`**: globally binds `FakeNetwork` to the container in `setUp` so every test transparently bypasses DNS.
- **`tests/Unit/Helpers/NetworkTest`**: instantiates `new Network()` directly (bypassing the container), so this remains a real integration test of the production `Network` class with real DNS. Unchanged assertions; it still requires internet to run, by design.

## Test plan

- [x] `php artisan test tests/Integration/Services/Podcast/PodcastServiceTest.php tests/Integration/Values/EpisodePlayableTest.php tests/Unit/Helpers/NetworkTest.php` — 42 passed.
- [x] Full backend suite (`php artisan test`): 1201 passed.
- [x] `composer cs && composer lint && composer analyze` — all green.
- [ ] Manual: disable internet on the dev machine and re-run the Podcast/Episode integration tests — they should now pass.

## Notes

- The `NetworkTest` unit test (`tests/Unit/Helpers/NetworkTest.php`) is intentionally not switched to the fake — it's the real unit test of `Network` itself and asserts DNS-rejecting behavior against `example.com` / `this-host-does-not-exist.invalid`. Running it offline will still fail one assertion, which is correct: that test is for the real class.
- `SafeUrl`'s constructor signature change is backward-compatible — `new SafeUrl()` still works because the constructor falls back to `app(Network::class)` when no instance is provided.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * URL/host validation helpers converted to instance-based dependencies and wired into podcast and playback flows.

* **Tests**
  * Added a fake network test double and bound it in test setup to exercise URL validation without external DNS.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2506?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->