### PR TITLE
chore: bump GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/lint-backend.yml
+++ b/.github/workflows/lint-backend.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         php-version: [ 8.3 ]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v6
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/lint-frontend.yml
+++ b/.github/workflows/lint-frontend.yml
@@ -29,10 +29,10 @@ jobs:
         node-version: [ 22 ]
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Check (format + lint)

--- a/.github/workflows/lint-frontend.yml
+++ b/.github/workflows/lint-frontend.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         node-version: [ 22 ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,10 +25,10 @@ jobs:
         with:
           composer-options: "--prefer-dist --no-dev --optimize-autoloader"
       - name: Set up Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v6
         with:
           node-version: 22
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - name: Build project
         run: |
           sudo apt install pngquant zip unzip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/test-backend-mariadb.yml
+++ b/.github/workflows/test-backend-mariadb.yml
@@ -46,7 +46,7 @@ jobs:
       DB_USERNAME: mariadb
       DB_PASSWORD: mariadb
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v6
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -64,7 +64,7 @@ jobs:
         env:
           COMPOSER_PROCESS_TIMEOUT: 600
       - name: Upload logs if broken
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: unit-be-mariadb-logs-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/test-backend-pgsql.yml
+++ b/.github/workflows/test-backend-pgsql.yml
@@ -45,7 +45,7 @@ jobs:
       DB_USERNAME: postgres
       DB_PASSWORD: postgres
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v6
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -63,7 +63,7 @@ jobs:
         env:
           COMPOSER_PROCESS_TIMEOUT: 600
       - name: Upload logs if broken
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: unit-be-pgsql-logs-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/test-backend-sqlite.yml
+++ b/.github/workflows/test-backend-sqlite.yml
@@ -23,7 +23,7 @@ jobs:
         php-version: [ 8.3 ]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v6
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -42,7 +42,7 @@ jobs:
         env:
           COMPOSER_PROCESS_TIMEOUT: 600
       - name: Upload logs if broken
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: unit-be-logs-${{ github.run_id }}-${{ github.run_attempt }}-sqlite

--- a/.github/workflows/test-proxy-auth-e2e.yml
+++ b/.github/workflows/test-proxy-auth-e2e.yml
@@ -35,7 +35,7 @@ jobs:
     # Skip on fork PRs — secrets.KOEL_PLUS_LICENSE_KEY isn't available there.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -201,7 +201,7 @@ jobs:
 
       - name: Upload logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: proxy-auth-e2e-logs-${{ github.run_id }}
           path: |

--- a/.github/workflows/unit-frontend.yml
+++ b/.github/workflows/unit-frontend.yml
@@ -30,8 +30,8 @@ jobs:
         shard: [ 1/3, 2/3, 3/3 ]
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: pnpm

--- a/.github/workflows/unit-frontend.yml
+++ b/.github/workflows/unit-frontend.yml
@@ -29,7 +29,7 @@ jobs:
         node-version: [ 22 ]
         shard: [ 1/3, 2/3, 3/3 ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary

Bumps GitHub Actions used across all workflows to their latest major versions.

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v1 (4 files), v2 (1 file), v4 (3 files) | **v6** |
| `actions/upload-artifact` | v4 (4 files) | **v7** |
| `actions/setup-node` | v2 (1 file), v4 (2 files) | **v6** |
| `pnpm/action-setup` | v4 (3 files) | **v6** |

`actions/download-artifact` isn't used in this repo.

## Why

`actions/checkout@v1` and `@v2` are years out of date — v1 runs on Node 12 which GitHub-hosted runners warn about. Consolidating everyone on the latest majors (v6/v7) also makes future bumps a single-pattern sed.

The newer majors are drop-in compatible with current usage: upload-artifact v7 added an optional `archive: false` direct-upload mode but defaults to the same behavior as v4; checkout v6 just bumps to Node 24 + isolates credentials; setup-node v6 continues caching `pnpm` automatically; pnpm/action-setup v6 reads from `package.json#packageManager` the same way v4 does.

## Files touched

```
.github/workflows/lint-backend.yml          checkout v1 → v6
.github/workflows/lint-frontend.yml         checkout v4 → v6, setup-node v4 → v6, pnpm/action-setup v4 → v6
.github/workflows/release.yml               checkout v2 → v6, setup-node v2 → v6, pnpm/action-setup v4 → v6
.github/workflows/test-backend-mariadb.yml  checkout v1 → v6, upload-artifact v4 → v7
.github/workflows/test-backend-pgsql.yml    checkout v1 → v6, upload-artifact v4 → v7
.github/workflows/test-backend-sqlite.yml   checkout v1 → v6, upload-artifact v4 → v7
.github/workflows/test-proxy-auth-e2e.yml   checkout v4 → v6, upload-artifact v4 → v7
.github/workflows/unit-frontend.yml         checkout v4 → v6, setup-node v4 → v6, pnpm/action-setup v4 → v6
```

## Test plan

CI run on the PR exercises every touched workflow. If a major-version bump regresses anything (e.g. a removed option), it surfaces immediately here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows across CI, test, and release pipelines to use newer action major versions for improved maintenance and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2510?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->