### PR TITLE
fix: align Song/Album searchable arrays with real column names

### DIFF
--- a/app/Casts/SongTitleCast.php
+++ b/app/Casts/SongTitleCast.php
@@ -15,7 +15,7 @@ class SongTitleCast implements CastsAttributes
     public function get(Model $model, string $key, mixed $value, array $attributes): string
     {
         // If the title is empty, we "guess" the title by extracting the filename from the song's path.
-        return $value ?: pathinfo($model->path, PATHINFO_FILENAME);
+        return $value ?: pathinfo($model->path ?? '', PATHINFO_FILENAME);
     }
 
     /**

--- a/app/Models/Album.php
+++ b/app/Models/Album.php
@@ -118,20 +118,11 @@ class Album extends Model implements AuditableContract, Embeddable, Favoriteable
     /** @inheritdoc */
     public function toSearchableArray(): array
     {
-        $array = [
+        return [
             'id' => $this->id,
             'user_id' => $this->user_id,
             'name' => $this->name,
+            'artist_name' => $this->artist_name,
         ];
-
-        if (
-            $this->artist_name
-            && $this->artist_name !== Artist::UNKNOWN_NAME
-            && $this->artist_name !== Artist::VARIOUS_NAME
-        ) {
-            $array['artist_name'] = $this->artist_name;
-        }
-
-        return $array;
     }
 }

--- a/app/Models/Song.php
+++ b/app/Models/Song.php
@@ -152,23 +152,13 @@ class Song extends Model implements AuditableContract, Favoriteable, Embeddable
     /** @inheritdoc */
     public function toSearchableArray(): array
     {
-        $array = [
+        return [
             'id' => $this->id,
             'owner_id' => $this->owner_id,
             'title' => $this->title,
-            'type' => $this->type->value,
             'album_name' => $this->album_name,
+            'artist_name' => $this->artist_name,
         ];
-
-        if (
-            $this->artist_name
-            && $this->artist_name !== Artist::UNKNOWN_NAME
-            && $this->artist_name !== Artist::VARIOUS_NAME
-        ) {
-            $array['artist_name'] = $this->artist_name;
-        }
-
-        return $array;
     }
 
     public function syncGenres(string|array $genres): void


### PR DESCRIPTION
`Song::toSearchableArray()` includes a `'type'` key (the PlayableType enum), but `songs.type` is not a real column — `Song::type` is a derived accessor (`SONG` if `podcast_id` is null, else `PODCAST_EPISODE`). Scout's database engine treats every key as a column name and emits `WHERE songs.type LIKE …` → SQL error on every `Song::search($q)` call → song search returns nothing for any query under `SCOUT_DRIVER=database`.

Drop the bogus `'type'` key. Same root cause in `Album::toSearchableArray()` (no bogus key but the `artist_name` conditional excludes the column from Scout's introspection on empty models, breaking artist-name lookups against the albums table) — make `artist_name` unconditional in both `Song` and `Album`. Also silences a PHP 8.5 deprecation in `SongTitleCast::get` (`pathinfo(null, …)` on empty-model introspection).

## Upgrade note for tntsearch users

The searchable shape has changed. Existing tntsearch indexes will continue to function, but to pick up the new column names and the now-unconditional `artist_name`, run:

```bash
php artisan scout:flush "App\Models\Song"
php artisan scout:flush "App\Models\Album"
php artisan scout:import "App\Models\Song"
php artisan scout:import "App\Models\Album"
```

## Minor semantic change

`artist_name` is no longer filtered out for sentinel values (`Unknown Artist`, `Various Artists`) at index time. Searches for `"various"` will now match Various Artists tracks/albums. Operators who want to preserve the previous filter behavior should apply it at query-callback level instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing song paths in title generation.
  * Ensured artist names are consistently included in search results.

* **Refactor**
  * Simplified search indexing behavior for songs and albums.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2514?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->