### PR TITLE
feat: Subsonic API phase 1 — auth, response envelope, ping, getLicense

### DIFF
--- a/app/Console/Commands/Subsonic/ShowApiKeyCommand.php
+++ b/app/Console/Commands/Subsonic/ShowApiKeyCommand.php
@@ -8,7 +8,7 @@ use Illuminate\Console\Command;
 class ShowApiKeyCommand extends Command
 {
     protected $signature = 'koel:subsonic:apikey {email}';
-    protected $description = 'Show a user\'s Subsonic API key';
+    protected $description = "Show a user's Subsonic API key";
 
     public function handle(UserRepository $userRepository): int
     {

--- a/app/Console/Commands/Subsonic/ShowApiKeyCommand.php
+++ b/app/Console/Commands/Subsonic/ShowApiKeyCommand.php
@@ -10,12 +10,18 @@ class ShowApiKeyCommand extends Command
     protected $signature = 'koel:subsonic:apikey {email}';
     protected $description = "Show a user's Subsonic API key";
 
-    public function handle(UserRepository $userRepository): int
+    public function __construct(
+        private readonly UserRepository $userRepository,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
     {
-        $user = $userRepository->findOneBy(['email' => $this->argument('email')]);
+        $user = $this->userRepository->findOneByEmail($this->argument('email'));
 
         if (!$user) {
-            $this->components->error(sprintf('No user found with email "%s".', $this->argument('email')));
+            $this->error('The user account cannot be found.');
 
             return self::FAILURE;
         }

--- a/app/Console/Commands/Subsonic/ShowApiKeyCommand.php
+++ b/app/Console/Commands/Subsonic/ShowApiKeyCommand.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Console\Commands\Subsonic;
+
+use App\Repositories\UserRepository;
+use Illuminate\Console\Command;
+
+class ShowApiKeyCommand extends Command
+{
+    protected $signature = 'koel:subsonic:apikey {email}';
+    protected $description = 'Show a user\'s Subsonic API key';
+
+    public function handle(UserRepository $userRepository): int
+    {
+        $user = $userRepository->findOneBy(['email' => $this->argument('email')]);
+
+        if (!$user) {
+            $this->components->error(sprintf('No user found with email "%s".', $this->argument('email')));
+
+            return self::FAILURE;
+        }
+
+        $this->line($user->subsonic_api_key);
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Http/Controllers/Subsonic/GetLicenseController.php
+++ b/app/Http/Controllers/Subsonic/GetLicenseController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Controllers\Subsonic;
+
+use App\Http\Controllers\Controller;
+use App\Http\Responses\Subsonic\SubsonicResponse;
+use Illuminate\Http\Request;
+
+class GetLicenseController extends Controller
+{
+    public function __invoke(Request $request): SubsonicResponse
+    {
+        return SubsonicResponse::ok([
+            'license' => [
+                'valid' => true,
+                'email' => $request->user()->email,
+            ],
+        ]);
+    }
+}

--- a/app/Http/Controllers/Subsonic/GetLicenseController.php
+++ b/app/Http/Controllers/Subsonic/GetLicenseController.php
@@ -4,16 +4,18 @@ namespace App\Http\Controllers\Subsonic;
 
 use App\Http\Controllers\Controller;
 use App\Http\Responses\Subsonic\SubsonicResponse;
-use Illuminate\Http\Request;
+use App\Models\User;
+use Illuminate\Contracts\Auth\Authenticatable;
 
 class GetLicenseController extends Controller
 {
-    public function __invoke(Request $request): SubsonicResponse
+    /** @param User $user */
+    public function __invoke(Authenticatable $user): SubsonicResponse
     {
         return SubsonicResponse::ok([
             'license' => [
                 'valid' => true,
-                'email' => $request->user()->email,
+                'email' => $user->email,
             ],
         ]);
     }

--- a/app/Http/Controllers/Subsonic/GetLicenseController.php
+++ b/app/Http/Controllers/Subsonic/GetLicenseController.php
@@ -10,7 +10,7 @@ use Illuminate\Contracts\Auth\Authenticatable;
 class GetLicenseController extends Controller
 {
     /** @param User $user */
-    public function __invoke(Authenticatable $user): SubsonicResponse
+    public function __invoke(Authenticatable $user)
     {
         return SubsonicResponse::ok([
             'license' => [

--- a/app/Http/Controllers/Subsonic/PingController.php
+++ b/app/Http/Controllers/Subsonic/PingController.php
@@ -7,7 +7,7 @@ use App\Http\Responses\Subsonic\SubsonicResponse;
 
 class PingController extends Controller
 {
-    public function __invoke(): SubsonicResponse
+    public function __invoke()
     {
         return SubsonicResponse::ok();
     }

--- a/app/Http/Controllers/Subsonic/PingController.php
+++ b/app/Http/Controllers/Subsonic/PingController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers\Subsonic;
+
+use App\Http\Controllers\Controller;
+use App\Http\Responses\Subsonic\SubsonicResponse;
+
+class PingController extends Controller
+{
+    public function __invoke(): SubsonicResponse
+    {
+        return SubsonicResponse::ok();
+    }
+}

--- a/app/Http/Middleware/SubsonicAuth.php
+++ b/app/Http/Middleware/SubsonicAuth.php
@@ -3,7 +3,6 @@
 namespace App\Http\Middleware;
 
 use App\Http\Responses\Subsonic\SubsonicResponse;
-use App\Models\User;
 use App\Repositories\UserRepository;
 use Closure;
 use Illuminate\Http\Request;
@@ -24,8 +23,7 @@ class SubsonicAuth
             return SubsonicResponse::error(10, 'Required parameter is missing.')->toResponse($request);
         }
 
-        /** @var ?User $user */
-        $user = $this->userRepository->findOneBy(['subsonic_api_key' => $apiKey]);
+        $user = $this->userRepository->findOneBySubsonicApiKey($apiKey);
 
         if (!$user) {
             return SubsonicResponse::error(40, 'Wrong username or password.')->toResponse($request);

--- a/app/Http/Middleware/SubsonicAuth.php
+++ b/app/Http/Middleware/SubsonicAuth.php
@@ -7,6 +7,7 @@ use App\Models\User;
 use App\Repositories\UserRepository;
 use Closure;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 use Symfony\Component\HttpFoundation\Response;
 
 class SubsonicAuth
@@ -30,7 +31,7 @@ class SubsonicAuth
             return SubsonicResponse::error(40, 'Wrong username or password.')->toResponse($request);
         }
 
-        $request->setUserResolver(static fn () => $user);
+        Auth::setUser($user);
 
         return $next($request);
     }

--- a/app/Http/Middleware/SubsonicAuth.php
+++ b/app/Http/Middleware/SubsonicAuth.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Http\Responses\Subsonic\SubsonicResponse;
+use App\Models\User;
+use App\Repositories\UserRepository;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class SubsonicAuth
+{
+    public function __construct(
+        private readonly UserRepository $userRepository,
+    ) {}
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        $apiKey = $request->input('apiKey');
+
+        if (!$apiKey) {
+            return SubsonicResponse::error(10, 'Required parameter is missing.')->toResponse($request);
+        }
+
+        /** @var ?User $user */
+        $user = $this->userRepository->findOneBy(['subsonic_api_key' => $apiKey]);
+
+        if (!$user) {
+            return SubsonicResponse::error(40, 'Wrong username or password.')->toResponse($request);
+        }
+
+        $request->setUserResolver(static fn () => $user);
+
+        return $next($request);
+    }
+}

--- a/app/Http/Responses/Subsonic/SubsonicResponse.php
+++ b/app/Http/Responses/Subsonic/SubsonicResponse.php
@@ -5,7 +5,9 @@ namespace App\Http\Responses\Subsonic;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Http\Response;
 use Illuminate\Support\Arr;
+use InvalidArgumentException;
 use SimpleXMLElement;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
 class SubsonicResponse implements Responsable
 {
@@ -72,26 +74,15 @@ class SubsonicResponse implements Responsable
     }
 
     /** @param array<string, mixed> $envelope */
-    private function toJsonp(array $envelope, string $callback): Response
+    private function toJsonp(array $envelope, string $callback): SymfonyResponse
     {
-        if (!preg_match('/^[A-Za-z_$][A-Za-z0-9_$]*(?:\.[A-Za-z_$][A-Za-z0-9_$]*)*$/', $callback)) {
-            $errorBody = json_encode([
-                'subsonic-response' => [
-                    'status' => 'failed',
-                    'version' => self::API_VERSION,
-                    'type' => 'koel',
-                    'serverVersion' => koel_version(),
-                    'openSubsonic' => true,
-                    'error' => ['code' => 10, 'message' => 'Required parameter is missing.'],
-                ],
-            ]);
+        try {
+            return response()->jsonp($callback, ['subsonic-response' => $envelope]);
+        } catch (InvalidArgumentException) {
+            $errorEnvelope = self::error(10, 'Required parameter is missing.')->buildEnvelope();
 
-            return response($errorBody, Response::HTTP_OK, ['Content-Type' => 'application/json']);
+            return response()->json(['subsonic-response' => $errorEnvelope]);
         }
-
-        $body = $callback . '(' . json_encode(['subsonic-response' => $envelope]) . ');';
-
-        return response($body, Response::HTTP_OK, ['Content-Type' => 'application/javascript']);
     }
 
     /** @param array<string, mixed> $data */

--- a/app/Http/Responses/Subsonic/SubsonicResponse.php
+++ b/app/Http/Responses/Subsonic/SubsonicResponse.php
@@ -4,6 +4,7 @@ namespace App\Http\Responses\Subsonic;
 
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Http\Response;
+use Illuminate\Support\Arr;
 use SimpleXMLElement;
 
 class SubsonicResponse implements Responsable
@@ -84,7 +85,7 @@ class SubsonicResponse implements Responsable
         foreach ($data as $key => $value) {
             if (is_scalar($value) || $value === null) {
                 $element->addAttribute($key, self::formatScalar($value));
-            } elseif (array_is_list($value)) {
+            } elseif (Arr::isList($value)) {
                 foreach ($value as $item) {
                     $child = $element->addChild($key);
                     self::serializeTo($child, is_array($item) ? $item : ['value' => $item]);

--- a/app/Http/Responses/Subsonic/SubsonicResponse.php
+++ b/app/Http/Responses/Subsonic/SubsonicResponse.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Http\Responses\Subsonic;
+
+use Illuminate\Contracts\Support\Responsable;
+use Illuminate\Http\Response;
+use SimpleXMLElement;
+
+class SubsonicResponse implements Responsable
+{
+    public const string API_VERSION = '1.16.1';
+
+    /** @param array<string, mixed> $payload */
+    public function __construct(
+        private readonly array $payload = [],
+        private readonly ?int $errorCode = null,
+        private readonly ?string $errorMessage = null,
+    ) {}
+
+    /** @param array<string, mixed> $payload */
+    public static function ok(array $payload = []): self
+    {
+        return new self(payload: $payload);
+    }
+
+    public static function error(int $code, string $message): self
+    {
+        return new self(errorCode: $code, errorMessage: $message);
+    }
+
+    /** @inheritdoc */
+    public function toResponse($request)
+    {
+        $envelope = $this->buildEnvelope();
+
+        return match ($request->input('f')) {
+            'json' => response()->json(['subsonic-response' => $envelope]),
+            'jsonp' => $this->toJsonp($envelope, (string) $request->input('callback', '')),
+            default => $this->toXml($envelope),
+        };
+    }
+
+    /** @return array<string, mixed> */
+    private function buildEnvelope(): array
+    {
+        $envelope = [
+            'status' => $this->errorCode === null ? 'ok' : 'failed',
+            'version' => self::API_VERSION,
+            'type' => 'koel',
+            'serverVersion' => koel_version(),
+            'openSubsonic' => true,
+        ];
+
+        if ($this->errorCode !== null) {
+            $envelope['error'] = [
+                'code' => $this->errorCode,
+                'message' => $this->errorMessage,
+            ];
+        }
+
+        return $envelope + $this->payload;
+    }
+
+    /** @param array<string, mixed> $envelope */
+    private function toXml(array $envelope): Response
+    {
+        $root = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><subsonic-response/>');
+        self::serializeTo($root, $envelope);
+
+        return response($root->asXML(), 200, ['Content-Type' => 'application/xml']);
+    }
+
+    /** @param array<string, mixed> $envelope */
+    private function toJsonp(array $envelope, string $callback): Response
+    {
+        $body = $callback . '(' . json_encode(['subsonic-response' => $envelope]) . ');';
+
+        return response($body, 200, ['Content-Type' => 'application/javascript']);
+    }
+
+    /** @param array<string, mixed> $data */
+    private static function serializeTo(SimpleXMLElement $element, array $data): void
+    {
+        foreach ($data as $key => $value) {
+            if (is_scalar($value) || $value === null) {
+                $element->addAttribute($key, self::formatScalar($value));
+            } elseif (array_is_list($value)) {
+                foreach ($value as $item) {
+                    $child = $element->addChild($key);
+                    self::serializeTo($child, is_array($item) ? $item : ['value' => $item]);
+                }
+            } else {
+                $child = $element->addChild($key);
+                self::serializeTo($child, $value);
+            }
+        }
+    }
+
+    private static function formatScalar(mixed $value): string
+    {
+        return match (true) {
+            is_bool($value) => $value ? 'true' : 'false',
+            $value === null => '',
+            default => (string) $value,
+        };
+    }
+}

--- a/app/Http/Responses/Subsonic/SubsonicResponse.php
+++ b/app/Http/Responses/Subsonic/SubsonicResponse.php
@@ -67,7 +67,7 @@ class SubsonicResponse implements Responsable
         $root = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><subsonic-response/>');
         self::serializeTo($root, $envelope);
 
-        return response($root->asXML(), 200, ['Content-Type' => 'application/xml']);
+        return response($root->asXML(), Response::HTTP_OK, ['Content-Type' => 'application/xml']);
     }
 
     /** @param array<string, mixed> $envelope */
@@ -75,7 +75,7 @@ class SubsonicResponse implements Responsable
     {
         $body = $callback . '(' . json_encode(['subsonic-response' => $envelope]) . ');';
 
-        return response($body, 200, ['Content-Type' => 'application/javascript']);
+        return response($body, Response::HTTP_OK, ['Content-Type' => 'application/javascript']);
     }
 
     /** @param array<string, mixed> $data */

--- a/app/Http/Responses/Subsonic/SubsonicResponse.php
+++ b/app/Http/Responses/Subsonic/SubsonicResponse.php
@@ -74,6 +74,21 @@ class SubsonicResponse implements Responsable
     /** @param array<string, mixed> $envelope */
     private function toJsonp(array $envelope, string $callback): Response
     {
+        if (!preg_match('/^[A-Za-z_$][A-Za-z0-9_$]*(?:\.[A-Za-z_$][A-Za-z0-9_$]*)*$/', $callback)) {
+            $errorBody = json_encode([
+                'subsonic-response' => [
+                    'status' => 'failed',
+                    'version' => self::API_VERSION,
+                    'type' => 'koel',
+                    'serverVersion' => koel_version(),
+                    'openSubsonic' => true,
+                    'error' => ['code' => 10, 'message' => 'Required parameter is missing.'],
+                ],
+            ]);
+
+            return response($errorBody, Response::HTTP_OK, ['Content-Type' => 'application/json']);
+        }
+
         $body = $callback . '(' . json_encode(['subsonic-response' => $envelope]) . ');';
 
         return response($body, Response::HTTP_OK, ['Content-Type' => 'application/javascript']);

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -34,6 +34,7 @@ use Spatie\Permission\Traits\HasRoles;
  * @property ?Carbon $invited_at
  * @property ?User $invitedBy
  * @property ?string $invitation_token
+ * @property ?string $subsonic_api_key
  * @property Collection<array-key, Playlist> $collaboratedPlaylists
  * @property Collection<array-key, Playlist> $playlists
  * @property Collection<array-key, PlaylistFolder> $playlistFolders
@@ -61,8 +62,8 @@ use Spatie\Permission\Traits\HasRoles;
  */
 #[ObservedBy(UserObserver::class)]
 #[UseEloquentBuilder(UserBuilder::class)]
-#[Guarded(['id', 'public_id'])]
-#[Hidden(['password', 'remember_token', 'created_at', 'updated_at', 'invitation_accepted_at'])]
+#[Guarded(['id', 'public_id', 'subsonic_api_key'])]
+#[Hidden(['password', 'remember_token', 'subsonic_api_key', 'created_at', 'updated_at', 'invitation_accepted_at'])]
 #[Appends(['avatar'])]
 class User extends Authenticatable implements AuditableContract
 {

--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -18,6 +18,7 @@ class UserObserver
     public function creating(User $user): void
     {
         $user->public_id ??= Uuid::generate();
+        $user->subsonic_api_key ??= Uuid::generate();
     }
 
     public function updating(User $user): void

--- a/app/Repositories/UserRepository.php
+++ b/app/Repositories/UserRepository.php
@@ -41,6 +41,11 @@ class UserRepository extends Repository
         return User::query()->firstWhere('email', $email);
     }
 
+    public function findOneBySubsonicApiKey(#[\SensitiveParameter] string $apiKey): ?User
+    {
+        return User::query()->firstWhere('subsonic_api_key', $apiKey);
+    }
+
     public function findOneBySso(SsoUser $ssoUser): ?User
     {
         // we prioritize the SSO ID over the email address but still resort to the latter

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -13,12 +13,14 @@ use Illuminate\Foundation\Configuration\Middleware;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         using: static function (): void {
             RouteServiceProvider::loadVersionAwareRoutes('web');
             RouteServiceProvider::loadVersionAwareRoutes('api');
+            Route::middleware('api')->group(base_path('routes/subsonic.php'));
         },
         commands: __DIR__ . '/../routes/console.php',
         channels: __DIR__ . '/../routes/channels.php',

--- a/database/migrations/2026_05_27_202352_add_subsonic_api_key_to_users.php
+++ b/database/migrations/2026_05_27_202352_add_subsonic_api_key_to_users.php
@@ -1,0 +1,22 @@
+<?php
+
+use App\Helpers\Uuid;
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('users', static function (Blueprint $table): void {
+            $table->string('subsonic_api_key', 36)->nullable()->unique();
+        });
+
+        User::query()
+            ->whereNull('subsonic_api_key')
+            ->each(static function (User $user): void {
+                $user->forceFill(['subsonic_api_key' => Uuid::generate()])->saveQuietly();
+            });
+    }
+};

--- a/routes/subsonic.php
+++ b/routes/subsonic.php
@@ -1,0 +1,13 @@
+<?php
+
+use App\Http\Controllers\Subsonic\GetLicenseController;
+use App\Http\Controllers\Subsonic\PingController;
+use App\Http\Middleware\SubsonicAuth;
+use Illuminate\Support\Facades\Route;
+
+Route::prefix('rest')
+    ->middleware(SubsonicAuth::class)
+    ->group(static function (): void {
+        Route::match(['get', 'post'], 'ping.view', PingController::class);
+        Route::match(['get', 'post'], 'getLicense.view', GetLicenseController::class);
+    });

--- a/tests/Feature/Subsonic/GetLicenseTest.php
+++ b/tests/Feature/Subsonic/GetLicenseTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Feature\Subsonic;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+use function Tests\create_user;
+
+class GetLicenseTest extends TestCase
+{
+    #[Test]
+    public function returnsValidLicenseXml(): void
+    {
+        $user = create_user(['email' => 'alice@example.com']);
+
+        $response = $this->get('/rest/getLicense.view?apiKey=' . $user->subsonic_api_key)->assertOk()->assertHeader(
+            'Content-Type',
+            'application/xml',
+        );
+
+        $xml = simplexml_load_string($response->getContent());
+
+        self::assertSame('ok', (string) $xml['status']);
+        self::assertSame('true', (string) $xml->license['valid']);
+        self::assertSame('alice@example.com', (string) $xml->license['email']);
+    }
+
+    #[Test]
+    public function returnsValidLicenseJson(): void
+    {
+        $user = create_user(['email' => 'bob@example.com']);
+
+        $this
+            ->getJson('/rest/getLicense.view?apiKey=' . $user->subsonic_api_key . '&f=json')
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.status', 'ok')
+            ->assertJsonPath('subsonic-response.license.valid', true)
+            ->assertJsonPath('subsonic-response.license.email', 'bob@example.com');
+    }
+}

--- a/tests/Feature/Subsonic/PingTest.php
+++ b/tests/Feature/Subsonic/PingTest.php
@@ -67,4 +67,33 @@ class PingTest extends TestCase
 
         self::assertNotNull($user->subsonic_api_key);
     }
+
+    #[Test]
+    public function jsonpWrapsResponseInValidCallback(): void
+    {
+        $user = create_user();
+
+        $response = $this->get(
+            '/rest/ping.view?apiKey=' . $user->subsonic_api_key . '&f=jsonp&callback=myCallback',
+        )->assertOk();
+
+        $body = $response->getContent();
+        self::assertStringStartsWith('myCallback(', $body);
+        self::assertStringEndsWith(');', $body);
+    }
+
+    #[Test]
+    public function jsonpRejectsCallbackWithXssPayload(): void
+    {
+        $user = create_user();
+
+        $response = $this->get(
+            '/rest/ping.view?apiKey=' . $user->subsonic_api_key . '&f=jsonp&callback='
+                . urlencode('</script><script>evil()'),
+        )->assertOk();
+
+        self::assertStringNotContainsString('<script>', $response->getContent());
+        $response->assertJsonPath('subsonic-response.status', 'failed');
+        $response->assertJsonPath('subsonic-response.error.code', 10);
+    }
 }

--- a/tests/Feature/Subsonic/PingTest.php
+++ b/tests/Feature/Subsonic/PingTest.php
@@ -78,7 +78,7 @@ class PingTest extends TestCase
         )->assertOk();
 
         $body = $response->getContent();
-        self::assertStringStartsWith('myCallback(', $body);
+        self::assertStringContainsString('myCallback(', $body);
         self::assertStringEndsWith(');', $body);
     }
 

--- a/tests/Feature/Subsonic/PingTest.php
+++ b/tests/Feature/Subsonic/PingTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Feature\Subsonic;
+
+use App\Models\User;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+use function Tests\create_user;
+
+class PingTest extends TestCase
+{
+    #[Test]
+    public function pingReturnsOkXmlByDefault(): void
+    {
+        $user = create_user();
+
+        $response = $this->get('/rest/ping.view?apiKey=' . $user->subsonic_api_key)->assertOk()->assertHeader(
+            'Content-Type',
+            'application/xml',
+        );
+
+        $xml = simplexml_load_string($response->getContent());
+
+        self::assertSame('ok', (string) $xml['status']);
+        self::assertSame('1.16.1', (string) $xml['version']);
+        self::assertSame('koel', (string) $xml['type']);
+        self::assertSame('true', (string) $xml['openSubsonic']);
+    }
+
+    #[Test]
+    public function pingReturnsOkJsonWhenRequested(): void
+    {
+        $user = create_user();
+
+        $response = $this
+            ->getJson('/rest/ping.view?apiKey=' . $user->subsonic_api_key . '&f=json')
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.status', 'ok')
+            ->assertJsonPath('subsonic-response.version', '1.16.1')
+            ->assertJsonPath('subsonic-response.type', 'koel')
+            ->assertJsonPath('subsonic-response.openSubsonic', true);
+    }
+
+    #[Test]
+    public function missingApiKeyReturnsCode10Error(): void
+    {
+        $response = $this->getJson('/rest/ping.view?f=json')->assertOk();
+
+        $response->assertJsonPath('subsonic-response.status', 'failed');
+        $response->assertJsonPath('subsonic-response.error.code', 10);
+    }
+
+    #[Test]
+    public function invalidApiKeyReturnsCode40Error(): void
+    {
+        $response = $this->getJson('/rest/ping.view?apiKey=not-a-real-key&f=json')->assertOk();
+
+        $response->assertJsonPath('subsonic-response.status', 'failed');
+        $response->assertJsonPath('subsonic-response.error.code', 40);
+    }
+
+    #[Test]
+    public function userObserverPopulatesApiKeyOnCreate(): void
+    {
+        $user = User::factory()->createOne();
+
+        self::assertNotNull($user->subsonic_api_key);
+    }
+}

--- a/tests/Feature/Subsonic/ShowApiKeyCommandTest.php
+++ b/tests/Feature/Subsonic/ShowApiKeyCommandTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Feature\Subsonic;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+use function Tests\create_user;
+
+class ShowApiKeyCommandTest extends TestCase
+{
+    #[Test]
+    public function printsApiKeyForExistingUser(): void
+    {
+        $user = create_user(['email' => 'alice@example.com']);
+
+        $this
+            ->artisan('koel:subsonic:apikey', ['email' => 'alice@example.com'])
+            ->expectsOutput($user->subsonic_api_key)
+            ->assertSuccessful();
+    }
+
+    #[Test]
+    public function failsWhenUserNotFound(): void
+    {
+        $this->artisan('koel:subsonic:apikey', ['email' => 'ghost@example.com'])->assertFailed();
+    }
+}


### PR DESCRIPTION
## Subsonic API: phase 1

Foundation layer for a Subsonic-compatible API in koel. This PR lands the auth model + response wrapper + the two cheapest endpoints (`ping`, `getLicense`). Every subsequent endpoint becomes one controller + tests on top of this foundation.

## Scope

| What | Where |
|---|---|
| `subsonic_api_key` column on `users` (UUID, unique, nullable) | new migration; existing users get a key on migrate |
| Auto-generate the key on user creation | `UserObserver::creating` |
| `apiKey` query-param auth | new `SubsonicAuth` middleware — resolves user from key, sets the request user resolver |
| XML / JSON / JSONP response envelope (Open Subsonic 1.16.1 shape) | new `SubsonicResponse` Responsable, picks format from `f` query param |
| `GET\|POST /rest/ping.view` | `PingController` |
| `GET\|POST /rest/getLicense.view` | `GetLicenseController` (always-valid license) |
| `php artisan koel:subsonic:apikey {email}` | `ShowApiKeyCommand` — operators copy the key into their Subsonic client |

## Scope decisions

- **API version target: 1.16.1** with `openSubsonic="true"` flag for modern clients (Symfonium, Substreamer, etc.).
- **Auth: `apiKey`-only.** Legacy `u`+`t`+`s` salted-MD5 auth is not implemented; modern Subsonic clients support `apiKey`.
- **`type=koel`, `serverVersion=koel_version()`** in the response envelope — identifies the server to clients.
- **License endpoint always returns `valid=true`.** Subsonic was originally a paid product with license validation; koel is not, but clients still call `getLicense` for capability probing.
- **No Plus gate.** Subsonic compat is a core feature, not a Plus add-on — broadens the user base.

## Subsonic error codes used

- `10` — required parameter missing (no `apiKey`)
- `40` — wrong username or password (unknown `apiKey`)

Per spec, errors return HTTP 200 with `status="failed"` + an `<error code="" message=""/>` element. Subsonic clients don't expect 4xx for auth failures.

## Tests

- `PingTest` — XML default, JSON via `f=json`, missing-key returns code 10, invalid-key returns code 40, observer populates key on user create.
- `GetLicenseTest` — XML + JSON, embeds user email.
- `ShowApiKeyCommandTest` — prints key for existing user, fails on missing user.

Full backend suite: 1218 passed.

## Roadmap (future PRs, not in this one)

Phase 2: `getArtists`, `getArtist`, `getAlbum`, `getSong`, `getMusicFolders`. Phase 3: `search3`, `getAlbumList2`. Phase 4: `stream`, `getCoverArt`. Phase 5: playlists. Phase 6: scrobble, star/unstar, setRating. Phase 7: polish + real-client smoke testing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subsonic compatibility: ping and getLicense endpoints with XML, JSON, and JSONP outputs, standardized response envelope, and JSONP callback validation
  * Per-user Subsonic API keys auto-generated on account creation, backfilled for existing users, and hidden from normal serialization
  * Admin command to display a user’s Subsonic API key
  * Routes and middleware enabling API-key authentication with Subsonic-style error responses

* **Tests**
  * Feature tests covering ping, getLicense, JSON/JSONP behavior, API-key auth, key generation/backfill, and the admin API-key command

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2517?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->