### PR TITLE
fix: provision demo accounts as users and disable uploads in demo

### DIFF
--- a/app/Http/Controllers/API/Upload/DiscardAllDuplicateUploadsController.php
+++ b/app/Http/Controllers/API/Upload/DiscardAllDuplicateUploadsController.php
@@ -2,12 +2,14 @@
 
 namespace App\Http\Controllers\API\Upload;
 
+use App\Attributes\DisabledInDemo;
 use App\Http\Controllers\Controller;
 use App\Models\User;
 use App\Repositories\DuplicateUploadRepository;
 use App\Services\Upload\DuplicateUploadService;
 use Illuminate\Contracts\Auth\Authenticatable;
 
+#[DisabledInDemo]
 class DiscardAllDuplicateUploadsController extends Controller
 {
     /** @param User $user */

--- a/app/Http/Controllers/API/Upload/DiscardDuplicateUploadController.php
+++ b/app/Http/Controllers/API/Upload/DiscardDuplicateUploadController.php
@@ -2,10 +2,12 @@
 
 namespace App\Http\Controllers\API\Upload;
 
+use App\Attributes\DisabledInDemo;
 use App\Http\Controllers\Controller;
 use App\Models\DuplicateUpload;
 use App\Services\Upload\DuplicateUploadService;
 
+#[DisabledInDemo]
 class DiscardDuplicateUploadController extends Controller
 {
     public function __invoke(DuplicateUpload $duplicateUpload, DuplicateUploadService $service)

--- a/app/Http/Controllers/API/Upload/KeepAllDuplicateUploadsController.php
+++ b/app/Http/Controllers/API/Upload/KeepAllDuplicateUploadsController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\API\Upload;
 
+use App\Attributes\DisabledInDemo;
 use App\Http\Controllers\Controller;
 use App\Models\Song;
 use App\Models\User;
@@ -12,6 +13,7 @@ use App\Responses\SongUploadResponse;
 use App\Services\Upload\DuplicateUploadService;
 use Illuminate\Contracts\Auth\Authenticatable;
 
+#[DisabledInDemo]
 class KeepAllDuplicateUploadsController extends Controller
 {
     /** @param User $user */

--- a/app/Http/Controllers/API/Upload/KeepDuplicateUploadController.php
+++ b/app/Http/Controllers/API/Upload/KeepDuplicateUploadController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\API\Upload;
 
+use App\Attributes\DisabledInDemo;
 use App\Http\Controllers\Controller;
 use App\Models\DuplicateUpload;
 use App\Repositories\AlbumRepository;
@@ -9,6 +10,7 @@ use App\Repositories\SongRepository;
 use App\Responses\SongUploadResponse;
 use App\Services\Upload\DuplicateUploadService;
 
+#[DisabledInDemo]
 class KeepDuplicateUploadController extends Controller
 {
     public function __invoke(

--- a/app/Http/Controllers/API/Upload/UploadSongController.php
+++ b/app/Http/Controllers/API/Upload/UploadSongController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\API\Upload;
 
+use App\Attributes\DisabledInDemo;
 use App\Exceptions\DuplicateSongUploadException;
 use App\Exceptions\MediaPathNotSetException;
 use App\Exceptions\SongUploadFailedException;
@@ -21,6 +22,7 @@ use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Http\Response;
 
+#[DisabledInDemo]
 class UploadSongController extends Controller
 {
     /** @param User $user */

--- a/app/Http/Controllers/Demo/NewSessionController.php
+++ b/app/Http/Controllers/Demo/NewSessionController.php
@@ -30,7 +30,7 @@ class NewSessionController extends Controller
             name: 'Koel',
             email: $email,
             plainTextPassword: User::DEMO_PASSWORD,
-            role: Role::ADMIN,
+            role: Role::USER,
         ));
 
         return redirect('/')->with('demo_account', [

--- a/tests/Feature/Demo/DemoSessionTest.php
+++ b/tests/Feature/Demo/DemoSessionTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Feature\Demo;
 
+use App\Enums\Acl\Role;
+use App\Models\User;
 use Jaybizzle\CrawlerDetect\CrawlerDetect;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
@@ -49,5 +51,17 @@ class DemoSessionTest extends TestCase
             'email' => 'demo@koel.dev',
             'password' => 'demo',
         ]);
+    }
+
+    #[Test]
+    public function demoAccountIsProvisionedAsUserNotAdmin(): void
+    {
+        $this->mock(CrawlerDetect::class)->expects('isCrawler')->andReturnFalse();
+
+        $this->get('/')->assertSuccessful();
+
+        $demoUser = User::query()->where('email', 'like', '%@demo.koel.dev')->latest('id')->first();
+
+        self::assertSame(Role::USER, $demoUser->role);
     }
 }

--- a/tests/Feature/UploadTest.php
+++ b/tests/Feature/UploadTest.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 use function Tests\create_admin;
+use function Tests\create_user;
 use function Tests\test_path;
 
 class UploadTest extends TestCase
@@ -55,5 +56,18 @@ class UploadTest extends TestCase
         Setting::set('media_path', public_path('sandbox/media'));
 
         $this->postAs('/api/upload', ['file' => $this->file], create_admin())->assertJsonStructure(['song', 'album']);
+    }
+
+    #[Test]
+    public function uploadDisabledInDemoMode(): void
+    {
+        config(['koel.misc.demo' => true]);
+        Setting::set('media_path', public_path('sandbox/media'));
+
+        try {
+            $this->postAs('/api/upload', ['file' => $this->file], create_user())->assertForbidden();
+        } finally {
+            config(['koel.misc.demo' => false]);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes a security hole on demo deployments where each visitor was provisioned as an admin and could `POST /api/upload` to deposit arbitrary audio files onto the host. Found in the wild on the canonical demo instance (a fresh visitor's account had uploaded a real audio file into the demo's media directory).

Two related issues, fixed together:

1. **`NewSessionController` provisioned every demo visitor as `Role::ADMIN`.** That gave each visitor the union of every permission in the system — manage other users, change settings, mutate any song/album/artist, etc. Downgraded to `Role::USER`, the default role, which on Community Edition has no permissions assigned (per the `2025_09_21_063859_create_default_roles_and_permissions` migration) and on Plus is the standard non-privileged role.
2. **The upload controllers were missing `#[DisabledInDemo]`.** Every other destructive write surface in the codebase is tagged (`ProfileController::destroy`, `RadioStationController::store|update|destroy`, podcast/password-reset writes, etc.) but the `app/Http/Controllers/API/Upload/*` family was overlooked. Added the attribute to `UploadSongController` and the four write-side duplicate-resolution controllers (`KeepDuplicateUploadController`, `KeepAllDuplicateUploadsController`, `DiscardDuplicateUploadController`, `DiscardAllDuplicateUploadsController`). `FetchDuplicateUploadsController` is read-only and untouched.

Either fix in isolation would close the hole. Together they're defense-in-depth: the role downgrade blocks at the policy layer (`UserPolicy::upload`), and the attribute blocks at the middleware layer (`HandleDemoMode`).

## Tests

- `DemoSessionTest::demoAccountIsProvisionedAsUserNotAdmin` — asserts the demo-spawned account is `Role::USER`.
- `UploadTest::uploadDisabledInDemoMode` — asserts `POST /api/upload` returns 403 when `koel.misc.demo=true`.
- Existing demo and upload tests still green: 1205 passed.

## Notes for reviewers

- `DisabledInDemo` defaults to `allowAdminOverride: true`. The new attributes inherit that default, which means a real admin user (not a demo-spawned one) could still upload in a demo deployment. That's intentional — for most demo-tagged endpoints the override is desirable (a deployment operator shouldn't be locked out of their own demo). The role downgrade is what closes the hole for normal demo visitors; the attribute is the second layer.
- For Plus deployments where you might want to demo upload-flow features for marketing reasons, you'd remove the `#[DisabledInDemo]` from `UploadSongController`. The role downgrade still keeps demo visitors at `Role::USER`, which on Plus can upload to their own library — so the demo experience for upload is intact, just attributed to the demo visitor rather than to an admin.
- No change to the `HandleDemoMode` middleware itself, the `DisabledInDemo` attribute, or any other demo plumbing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Upload functionality is now disabled in demo mode
  * Demo accounts are created as standard users instead of administrators

* **Tests**
  * Added tests to verify upload restrictions in demo mode
  * Added tests to confirm demo account role assignment

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2508?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->