### PR TITLE
feat: subsonic API browse endpoints

### DIFF
--- a/app/Http/Controllers/Subsonic/GetAlbumController.php
+++ b/app/Http/Controllers/Subsonic/GetAlbumController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Controllers\Subsonic;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Subsonic\IdRequest;
+use App\Http\Responses\Subsonic\Resources\AlbumResource;
+use App\Http\Responses\Subsonic\Resources\SongResource;
+use App\Http\Responses\Subsonic\SubsonicResponse;
+use App\Repositories\AlbumRepository;
+use App\Repositories\SongRepository;
+
+class GetAlbumController extends Controller
+{
+    public function __construct(
+        private readonly AlbumRepository $albumRepository,
+        private readonly SongRepository $songRepository,
+    ) {}
+
+    public function __invoke(IdRequest $request)
+    {
+        $album = $this->albumRepository->getOne($request->id());
+        $album->loadCount('songs')->loadSum('songs', 'length');
+
+        $songs = $this->songRepository->getByAlbum($album);
+        $songPayloads = [];
+
+        foreach ($songs as $song) {
+            $songPayloads[] = SongResource::toArray($song);
+        }
+
+        return SubsonicResponse::ok([
+            'album' => AlbumResource::toArray($album) + ['song' => $songPayloads],
+        ]);
+    }
+}

--- a/app/Http/Controllers/Subsonic/GetAlbumController.php
+++ b/app/Http/Controllers/Subsonic/GetAlbumController.php
@@ -19,7 +19,7 @@ class GetAlbumController extends Controller
 
     public function __invoke(IdRequest $request)
     {
-        $album = $this->albumRepository->getOne($request->id());
+        $album = $this->albumRepository->getOne($request->id);
         $album->loadCount('songs')->loadSum('songs', 'length');
 
         $songs = $this->songRepository->getByAlbum($album);

--- a/app/Http/Controllers/Subsonic/GetAlbumController.php
+++ b/app/Http/Controllers/Subsonic/GetAlbumController.php
@@ -23,14 +23,12 @@ class GetAlbumController extends Controller
         $album->loadCount('songs')->loadSum('songs', 'length');
 
         $songs = $this->songRepository->getByAlbum($album);
-        $songPayloads = [];
-
-        foreach ($songs as $song) {
-            $songPayloads[] = SongResource::toArray($song);
-        }
 
         return SubsonicResponse::ok([
-            'album' => AlbumResource::toArray($album) + ['song' => $songPayloads],
+            'album' => AlbumResource::toArray($album)
+                + [
+                    'song' => $songs->map(SongResource::toArray(...))->all(),
+                ],
         ]);
     }
 }

--- a/app/Http/Controllers/Subsonic/GetArtistController.php
+++ b/app/Http/Controllers/Subsonic/GetArtistController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Controllers\Subsonic;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Subsonic\IdRequest;
+use App\Http\Responses\Subsonic\Resources\AlbumResource;
+use App\Http\Responses\Subsonic\Resources\ArtistResource;
+use App\Http\Responses\Subsonic\SubsonicResponse;
+use App\Repositories\AlbumRepository;
+use App\Repositories\ArtistRepository;
+
+class GetArtistController extends Controller
+{
+    public function __construct(
+        private readonly ArtistRepository $artistRepository,
+        private readonly AlbumRepository $albumRepository,
+    ) {}
+
+    public function __invoke(IdRequest $request)
+    {
+        $artist = $this->artistRepository->getOne($request->id());
+        $artist->loadCount('albums');
+
+        $albums = $this->albumRepository->getByArtist($artist)->loadCount('songs')->loadSum('songs', 'length');
+        $albumPayloads = [];
+
+        foreach ($albums as $album) {
+            $albumPayloads[] = AlbumResource::toArray($album);
+        }
+
+        return SubsonicResponse::ok([
+            'artist' => ArtistResource::toArray($artist) + ['album' => $albumPayloads],
+        ]);
+    }
+}

--- a/app/Http/Controllers/Subsonic/GetArtistController.php
+++ b/app/Http/Controllers/Subsonic/GetArtistController.php
@@ -23,14 +23,12 @@ class GetArtistController extends Controller
         $artist->loadCount('albums');
 
         $albums = $this->albumRepository->getByArtist($artist)->loadCount('songs')->loadSum('songs', 'length');
-        $albumPayloads = [];
-
-        foreach ($albums as $album) {
-            $albumPayloads[] = AlbumResource::toArray($album);
-        }
 
         return SubsonicResponse::ok([
-            'artist' => ArtistResource::toArray($artist) + ['album' => $albumPayloads],
+            'artist' => ArtistResource::toArray($artist)
+                + [
+                    'album' => $albums->map(AlbumResource::toArray(...))->all(),
+                ],
         ]);
     }
 }

--- a/app/Http/Controllers/Subsonic/GetArtistController.php
+++ b/app/Http/Controllers/Subsonic/GetArtistController.php
@@ -19,7 +19,7 @@ class GetArtistController extends Controller
 
     public function __invoke(IdRequest $request)
     {
-        $artist = $this->artistRepository->getOne($request->id());
+        $artist = $this->artistRepository->getOne($request->id);
         $artist->loadCount('albums');
 
         $albums = $this->albumRepository->getByArtist($artist)->loadCount('songs')->loadSum('songs', 'length');

--- a/app/Http/Controllers/Subsonic/GetArtistsController.php
+++ b/app/Http/Controllers/Subsonic/GetArtistsController.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Http\Controllers\Subsonic;
+
+use App\Http\Controllers\Controller;
+use App\Http\Responses\Subsonic\Resources\ArtistResource;
+use App\Http\Responses\Subsonic\SubsonicResponse;
+use App\Models\Artist;
+use App\Repositories\ArtistRepository;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Str;
+
+class GetArtistsController extends Controller
+{
+    private const string IGNORED_ARTICLES = 'The El La Los Las Le Les';
+
+    public function __construct(
+        private readonly ArtistRepository $artistRepository,
+    ) {}
+
+    public function __invoke()
+    {
+        $ignored = array_map(Str::lower(...), explode(' ', self::IGNORED_ARTICLES));
+
+        $indexes = $this->artistRepository
+            ->getAll()
+            ->groupBy(static fn (Artist $artist) => self::indexLetter($artist->name, $ignored))
+            ->sortKeys()
+            ->map(static fn (Collection $group, string $letter) => [
+                'name' => $letter,
+                'artist' => $group->map(ArtistResource::toArray(...))->all(),
+            ])
+            ->values()
+            ->all();
+
+        return SubsonicResponse::ok([
+            'artists' => [
+                'ignoredArticles' => self::IGNORED_ARTICLES,
+                'index' => $indexes,
+            ],
+        ]);
+    }
+
+    /** @param array<string> $lowerArticles */
+    private static function indexLetter(string $name, array $lowerArticles): string
+    {
+        $name = Str::trim($name);
+        $lower = Str::lower($name);
+
+        foreach ($lowerArticles as $article) {
+            $prefix = $article . ' ';
+
+            if (Str::startsWith($lower, $prefix)) {
+                $name = Str::substr($name, Str::length($prefix));
+                break;
+            }
+        }
+
+        $first = Str::upper(Str::substr(trim($name), 0, 1));
+
+        return ctype_alpha($first) ? $first : '#';
+    }
+}

--- a/app/Http/Controllers/Subsonic/GetGenresController.php
+++ b/app/Http/Controllers/Subsonic/GetGenresController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers\Subsonic;
+
+use App\Http\Controllers\Controller;
+use App\Http\Responses\Subsonic\Resources\GenreResource;
+use App\Http\Responses\Subsonic\SubsonicResponse;
+use App\Repositories\GenreRepository;
+
+class GetGenresController extends Controller
+{
+    public function __construct(
+        private readonly GenreRepository $genreRepository,
+    ) {}
+
+    public function __invoke()
+    {
+        $genres = $this->genreRepository
+            ->getAllSummaries()
+            ->map(GenreResource::toArray(...))
+            ->all();
+
+        return SubsonicResponse::ok([
+            'genres' => [
+                'genre' => $genres,
+            ],
+        ]);
+    }
+}

--- a/app/Http/Controllers/Subsonic/GetMusicFoldersController.php
+++ b/app/Http/Controllers/Subsonic/GetMusicFoldersController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Controllers\Subsonic;
+
+use App\Http\Controllers\Controller;
+use App\Http\Responses\Subsonic\SubsonicResponse;
+
+class GetMusicFoldersController extends Controller
+{
+    public function __invoke()
+    {
+        return SubsonicResponse::ok([
+            'musicFolders' => [
+                'musicFolder' => [
+                    ['id' => 1, 'name' => 'Music'],
+                ],
+            ],
+        ]);
+    }
+}

--- a/app/Http/Controllers/Subsonic/GetSongController.php
+++ b/app/Http/Controllers/Subsonic/GetSongController.php
@@ -16,7 +16,7 @@ class GetSongController extends Controller
 
     public function __invoke(IdRequest $request)
     {
-        $song = $this->songRepository->getOne($request->id());
+        $song = $this->songRepository->getOne($request->id);
 
         return SubsonicResponse::ok([
             'song' => SongResource::toArray($song),

--- a/app/Http/Controllers/Subsonic/GetSongController.php
+++ b/app/Http/Controllers/Subsonic/GetSongController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers\Subsonic;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Subsonic\IdRequest;
+use App\Http\Responses\Subsonic\Resources\SongResource;
+use App\Http\Responses\Subsonic\SubsonicResponse;
+use App\Repositories\SongRepository;
+
+class GetSongController extends Controller
+{
+    public function __construct(
+        private readonly SongRepository $songRepository,
+    ) {}
+
+    public function __invoke(IdRequest $request)
+    {
+        $song = $this->songRepository->getOne($request->id());
+
+        return SubsonicResponse::ok([
+            'song' => SongResource::toArray($song),
+        ]);
+    }
+}

--- a/app/Http/Requests/Subsonic/IdRequest.php
+++ b/app/Http/Requests/Subsonic/IdRequest.php
@@ -4,6 +4,9 @@ namespace App\Http\Requests\Subsonic;
 
 use App\Http\Requests\Request;
 
+/**
+ * @property string $id
+ */
 class IdRequest extends Request
 {
     /** @inheritdoc */
@@ -12,10 +15,5 @@ class IdRequest extends Request
         return [
             'id' => ['required', 'string'],
         ];
-    }
-
-    public function id(): string
-    {
-        return (string) $this->input('id');
     }
 }

--- a/app/Http/Requests/Subsonic/IdRequest.php
+++ b/app/Http/Requests/Subsonic/IdRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Subsonic;
+
+use App\Http\Requests\Request;
+
+class IdRequest extends Request
+{
+    /** @inheritdoc */
+    public function rules(): array
+    {
+        return [
+            'id' => ['required', 'string'],
+        ];
+    }
+
+    public function id(): string
+    {
+        return (string) $this->input('id');
+    }
+}

--- a/app/Http/Responses/Subsonic/Resources/AlbumResource.php
+++ b/app/Http/Responses/Subsonic/Resources/AlbumResource.php
@@ -6,7 +6,19 @@ use App\Models\Album;
 
 final class AlbumResource
 {
-    /** @return array<string, mixed> */
+    /**
+     * @return array{
+     *     id: string,
+     *     name: string,
+     *     artist: string,
+     *     artistId: string,
+     *     coverArt: ?string,
+     *     songCount: int,
+     *     duration: int,
+     *     created: string,
+     *     year: ?int,
+     * }
+     */
     public static function toArray(Album $album): array
     {
         return [

--- a/app/Http/Responses/Subsonic/Resources/AlbumResource.php
+++ b/app/Http/Responses/Subsonic/Resources/AlbumResource.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Responses\Subsonic\Resources;
+
+use App\Models\Album;
+
+final class AlbumResource
+{
+    /** @return array<string, mixed> */
+    public static function toArray(Album $album): array
+    {
+        return [
+            'id' => $album->id,
+            'name' => $album->name,
+            'artist' => $album->artist_name,
+            'artistId' => $album->artist_id,
+            'coverArt' => $album->cover ? $album->id : null,
+            'songCount' => $album->songs_count ?? 0,
+            'duration' => (int) round($album->songs_sum_length ?? 0),
+            'created' => $album->created_at->toIso8601String(),
+            'year' => $album->year,
+        ];
+    }
+}

--- a/app/Http/Responses/Subsonic/Resources/ArtistResource.php
+++ b/app/Http/Responses/Subsonic/Resources/ArtistResource.php
@@ -6,7 +6,14 @@ use App\Models\Artist;
 
 final class ArtistResource
 {
-    /** @return array<string, mixed> */
+    /**
+     * @return array{
+     *     id: string,
+     *     name: string,
+     *     coverArt: ?string,
+     *     albumCount: int,
+     * }
+     */
     public static function toArray(Artist $artist): array
     {
         return [

--- a/app/Http/Responses/Subsonic/Resources/ArtistResource.php
+++ b/app/Http/Responses/Subsonic/Resources/ArtistResource.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Responses\Subsonic\Resources;
+
+use App\Models\Artist;
+
+final class ArtistResource
+{
+    /** @return array<string, mixed> */
+    public static function toArray(Artist $artist): array
+    {
+        return [
+            'id' => $artist->id,
+            'name' => $artist->name,
+            'coverArt' => $artist->image ? $artist->id : null,
+            'albumCount' => $artist->albums_count ?? 0,
+        ];
+    }
+}

--- a/app/Http/Responses/Subsonic/Resources/GenreResource.php
+++ b/app/Http/Responses/Subsonic/Resources/GenreResource.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Responses\Subsonic\Resources;
+
+use App\Values\GenreSummary;
+
+final class GenreResource
+{
+    /** @return array<string, mixed> */
+    public static function toArray(GenreSummary $genre): array
+    {
+        return [
+            'songCount' => $genre->songCount,
+            'albumCount' => 0,
+            'value' => $genre->name,
+        ];
+    }
+}

--- a/app/Http/Responses/Subsonic/Resources/GenreResource.php
+++ b/app/Http/Responses/Subsonic/Resources/GenreResource.php
@@ -6,7 +6,13 @@ use App\Values\GenreSummary;
 
 final class GenreResource
 {
-    /** @return array<string, mixed> */
+    /**
+     * @return array{
+     *     songCount: int,
+     *     albumCount: int,
+     *     value: string,
+     * }
+     */
     public static function toArray(GenreSummary $genre): array
     {
         return [

--- a/app/Http/Responses/Subsonic/Resources/SongResource.php
+++ b/app/Http/Responses/Subsonic/Resources/SongResource.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Responses\Subsonic\Resources;
+
+use App\Models\Song;
+
+final class SongResource
+{
+    /** @return array<string, mixed> */
+    public static function toArray(Song $song): array
+    {
+        return [
+            'id' => $song->id,
+            'parent' => $song->album_id,
+            'isDir' => false,
+            'title' => $song->title,
+            'album' => $song->album_name,
+            'artist' => $song->artist_name,
+            'track' => $song->track ?: null,
+            'year' => $song->year,
+            'genre' => $song->genre ?: null,
+            'coverArt' => $song->album?->cover ? $song->album_id : null,
+            'size' => $song->file_size,
+            'contentType' => $song->mime_type,
+            'suffix' => pathinfo($song->path, PATHINFO_EXTENSION) ?: null,
+            'duration' => (int) round($song->length),
+            'created' => $song->created_at->toIso8601String(),
+            'albumId' => $song->album_id,
+            'artistId' => $song->artist_id,
+            'type' => 'music',
+            'discNumber' => $song->disc ?: null,
+            'isVideo' => false,
+        ];
+    }
+}

--- a/app/Http/Responses/Subsonic/Resources/SongResource.php
+++ b/app/Http/Responses/Subsonic/Resources/SongResource.php
@@ -6,7 +6,30 @@ use App\Models\Song;
 
 final class SongResource
 {
-    /** @return array<string, mixed> */
+    /**
+     * @return array{
+     *     id: string,
+     *     parent: string,
+     *     isDir: bool,
+     *     title: string,
+     *     album: ?string,
+     *     artist: ?string,
+     *     track: ?int,
+     *     year: ?int,
+     *     genre: ?string,
+     *     coverArt: ?string,
+     *     size: ?int,
+     *     contentType: ?string,
+     *     suffix: ?string,
+     *     duration: int,
+     *     created: string,
+     *     albumId: string,
+     *     artistId: string,
+     *     type: string,
+     *     discNumber: ?int,
+     *     isVideo: bool,
+     * }
+     */
     public static function toArray(Song $song): array
     {
         return [

--- a/app/Http/Responses/Subsonic/SubsonicResponse.php
+++ b/app/Http/Responses/Subsonic/SubsonicResponse.php
@@ -34,13 +34,32 @@ class SubsonicResponse implements Responsable
     /** @inheritdoc */
     public function toResponse($request)
     {
-        $envelope = $this->buildEnvelope();
+        $envelope = self::stripNulls($this->buildEnvelope());
 
         return match ($request->input('f')) {
             'json' => response()->json(['subsonic-response' => $envelope]),
             'jsonp' => $this->toJsonp($envelope, (string) $request->input('callback', '')),
             default => $this->toXml($envelope),
         };
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @return array<string, mixed>
+     */
+    private static function stripNulls(array $data): array
+    {
+        $result = [];
+
+        foreach ($data as $key => $value) {
+            if ($value === null) {
+                continue;
+            }
+
+            $result[$key] = is_array($value) ? self::stripNulls($value) : $value;
+        }
+
+        return $result;
     }
 
     /** @return array<string, mixed> */
@@ -93,14 +112,24 @@ class SubsonicResponse implements Responsable
                 $element->addAttribute($key, self::formatScalar($value));
             } elseif (Arr::isList($value)) {
                 foreach ($value as $item) {
-                    $child = $element->addChild($key);
-                    self::serializeTo($child, is_array($item) ? $item : ['value' => $item]);
+                    self::appendChild($element, $key, is_array($item) ? $item : ['value' => $item]);
                 }
             } else {
-                $child = $element->addChild($key);
-                self::serializeTo($child, $value);
+                self::appendChild($element, $key, $value);
             }
         }
+    }
+
+    /** @param array<string, mixed> $data */
+    private static function appendChild(SimpleXMLElement $parent, string $key, array $data): void
+    {
+        $text = $data['value'] ?? null;
+
+        $child = is_scalar($text)
+            ? $parent->addChild($key, htmlspecialchars(self::formatScalar($text), ENT_XML1, 'UTF-8'))
+            : $parent->addChild($key);
+
+        self::serializeTo($child, Arr::except($data, 'value'));
     }
 
     private static function formatScalar(mixed $value): string

--- a/app/Repositories/AlbumRepository.php
+++ b/app/Repositories/AlbumRepository.php
@@ -57,6 +57,7 @@ class AlbumRepository extends Repository implements ScoutableRepository
         return $preserveOrder ? $albums->orderByArray($ids) : $albums;
     }
 
+    /** @return Collection<int, Album> */
     public function getByArtist(Artist $artist, ?User $user = null): Collection
     {
         return Album::query()

--- a/app/Repositories/ArtistRepository.php
+++ b/app/Repositories/ArtistRepository.php
@@ -57,6 +57,17 @@ class ArtistRepository extends Repository implements ScoutableRepository
         return $preserveOrder ? $artists->orderByArray($ids) : $artists;
     }
 
+    public function getAll(?User $user = null): Collection
+    {
+        return Artist::query()
+            ->withUserContext(user: $user ?? $this->auth->user())
+            ->onlyStandard()
+            ->onlyAlbumArtists()
+            ->withCount('albums')
+            ->orderBy('name')
+            ->get();
+    }
+
     public function getForListing(
         string $sortColumn,
         string $sortDirection,

--- a/app/Repositories/SongRepository.php
+++ b/app/Repositories/SongRepository.php
@@ -152,6 +152,7 @@ class SongRepository extends Repository implements ScoutableRepository
             ->get();
     }
 
+    /** @return Collection<int, Song> */
     public function getByAlbum(Album|string $album, ?User $scopedUser = null): Collection
     {
         $album = $this->albumRepository->resolveOne($album);

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -5,6 +5,7 @@ use App\Http\Middleware\ForceHttps;
 use App\Http\Middleware\HandleDemoMode;
 use App\Http\Middleware\ObjectStorageAuthenticate;
 use App\Http\Middleware\RestrictPlusFeatures;
+use App\Http\Responses\Subsonic\SubsonicResponse;
 use App\Providers\RouteServiceProvider;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Foundation\Application;
@@ -14,6 +15,9 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Validation\ValidationException;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -58,6 +62,18 @@ return Application::configure(basePath: dirname(__DIR__))
             }
 
             return redirect()->guest('/');
+        });
+
+        $exceptions->render(static function (NotFoundHttpException $e, Request $request): ?SymfonyResponse {
+            return $request->is('rest/*')
+                ? SubsonicResponse::error(70, 'The requested data was not found.')->toResponse($request)
+                : null;
+        });
+
+        $exceptions->render(static function (ValidationException $e, Request $request): ?SymfonyResponse {
+            return $request->is('rest/*')
+                ? SubsonicResponse::error(10, 'Required parameter is missing.')->toResponse($request)
+                : null;
         });
     })
     ->create();

--- a/routes/subsonic.php
+++ b/routes/subsonic.php
@@ -1,6 +1,12 @@
 <?php
 
+use App\Http\Controllers\Subsonic\GetAlbumController;
+use App\Http\Controllers\Subsonic\GetArtistController;
+use App\Http\Controllers\Subsonic\GetArtistsController;
+use App\Http\Controllers\Subsonic\GetGenresController;
 use App\Http\Controllers\Subsonic\GetLicenseController;
+use App\Http\Controllers\Subsonic\GetMusicFoldersController;
+use App\Http\Controllers\Subsonic\GetSongController;
 use App\Http\Controllers\Subsonic\PingController;
 use App\Http\Middleware\SubsonicAuth;
 use Illuminate\Support\Facades\Route;
@@ -10,4 +16,10 @@ Route::prefix('rest')
     ->group(static function (): void {
         Route::match(['get', 'post'], 'ping.view', PingController::class);
         Route::match(['get', 'post'], 'getLicense.view', GetLicenseController::class);
+        Route::match(['get', 'post'], 'getMusicFolders.view', GetMusicFoldersController::class);
+        Route::match(['get', 'post'], 'getArtists.view', GetArtistsController::class);
+        Route::match(['get', 'post'], 'getArtist.view', GetArtistController::class);
+        Route::match(['get', 'post'], 'getAlbum.view', GetAlbumController::class);
+        Route::match(['get', 'post'], 'getSong.view', GetSongController::class);
+        Route::match(['get', 'post'], 'getGenres.view', GetGenresController::class);
     });

--- a/tests/Feature/Subsonic/GetAlbumTest.php
+++ b/tests/Feature/Subsonic/GetAlbumTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Feature\Subsonic;
+
+use App\Models\Album;
+use App\Models\Song;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+use function Tests\create_user;
+
+class GetAlbumTest extends TestCase
+{
+    #[Test]
+    public function returnsAlbumWithSongs(): void
+    {
+        $user = create_user();
+        $album = Album::factory()->createOne(['name' => 'OK Computer', 'user_id' => $user->id]);
+
+        Song::factory()->createMany([
+            ['title' => 'Airbag', 'album_id' => $album->id, 'owner_id' => $user->id],
+            ['title' => 'Paranoid Android', 'album_id' => $album->id, 'owner_id' => $user->id],
+        ]);
+
+        $response = $this
+            ->getJson("/rest/getAlbum.view?apiKey={$user->subsonic_api_key}&f=json&id={$album->id}")
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.status', 'ok')
+            ->assertJsonPath('subsonic-response.album.id', $album->id)
+            ->assertJsonPath('subsonic-response.album.name', 'OK Computer');
+
+        $titles = collect($response->json('subsonic-response.album.song'))->pluck('title')->all();
+        self::assertContains('Airbag', $titles);
+        self::assertContains('Paranoid Android', $titles);
+    }
+
+    #[Test]
+    public function unknownIdReturnsCode70(): void
+    {
+        $user = create_user();
+
+        $this
+            ->getJson("/rest/getAlbum.view?apiKey={$user->subsonic_api_key}&f=json&id=does-not-exist")
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.error.code', 70);
+    }
+}

--- a/tests/Feature/Subsonic/GetAlbumTest.php
+++ b/tests/Feature/Subsonic/GetAlbumTest.php
@@ -42,6 +42,7 @@ class GetAlbumTest extends TestCase
         $this
             ->getJson("/rest/getAlbum.view?apiKey={$user->subsonic_api_key}&f=json&id=does-not-exist")
             ->assertOk()
+            ->assertJsonPath('subsonic-response.status', 'failed')
             ->assertJsonPath('subsonic-response.error.code', 70);
     }
 }

--- a/tests/Feature/Subsonic/GetArtistTest.php
+++ b/tests/Feature/Subsonic/GetArtistTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Feature\Subsonic;
+
+use App\Models\Album;
+use App\Models\Artist;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+use function Tests\create_user;
+
+class GetArtistTest extends TestCase
+{
+    #[Test]
+    public function returnsArtistWithAlbums(): void
+    {
+        $user = create_user();
+        $artist = Artist::factory()->createOne(['name' => 'Tool', 'user_id' => $user->id]);
+
+        Album::factory()->createMany([
+            ['name' => 'Ænima', 'artist_id' => $artist->id, 'artist_name' => $artist->name, 'user_id' => $user->id],
+            ['name' => 'Lateralus', 'artist_id' => $artist->id, 'artist_name' => $artist->name, 'user_id' => $user->id],
+        ]);
+
+        $response = $this
+            ->getJson("/rest/getArtist.view?apiKey={$user->subsonic_api_key}&f=json&id={$artist->id}")
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.status', 'ok')
+            ->assertJsonPath('subsonic-response.artist.id', $artist->id)
+            ->assertJsonPath('subsonic-response.artist.name', 'Tool');
+
+        $albumNames = collect($response->json('subsonic-response.artist.album'))->pluck('name')->all();
+        self::assertContains('Ænima', $albumNames);
+        self::assertContains('Lateralus', $albumNames);
+    }
+
+    #[Test]
+    public function unknownIdReturnsCode70(): void
+    {
+        $user = create_user();
+
+        $this
+            ->getJson("/rest/getArtist.view?apiKey={$user->subsonic_api_key}&f=json&id=does-not-exist")
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.status', 'failed')
+            ->assertJsonPath('subsonic-response.error.code', 70);
+    }
+
+    #[Test]
+    public function missingIdReturnsCode10(): void
+    {
+        $user = create_user();
+
+        $this
+            ->getJson("/rest/getArtist.view?apiKey={$user->subsonic_api_key}&f=json")
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.status', 'failed')
+            ->assertJsonPath('subsonic-response.error.code', 10);
+    }
+}

--- a/tests/Feature/Subsonic/GetArtistsTest.php
+++ b/tests/Feature/Subsonic/GetArtistsTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Feature\Subsonic;
+
+use App\Models\Album;
+use App\Models\Artist;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+use function Tests\create_user;
+
+class GetArtistsTest extends TestCase
+{
+    #[Test]
+    public function bucketsArtistsByLetterAndStripsArticles(): void
+    {
+        $user = create_user();
+
+        $abba = Artist::factory()->createOne(['name' => 'Abba', 'user_id' => $user->id]);
+        $beatles = Artist::factory()->createOne(['name' => 'The Beatles', 'user_id' => $user->id]);
+        $hundredGecs = Artist::factory()->createOne(['name' => '100 gecs', 'user_id' => $user->id]);
+
+        Album::factory()->createOne(['artist_id' => $abba->id, 'artist_name' => $abba->name, 'user_id' => $user->id]);
+        Album::factory()->createOne([
+            'artist_id' => $beatles->id,
+            'artist_name' => $beatles->name,
+            'user_id' => $user->id,
+        ]);
+        Album::factory()->createOne([
+            'artist_id' => $hundredGecs->id,
+            'artist_name' => $hundredGecs->name,
+            'user_id' => $user->id,
+        ]);
+
+        $response = $this
+            ->getJson('/rest/getArtists.view?apiKey=' . $user->subsonic_api_key . '&f=json')
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.status', 'ok')
+            ->assertJsonPath('subsonic-response.artists.ignoredArticles', 'The El La Los Las Le Les');
+
+        $indexes = $response->json('subsonic-response.artists.index');
+        $byLetter = collect($indexes)->keyBy('name');
+
+        self::assertSame('Abba', $byLetter->get('A')['artist'][0]['name']);
+        self::assertSame('The Beatles', $byLetter->get('B')['artist'][0]['name']);
+        self::assertSame('100 gecs', $byLetter->get('#')['artist'][0]['name']);
+    }
+
+    #[Test]
+    public function excludesArtistsWithoutAlbums(): void
+    {
+        $user = create_user();
+
+        Artist::factory()->createOne(['name' => 'Lonely', 'user_id' => $user->id]);
+
+        $response = $this->getJson('/rest/getArtists.view?apiKey=' . $user->subsonic_api_key . '&f=json')->assertOk();
+
+        $names = collect($response->json('subsonic-response.artists.index') ?? [])
+            ->flatMap(static fn (array $idx) => array_column($idx['artist'], 'name'));
+
+        self::assertFalse($names->contains('Lonely'));
+    }
+}

--- a/tests/Feature/Subsonic/GetGenresTest.php
+++ b/tests/Feature/Subsonic/GetGenresTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Feature\Subsonic;
+
+use App\Models\Genre;
+use App\Models\Song;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+use function Tests\create_user;
+
+class GetGenresTest extends TestCase
+{
+    #[Test]
+    public function returnsGenresWithCounts(): void
+    {
+        $user = create_user();
+
+        $rock = Genre::factory()->createOne(['name' => 'Rock']);
+        $song = Song::factory()->createOne(['owner_id' => $user->id]);
+        $song->genres()->attach($rock->id);
+
+        $response = $this
+            ->getJson('/rest/getGenres.view?apiKey=' . $user->subsonic_api_key . '&f=json')
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.status', 'ok');
+
+        $genres = collect($response->json('subsonic-response.genres.genre') ?? []);
+        $rockEntry = $genres->firstWhere('value', 'Rock');
+
+        self::assertNotNull($rockEntry);
+        self::assertSame(1, $rockEntry['songCount']);
+    }
+}

--- a/tests/Feature/Subsonic/GetMusicFoldersTest.php
+++ b/tests/Feature/Subsonic/GetMusicFoldersTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Feature\Subsonic;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+use function Tests\create_user;
+
+class GetMusicFoldersTest extends TestCase
+{
+    #[Test]
+    public function returnsSingleMusicFolder(): void
+    {
+        $user = create_user();
+
+        $this
+            ->getJson('/rest/getMusicFolders.view?apiKey=' . $user->subsonic_api_key . '&f=json')
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.status', 'ok')
+            ->assertJsonPath('subsonic-response.musicFolders.musicFolder.0.id', 1)
+            ->assertJsonPath('subsonic-response.musicFolders.musicFolder.0.name', 'Music');
+    }
+}

--- a/tests/Feature/Subsonic/GetSongTest.php
+++ b/tests/Feature/Subsonic/GetSongTest.php
@@ -34,6 +34,7 @@ class GetSongTest extends TestCase
         $this
             ->getJson("/rest/getSong.view?apiKey={$user->subsonic_api_key}&f=json&id=does-not-exist")
             ->assertOk()
+            ->assertJsonPath('subsonic-response.status', 'failed')
             ->assertJsonPath('subsonic-response.error.code', 70);
     }
 }

--- a/tests/Feature/Subsonic/GetSongTest.php
+++ b/tests/Feature/Subsonic/GetSongTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Feature\Subsonic;
+
+use App\Models\Song;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+use function Tests\create_user;
+
+class GetSongTest extends TestCase
+{
+    #[Test]
+    public function returnsSong(): void
+    {
+        $user = create_user();
+        $song = Song::factory()->createOne(['title' => 'Karma Police', 'owner_id' => $user->id]);
+
+        $this
+            ->getJson("/rest/getSong.view?apiKey={$user->subsonic_api_key}&f=json&id={$song->id}")
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.status', 'ok')
+            ->assertJsonPath('subsonic-response.song.id', $song->id)
+            ->assertJsonPath('subsonic-response.song.title', 'Karma Police')
+            ->assertJsonPath('subsonic-response.song.type', 'music')
+            ->assertJsonPath('subsonic-response.song.isDir', false);
+    }
+
+    #[Test]
+    public function unknownIdReturnsCode70(): void
+    {
+        $user = create_user();
+
+        $this
+            ->getJson("/rest/getSong.view?apiKey={$user->subsonic_api_key}&f=json&id=does-not-exist")
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.error.code', 70);
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 of the Subsonic API — the browse family. Builds on the foundation in #2517.

New endpoints under `/rest/`:

- `getMusicFolders.view` — single synthetic "Music" folder representing the koel library
- `getArtists.view` — all artists bucketed by first letter, with ignored-articles normalization (`The Beatles` → `B` bucket, `100 gecs` → `#`)
- `getArtist.view?id=…` — artist with their albums, including per-album song count and total duration
- `getAlbum.view?id=…` — album with its songs
- `getSong.view?id=…` — single song
- `getGenres.view` — all genres with song counts

All endpoints reuse the existing user-scoped repositories (`ArtistRepository`, `AlbumRepository`, `SongRepository`, `GenreRepository`) — the Subsonic auth middleware sets the user via `Auth::setUser`, so the rest of the stack sees a normal authenticated request.

## Design notes

### ID scheme — raw IDs, no typed prefix

Album, Artist and Song now all use stable string IDs (ULID/UUID) after the 2025 `promote_public_ids` migration. They're wide enough to be globally unique in practice, so a typed-prefix scheme like `ar-…/al-…/so-…` would be ceremony for no real benefit. The few polymorphic endpoints in later phases (`star.view`, `getCoverArt.view`) can route by looking up which repository finds the row.

### Resource mappers

Subsonic responses don't map cleanly to Laravel's `JsonResource` (XML/JSON/JSONP all served from the same envelope), so each entity has a plain mapper class under `App\Http\Responses\Subsonic\Resources\` with a `toArray(Model): array` static. Mappers expect counts (`albums_count`, `songs_count`, `songs_sum_length`) to be eager-loaded by the controller — they never trigger lazy loads, which keeps them safe under koel's `preventLazyLoading`.

### Null stripping + XML text-content support in `SubsonicResponse`

- `stripNulls()` recursively drops null values from the envelope so optional fields don't surface as `year=""` or `"year": null`.
- `appendChild()` honors a `value` sentinel key (Subsonic's own JSON convention for element text) so the XML serializer can emit `<genre songCount="1">Rock</genre>` instead of forcing everything to be an attribute.

### Exception handling

Two new render hooks in `bootstrap/app.php`, both scoped to `rest/*`:

- `NotFoundHttpException` → Subsonic error code 70. Catching `NotFoundHttpException` (not `ModelNotFoundException`) because Laravel's `prepareException` converts the model variant to the HTTP variant *before* user render hooks run.
- `ValidationException` → Subsonic error code 10 ("Required parameter is missing"), used by the shared `IdRequest`.

## Known follow-ups

- `genres.genre[].albumCount` is currently always `0` — `GenreSummary` doesn't carry album count yet. Widening that value object belongs in its own PR.
- `coverArt` IDs are emitted on artists/albums/songs, but `getCoverArt.view` lands in Phase 4. Clients will get 404s for cover URLs until then; harmless.
- Optional fields not yet emitted: `path`, `bitRate`.

## Test plan

- [x] `php artisan test --compact tests/Feature/Subsonic/` — 22 passed, 83 assertions
- [x] `composer cs` / `composer lint` / `composer analyze` all green
- [ ] Manually browse a koel library from a Subsonic client (e.g. play:Sub, DSub, Symfonium) — happy-path browse from artists → albums → songs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Subsonic API endpoints: music folders, artists (index/grouped), artist details with albums, album details with songs, song details, and genres.
  * Responses now strip null fields and have improved XML/serialization handling.
  * Added clearer Subsonic-formatted error responses for missing resources and validation issues.

* **Tests**
  * Added feature tests covering all new Subsonic endpoints and related error cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2518?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->