### PR TITLE
fix: guard dropFullText with hasIndex check for partial-state DBs

### DIFF
--- a/database/migrations/2026_05_26_213550_tune_fulltext_search_indexes.php
+++ b/database/migrations/2026_05_26_213550_tune_fulltext_search_indexes.php
@@ -13,12 +13,16 @@ return new class extends Migration {
         }
 
         Schema::table('songs', static function (Blueprint $table): void {
-            $table->dropFullText(['title']);
+            if (Schema::hasIndex('songs', 'songs_title_fulltext')) {
+                $table->dropFullText(['title']);
+            }
             $table->fullText(['title', 'artist_name', 'album_name'])->language('simple');
         });
 
         Schema::table('albums', static function (Blueprint $table): void {
-            $table->dropFullText(['name']);
+            if (Schema::hasIndex('albums', 'albums_name_fulltext')) {
+                $table->dropFullText(['name']);
+            }
             $table->fullText(['name', 'artist_name'])->language('simple');
         });
 


### PR DESCRIPTION
Migration #2511 (`2026_05_26_213550_tune_fulltext_search_indexes`) fails on databases where the 2022-era `songs_title_fulltext` / `albums_name_fulltext` indexes never landed (or were dropped out-of-band). Real example: stream.phanan.net crashed with `SQLSTATE[42000] 1091 Can't DROP INDEX songs_title_fulltext`.

Wrapping each `dropFullText` in a `Schema::hasIndex(...)` check so divergent DB states converge cleanly. Adds remain unchanged.

```php
if (Schema::hasIndex('songs', 'songs_title_fulltext')) {
    $table->dropFullText(['title']);
}
$table->fullText(['title', 'artist_name', 'album_name'])->language('simple');
```

Same pattern for `albums.albums_name_fulltext`. Operators whose indexes exist still get the rename; operators whose indexes never existed skip the drop and just get the new composite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database migration robustness by adding defensive validation checks before updating full-text search indexes. These enhancements prevent errors during index recreation operations, ensuring reliable search functionality and maintaining platform stability during system updates and maintenance procedures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2512?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->