### PR TITLE
fix: make Artist::name accessor null-safe for empty model introspection

### DIFF
--- a/app/Models/Concerns/Artists/HasArtistAttributes.php
+++ b/app/Models/Concerns/Artists/HasArtistAttributes.php
@@ -22,6 +22,8 @@ trait HasArtistAttributes
      */
     protected function name(): Attribute
     {
-        return Attribute::get(static fn (string $value): string => html_entity_decode($value) ?: self::UNKNOWN_NAME);
+        return Attribute::get(
+            static fn (?string $value): string => html_entity_decode($value ?? '') ?: self::UNKNOWN_NAME,
+        );
     }
 }

--- a/tests/Unit/Models/ArtistTest.php
+++ b/tests/Unit/Models/ArtistTest.php
@@ -54,4 +54,13 @@ class ArtistTest extends TestCase
 
         self::assertTrue(Artist::getOrCreate($artist->user, $name)->is($artist));
     }
+
+    #[Test]
+    public function nameAccessorIsNullSafe(): void
+    {
+        // Scout's database engine calls toSearchableArray() on a fresh model instance
+        // to introspect searchable columns; that read of $this->name hits the accessor
+        // with a null value.
+        self::assertSame(Artist::UNKNOWN_NAME, (new Artist())->name);
+    }
 }


### PR DESCRIPTION
The `Artist::name` accessor is strictly typed `string $value`, but Eloquent's `transformModelValue` calls accessors during any read of `$this->name`, including on **empty model instances**. Scout's database engine introspects searchable columns by calling `toSearchableArray()` on a fresh `new Artist()` — which triggers `$this->name` → accessor → TypeError because `$value` is null.

Symptom: `Artist::search($keyword)` throws `TypeError: Argument #1 ($value) must be of type string, null given` under `SCOUT_DRIVER=database`. Bubbles up and kills the entire search endpoint response.

One-line widen to `?string` + `?? ''`. Empty-model name resolves to `UNKNOWN_NAME`, same as the existing behavior for a record stored with an empty name.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced artist name attribute handling to safely manage null or missing values, ensuring the application displays consistent default naming when artist information is incomplete or unavailable. This improvement enhances overall stability and reliability, preventing potential errors when accessing or processing artist data throughout the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2513?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->