### PR TITLE
perf: consolidate fulltext indexes onto short-string display columns

### DIFF
--- a/app/Models/Album.php
+++ b/app/Models/Album.php
@@ -118,11 +118,20 @@ class Album extends Model implements AuditableContract, Embeddable, Favoriteable
     /** @inheritdoc */
     public function toSearchableArray(): array
     {
-        return [
+        $array = [
             'id' => $this->id,
             'user_id' => $this->user_id,
             'name' => $this->name,
-            'artist_name' => $this->artist_name,
         ];
+
+        if (
+            $this->artist_name
+            && $this->artist_name !== Artist::UNKNOWN_NAME
+            && $this->artist_name !== Artist::VARIOUS_NAME
+        ) {
+            $array['artist_name'] = $this->artist_name;
+        }
+
+        return $array;
     }
 }

--- a/app/Models/Album.php
+++ b/app/Models/Album.php
@@ -118,20 +118,11 @@ class Album extends Model implements AuditableContract, Embeddable, Favoriteable
     /** @inheritdoc */
     public function toSearchableArray(): array
     {
-        $array = [
+        return [
             'id' => $this->id,
             'user_id' => $this->user_id,
             'name' => $this->name,
+            'artist_name' => $this->artist_name,
         ];
-
-        if (
-            $this->artist_name
-            && $this->artist_name !== Artist::UNKNOWN_NAME
-            && $this->artist_name !== Artist::VARIOUS_NAME
-        ) {
-            $array['artist'] = $this->artist_name;
-        }
-
-        return $array;
     }
 }

--- a/app/Models/Song.php
+++ b/app/Models/Song.php
@@ -152,14 +152,23 @@ class Song extends Model implements AuditableContract, Favoriteable, Embeddable
     /** @inheritdoc */
     public function toSearchableArray(): array
     {
-        return [
+        $array = [
             'id' => $this->id,
             'owner_id' => $this->owner_id,
             'title' => $this->title,
             'type' => $this->type->value,
-            'artist_name' => $this->artist_name,
             'album_name' => $this->album_name,
         ];
+
+        if (
+            $this->artist_name
+            && $this->artist_name !== Artist::UNKNOWN_NAME
+            && $this->artist_name !== Artist::VARIOUS_NAME
+        ) {
+            $array['artist_name'] = $this->artist_name;
+        }
+
+        return $array;
     }
 
     public function syncGenres(string|array $genres): void

--- a/app/Models/Song.php
+++ b/app/Models/Song.php
@@ -152,26 +152,14 @@ class Song extends Model implements AuditableContract, Favoriteable, Embeddable
     /** @inheritdoc */
     public function toSearchableArray(): array
     {
-        $array = [
+        return [
             'id' => $this->id,
             'owner_id' => $this->owner_id,
             'title' => $this->title,
             'type' => $this->type->value,
+            'artist_name' => $this->artist_name,
+            'album_name' => $this->album_name,
         ];
-
-        if ($this->episode_metadata?->description) {
-            $array['episode_description'] = $this->episode_metadata->description;
-        }
-
-        if (
-            $this->artist_name
-            && $this->artist_name !== Artist::UNKNOWN_NAME
-            && $this->artist_name !== Artist::VARIOUS_NAME
-        ) {
-            $array['artist'] = $this->artist_name;
-        }
-
-        return $array;
     }
 
     public function syncGenres(string|array $genres): void

--- a/database/migrations/2026_05_26_213550_tune_fulltext_search_indexes.php
+++ b/database/migrations/2026_05_26_213550_tune_fulltext_search_indexes.php
@@ -8,16 +8,10 @@ use Illuminate\Support\Facades\Schema;
 return new class extends Migration {
     public function up(): void
     {
-        // SQLite doesn't support fulltext indexes on regular columns; nothing to drop or add.
         if (DB::getDriverName() === 'sqlite') {
             return;
         }
 
-        // Replace the per-column singles with a composite over the short-string display
-        // fields. 'simple' language — none of the composite columns hold prose where English
-        // stemming would earn its keep. The lyrics fulltext (added in the 2026-03 migration)
-        // stays — it backs `SongRepository::searchByLyrics()` via the AI assistant's
-        // PlaySongsByLyrics tool.
         Schema::table('songs', static function (Blueprint $table): void {
             $table->dropFullText(['title']);
             $table->fullText(['title', 'artist_name', 'album_name'])->language('simple');

--- a/database/migrations/2026_05_26_213550_tune_fulltext_search_indexes.php
+++ b/database/migrations/2026_05_26_213550_tune_fulltext_search_indexes.php
@@ -13,12 +13,13 @@ return new class extends Migration {
             return;
         }
 
-        // Drop long-text-body indexes (lyrics) and per-column singles in favor of composites
-        // over short-string display fields. 'simple' language across the board — none of the
-        // indexed columns hold prose where English stemming would earn its keep.
+        // Replace the per-column singles with a composite over the short-string display
+        // fields. 'simple' language — none of the composite columns hold prose where English
+        // stemming would earn its keep. The lyrics fulltext (added in the 2026-03 migration)
+        // stays — it backs `SongRepository::searchByLyrics()` via the AI assistant's
+        // PlaySongsByLyrics tool.
         Schema::table('songs', static function (Blueprint $table): void {
             $table->dropFullText(['title']);
-            $table->dropFullText(['lyrics']);
             $table->fullText(['title', 'artist_name', 'album_name'])->language('simple');
         });
 

--- a/database/migrations/2026_05_26_213550_tune_fulltext_search_indexes.php
+++ b/database/migrations/2026_05_26_213550_tune_fulltext_search_indexes.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        // SQLite doesn't support fulltext indexes on regular columns; nothing to drop or add.
+        if (DB::getDriverName() === 'sqlite') {
+            return;
+        }
+
+        // Drop long-text-body indexes (lyrics) and per-column singles in favor of composites
+        // over short-string display fields. 'simple' language across the board — none of the
+        // indexed columns hold prose where English stemming would earn its keep.
+        Schema::table('songs', static function (Blueprint $table): void {
+            $table->dropFullText(['title']);
+            $table->dropFullText(['lyrics']);
+            $table->fullText(['title', 'artist_name', 'album_name'])->language('simple');
+        });
+
+        Schema::table('albums', static function (Blueprint $table): void {
+            $table->dropFullText(['name']);
+            $table->fullText(['name', 'artist_name'])->language('simple');
+        });
+
+        Schema::table('artists', static function (Blueprint $table): void {
+            $table->fullText('name')->language('simple');
+        });
+
+        Schema::table('genres', static function (Blueprint $table): void {
+            $table->fullText('name')->language('simple');
+        });
+
+        Schema::table('playlists', static function (Blueprint $table): void {
+            $table->fullText(['name', 'description'])->language('simple');
+        });
+
+        Schema::table('radio_stations', static function (Blueprint $table): void {
+            $table->fullText(['name', 'description'])->language('simple');
+        });
+
+        Schema::table('podcasts', static function (Blueprint $table): void {
+            $table->fullText(['title', 'description', 'author'])->language('simple');
+        });
+    }
+};


### PR DESCRIPTION
Re-shapes fulltext indexes to cover the columns models actually expose, so operators can point Scout at the database driver instead of an external service via `.env`. No config changes here.

```
songs           drop fullText(['title']) → fullText(['title', 'artist_name', 'album_name'])
albums          drop fullText(['name'])  → fullText(['name', 'artist_name'])
artists         + fullText('name')
genres          + fullText('name')
playlists       + fullText(['name', 'description'])
radio_stations  + fullText(['name', 'description'])
podcasts        + fullText(['title', 'description', 'author'])
```

All `language('simple')` — none of the indexed columns hold prose where English stemming would help. `songs.lyrics` index stays (backs `SongRepository::searchByLyrics()` for the `PlaySongsByLyrics` AI tool). SQLite early-returns as before.

`Song::toSearchableArray()` / `Album::toSearchableArray()` now use real column names (`artist_name` / `album_name`) and drop the sentinel-filter conditional — needed for the DB driver to match on actual columns, harmless for tntsearch.

CI matrix exercises the migration on MySQL + PostgreSQL.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Optimized full‑text search indexes across songs, albums, artists, genres, playlists, radio stations, and podcasts for faster, more consistent search results.
  * Standardized search payloads: albums and songs now use an artist_name field (replacing prior artist usage), songs exclude episode_description, and core metadata (id, names, type/owner) are consistently included.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2511?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->