### PR TITLE
fix: self-heal image storage directory and surface missing dir in doctor

### DIFF
--- a/app/Console/Commands/DoctorCommand.php
+++ b/app/Console/Commands/DoctorCommand.php
@@ -14,6 +14,7 @@ use App\Http\Integrations\YouTube\YouTubeConnector;
 use App\Models\Setting;
 use App\Models\Song;
 use App\Models\User;
+use App\Services\Image\ImageWriter;
 use App\Services\Integrations\LastfmService;
 use App\Services\Integrations\SpotifyService;
 use App\Services\Integrations\YouTubeService;
@@ -68,6 +69,7 @@ class DoctorCommand extends Command
         $this->checkFullTextSearch();
         $this->checkApiHealth();
         $this->checkFFMpeg();
+        $this->checkImageWriting();
         $this->checkPhpExtensions();
         $this->checkPhpConfiguration();
         $this->checkStreamingMethod();
@@ -338,6 +340,18 @@ class DoctorCommand extends Command
         $this->assertDirectoryPermissions(base_path('storage/framework/sessions'), 'Session');
         $this->assertDirectoryPermissions(base_path('storage/framework/cache'), 'Cache');
         $this->assertDirectoryPermissions(base_path('storage/logs'), 'Log');
+        $this->assertDirectoryPermissions(public_path(config('koel.image_storage_dir')), 'Image storage');
+    }
+
+    private function checkImageWriting(): void
+    {
+        try {
+            $writer = new ImageWriter();
+            $this->reportSuccess('Image processing', $writer->extension->value);
+        } catch (Throwable $e) {
+            $this->collectError($e);
+            $this->reportError('Image processing', 'No supported format');
+        }
     }
 
     private function reportError(string $message, ?string $value = 'ERROR'): void

--- a/app/Helpers.php
+++ b/app/Helpers.php
@@ -27,9 +27,19 @@ function base_url(): string
     return app()->runningUnitTests() ? config('app.url') : asset('');
 }
 
-function image_storage_path(?string $fileName, ?string $default = null): ?string
+function image_storage_path(?string $fileName, ?string $default = null, bool $ensureDirectoryExists = true): ?string
 {
-    return $fileName ? public_path(config('koel.image_storage_dir') . DIRECTORY_SEPARATOR . $fileName) : $default;
+    if (!$fileName) {
+        return $default;
+    }
+
+    $path = public_path(config('koel.image_storage_dir') . DIRECTORY_SEPARATOR . $fileName);
+
+    if ($ensureDirectoryExists && !is_dir(dirname($path))) {
+        File::ensureDirectoryExists(dirname($path));
+    }
+
+    return $path;
 }
 
 function image_storage_url(?string $fileName, ?string $default = null): ?string

--- a/app/Services/Image/ImageWriter.php
+++ b/app/Services/Image/ImageWriter.php
@@ -13,7 +13,7 @@ use Throwable;
 
 class ImageWriter
 {
-    private FileExtension $extension;
+    public readonly FileExtension $extension;
 
     public function __construct()
     {

--- a/tests/Unit/Helpers/ImageStoragePathTest.php
+++ b/tests/Unit/Helpers/ImageStoragePathTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Unit\Helpers;
+
+use Illuminate\Support\Facades\File;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class ImageStoragePathTest extends TestCase
+{
+    #[Test]
+    public function createsParentDirectoryIfMissing(): void
+    {
+        $dir = public_path(config('koel.image_storage_dir'));
+        File::deleteDirectory($dir);
+        self::assertFalse(File::isDirectory($dir));
+
+        $path = image_storage_path('cover.webp');
+
+        self::assertTrue(File::isDirectory(dirname($path)));
+        self::assertSame($dir . DIRECTORY_SEPARATOR . 'cover.webp', $path);
+    }
+
+    #[Test]
+    public function doesNotCreateDirectoryWhenSkipFlagPassed(): void
+    {
+        $dir = public_path(config('koel.image_storage_dir'));
+        File::deleteDirectory($dir);
+        self::assertFalse(File::isDirectory($dir));
+
+        image_storage_path('cover.webp', null, ensureDirectoryExists: false);
+
+        self::assertFalse(File::isDirectory($dir));
+    }
+
+    #[Test]
+    public function returnsDefaultForEmptyFileName(): void
+    {
+        self::assertSame('fallback', image_storage_path(null, 'fallback'));
+        self::assertNull(image_storage_path(null));
+    }
+}


### PR DESCRIPTION
Closes #2507.

## Summary

Album cover writes fail with `Intervention\Image\Exceptions\NotWritableException: Can't write image to path. Directory does not exist.` when the configured image storage directory hasn't been created on disk. Most affected: Franken bundles, where the launcher pre-creates `$HOME/.koel/storage/app/public/` but stops one directory short of `images/` — so the very first cover write at upload time (or via `koel:fetch-artwork`) blows up.

This PR self-heals the directory in the helper that builds the path, mirroring how `artifact_path()` already does it, and adds two new diagnostic surfaces to `koel:doctor` so the failure mode is discoverable without grepping a stack trace.

## Changes

### `app/Helpers.php`

`image_storage_path()` now ensures the parent directory exists before returning, with an opt-out flag for the (rare) case where the caller doesn't intend to write. Behaviour mirrors `artifact_path()`'s self-heal pattern — same signature shape, same default. A native `is_dir()` check guards the `File::ensureDirectoryExists()` call, both to avoid the syscall when the dir already exists and to keep strictly-mocked tests undisturbed.

### `app/Console/Commands/DoctorCommand.php`

Two new checks:

- **Image storage directory** added to `checkDirectoryPermissions()`. On the broken Franken install in #2507 this would have flagged "Image storage directory is not readable/writable" at install time, instead of producing the confusing fetch-artwork failure.
- **Image processing**: a new `checkImageWriting()` reports the selected output format (AVIF / WEBP / JPEG, in order of preference) and surfaces the rare case where GD/Imagick supports none of them — another silent runtime crash mode previously invisible to `koel:doctor`.

### `app/Services/Image/ImageWriter.php`

`$extension` is now `public readonly` so `koel:doctor` can display the chosen format. No behavioural change.

## Tests

- `tests/Unit/Helpers/ImageStoragePathTest.php` (new):
  - `createsParentDirectoryIfMissing` — deletes the storage dir, calls `image_storage_path('cover.webp')`, asserts the dir is recreated.
  - `doesNotCreateDirectoryWhenSkipFlagPassed` — verifies the opt-out flag works.
  - `returnsDefaultForEmptyFileName` — covers the `?string $default` fallback.
- Full backend suite: 1208 passing, no regressions.
- `composer cs && composer lint && composer analyze` — all green.

## Note for Franken users

Even with this fix shipped in the next koel release, anyone on a Franken bundle that wraps v9.3.x / v9.4.0 / v9.4.1 still hits #2507 until they upgrade to the new bundle. A companion launcher fix on the franken side will pre-create `$KOEL_HOME/storage/app/public/images` so existing bundles can be unblocked by repacking, without waiting for koel's next release.

## Workaround for affected users right now

```bash
mkdir -p ~/.koel/storage/app/public/images
```

(On Pterodactyl-style containers where `$HOME=/home/container`, that resolves to `/home/container/.koel/storage/app/public/images`.) Re-run uploads or `koel:fetch-artwork` afterward. Covers land in the externalized storage and survive future Franken upgrades.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Doctor diagnostic command now validates image writing capabilities and reports supported image formats for system compatibility.
  * Image storage directories are automatically created when needed during image operations.

* **Tests**
  * Added test coverage for image storage path creation and directory handling behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2509?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->