### PR TITLE
feat: subsonic API search and album listing

### DIFF
--- a/app/Http/Controllers/Subsonic/GetAlbumList2Controller.php
+++ b/app/Http/Controllers/Subsonic/GetAlbumList2Controller.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Controllers\Subsonic;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Subsonic\GetAlbumList2Request;
+use App\Http\Responses\Subsonic\Resources\AlbumResource;
+use App\Http\Responses\Subsonic\SubsonicResponse;
+use App\Models\Album;
+use App\Repositories\AlbumRepository;
+use Illuminate\Database\Eloquent\Collection;
+use LogicException;
+
+class GetAlbumList2Controller extends Controller
+{
+    public function __construct(
+        private readonly AlbumRepository $albumRepository,
+    ) {}
+
+    public function __invoke(GetAlbumList2Request $request)
+    {
+        $size = $request->integer('size', 10);
+        $offset = $request->integer('offset', 0);
+
+        $albums = $this->loadAlbums($request->type, $size, $offset)->loadCount('songs')->loadSum('songs', 'length');
+
+        return SubsonicResponse::ok([
+            'albumList2' => [
+                'album' => $albums->map(AlbumResource::toArray(...))->all(),
+            ],
+        ]);
+    }
+
+    /** @return Collection<int, Album> */
+    private function loadAlbums(string $type, int $size, int $offset): Collection
+    {
+        return match ($type) {
+            'newest' => $this->albumRepository->getRecentlyAdded($size),
+            'frequent' => $this->albumRepository->getMostPlayed($size),
+            'random' => $this->albumRepository->getRandom($size),
+            'starred' => $this->albumRepository->getFavorites(),
+            'alphabeticalByName' => $this->albumRepository->getOrdered('albums.name', 'asc', $size, $offset),
+            default => throw new LogicException("Unsupported album list type: {$type}"),
+        };
+    }
+}

--- a/app/Http/Controllers/Subsonic/GetAlbumList2Controller.php
+++ b/app/Http/Controllers/Subsonic/GetAlbumList2Controller.php
@@ -38,7 +38,7 @@ class GetAlbumList2Controller extends Controller
             'newest' => $this->albumRepository->getRecentlyAdded($size),
             'frequent' => $this->albumRepository->getMostPlayed($size),
             'random' => $this->albumRepository->getRandom($size),
-            'starred' => $this->albumRepository->getFavorites(),
+            'starred' => $this->albumRepository->getFavorites($size, $offset),
             'alphabeticalByName' => $this->albumRepository->getOrdered('albums.name', 'asc', $size, $offset),
             default => throw new LogicException("Unsupported album list type: {$type}"),
         };

--- a/app/Http/Controllers/Subsonic/Search3Controller.php
+++ b/app/Http/Controllers/Subsonic/Search3Controller.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Controllers\Subsonic;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Subsonic\Search3Request;
+use App\Http\Responses\Subsonic\Resources\AlbumResource;
+use App\Http\Responses\Subsonic\Resources\ArtistResource;
+use App\Http\Responses\Subsonic\Resources\SongResource;
+use App\Http\Responses\Subsonic\SubsonicResponse;
+use App\Repositories\AlbumRepository;
+use App\Repositories\ArtistRepository;
+use App\Repositories\SongRepository;
+
+class Search3Controller extends Controller
+{
+    public function __construct(
+        private readonly ArtistRepository $artistRepository,
+        private readonly AlbumRepository $albumRepository,
+        private readonly SongRepository $songRepository,
+    ) {}
+
+    public function __invoke(Search3Request $request)
+    {
+        $artists = $this->artistRepository
+            ->search($request->input('query'), $request->integer('artistCount', 20))
+            ->loadCount('albums');
+
+        $albums = $this->albumRepository
+            ->search($request->input('query'), $request->integer('albumCount', 20))
+            ->loadCount('songs')
+            ->loadSum('songs', 'length');
+
+        $songs = $this->songRepository->search($request->input('query'), $request->integer('songCount', 20));
+
+        return SubsonicResponse::ok([
+            'searchResult3' => [
+                'artist' => $artists->map(ArtistResource::toArray(...))->all(),
+                'album' => $albums->map(AlbumResource::toArray(...))->all(),
+                'song' => $songs->map(SongResource::toArray(...))->all(),
+            ],
+        ]);
+    }
+}

--- a/app/Http/Requests/Subsonic/GetAlbumList2Request.php
+++ b/app/Http/Requests/Subsonic/GetAlbumList2Request.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Requests\Subsonic;
+
+use App\Http\Requests\Request;
+
+/**
+ * @property string $type
+ */
+class GetAlbumList2Request extends Request
+{
+    public const array SUPPORTED_TYPES = [
+        'newest',
+        'frequent',
+        'random',
+        'starred',
+        'alphabeticalByName',
+    ];
+
+    /** @inheritdoc */
+    public function rules(): array
+    {
+        return [
+            'type' => ['required', 'string', 'in:' . implode(',', self::SUPPORTED_TYPES)],
+            'size' => ['integer', 'min:1', 'max:500'],
+            'offset' => ['integer', 'min:0'],
+        ];
+    }
+}

--- a/app/Http/Requests/Subsonic/Search3Request.php
+++ b/app/Http/Requests/Subsonic/Search3Request.php
@@ -11,9 +11,9 @@ class Search3Request extends Request
     {
         return [
             'query' => ['required', 'string'],
-            'artistCount' => ['integer', 'min:0'],
-            'albumCount' => ['integer', 'min:0'],
-            'songCount' => ['integer', 'min:0'],
+            'artistCount' => ['integer', 'min:0', 'max:500'],
+            'albumCount' => ['integer', 'min:0', 'max:500'],
+            'songCount' => ['integer', 'min:0', 'max:500'],
         ];
     }
 }

--- a/app/Http/Requests/Subsonic/Search3Request.php
+++ b/app/Http/Requests/Subsonic/Search3Request.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Requests\Subsonic;
+
+use App\Http\Requests\Request;
+
+class Search3Request extends Request
+{
+    /** @inheritdoc */
+    public function rules(): array
+    {
+        return [
+            'query' => ['required', 'string'],
+            'artistCount' => ['integer', 'min:0'],
+            'albumCount' => ['integer', 'min:0'],
+            'songCount' => ['integer', 'min:0'],
+        ];
+    }
+}

--- a/app/Repositories/AlbumRepository.php
+++ b/app/Repositories/AlbumRepository.php
@@ -73,6 +73,44 @@ class AlbumRepository extends Repository implements ScoutableRepository
             ->get();
     }
 
+    /** @return Collection<int, Album> */
+    public function getFavorites(?User $user = null): Collection
+    {
+        return Album::query()
+            ->onlyStandard()
+            ->withUserContext(user: $user ?? $this->auth->user(), favoritesOnly: true)
+            ->orderBy('favorites.position')
+            ->get();
+    }
+
+    /** @return Collection<int, Album> */
+    public function getRandom(int $limit, ?User $user = null): Collection
+    {
+        return Album::query()
+            ->onlyStandard()
+            ->withUserContext(user: $user ?? $this->auth->user())
+            ->inRandomOrder()
+            ->limit($limit)
+            ->get();
+    }
+
+    /** @return Collection<int, Album> */
+    public function getOrdered(
+        string $sortColumn,
+        string $sortDirection,
+        int $limit,
+        int $offset = 0,
+        ?User $user = null,
+    ): Collection {
+        return Album::query()
+            ->onlyStandard()
+            ->withUserContext(user: $user ?? $this->auth->user())
+            ->sort($sortColumn, $sortDirection)
+            ->offset($offset)
+            ->limit($limit)
+            ->get();
+    }
+
     public function getForListing(
         string $sortColumn,
         string $sortDirection,

--- a/app/Repositories/AlbumRepository.php
+++ b/app/Repositories/AlbumRepository.php
@@ -74,12 +74,14 @@ class AlbumRepository extends Repository implements ScoutableRepository
     }
 
     /** @return Collection<int, Album> */
-    public function getFavorites(?User $user = null): Collection
+    public function getFavorites(int $limit, int $offset = 0, ?User $user = null): Collection
     {
         return Album::query()
             ->onlyStandard()
             ->withUserContext(user: $user ?? $this->auth->user(), favoritesOnly: true)
             ->orderBy('favorites.position')
+            ->offset($offset)
+            ->limit($limit)
             ->get();
     }
 

--- a/routes/subsonic.php
+++ b/routes/subsonic.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Subsonic\GetAlbumController;
+use App\Http\Controllers\Subsonic\GetAlbumList2Controller;
 use App\Http\Controllers\Subsonic\GetArtistController;
 use App\Http\Controllers\Subsonic\GetArtistsController;
 use App\Http\Controllers\Subsonic\GetGenresController;
@@ -8,6 +9,7 @@ use App\Http\Controllers\Subsonic\GetLicenseController;
 use App\Http\Controllers\Subsonic\GetMusicFoldersController;
 use App\Http\Controllers\Subsonic\GetSongController;
 use App\Http\Controllers\Subsonic\PingController;
+use App\Http\Controllers\Subsonic\Search3Controller;
 use App\Http\Middleware\SubsonicAuth;
 use Illuminate\Support\Facades\Route;
 
@@ -22,4 +24,6 @@ Route::prefix('rest')
         Route::match(['get', 'post'], 'getAlbum.view', GetAlbumController::class);
         Route::match(['get', 'post'], 'getSong.view', GetSongController::class);
         Route::match(['get', 'post'], 'getGenres.view', GetGenresController::class);
+        Route::match(['get', 'post'], 'search3.view', Search3Controller::class);
+        Route::match(['get', 'post'], 'getAlbumList2.view', GetAlbumList2Controller::class);
     });

--- a/tests/Feature/Subsonic/GetAlbumList2Test.php
+++ b/tests/Feature/Subsonic/GetAlbumList2Test.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\Feature\Subsonic;
+
+use App\Models\Album;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+use function Tests\create_user;
+
+class GetAlbumList2Test extends TestCase
+{
+    #[Test]
+    public function newestReturnsRecentAlbums(): void
+    {
+        $user = create_user();
+
+        Album::factory()->createMany([
+            ['name' => 'Older', 'user_id' => $user->id, 'created_at' => now()->subDays(10)],
+            ['name' => 'Newer', 'user_id' => $user->id, 'created_at' => now()],
+        ]);
+
+        $response = $this
+            ->getJson("/rest/getAlbumList2.view?apiKey={$user->subsonic_api_key}&f=json&type=newest&size=2")
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.status', 'ok');
+
+        $names = array_column($response->json('subsonic-response.albumList2.album'), 'name');
+        self::assertSame(['Newer', 'Older'], $names);
+    }
+
+    #[Test]
+    public function alphabeticalByNameRespectsOffsetAndSize(): void
+    {
+        $user = create_user();
+
+        foreach (['Alpha', 'Bravo', 'Charlie', 'Delta'] as $name) {
+            Album::factory()->createOne(['name' => $name, 'user_id' => $user->id]);
+        }
+
+        $response = $this->getJson(
+            "/rest/getAlbumList2.view?apiKey={$user->subsonic_api_key}"
+            . '&f=json&type=alphabeticalByName&size=2&offset=1',
+        )->assertOk();
+
+        $names = array_column($response->json('subsonic-response.albumList2.album'), 'name');
+        self::assertSame(['Bravo', 'Charlie'], $names);
+    }
+
+    #[Test]
+    public function randomReturnsRequestedNumber(): void
+    {
+        $user = create_user();
+
+        Album::factory()->count(5)->create(['user_id' => $user->id]);
+
+        $response = $this->getJson(
+            "/rest/getAlbumList2.view?apiKey={$user->subsonic_api_key}&f=json&type=random&size=3",
+        )->assertOk();
+
+        self::assertCount(3, $response->json('subsonic-response.albumList2.album'));
+    }
+
+    #[Test]
+    public function unsupportedTypeReturnsCode10(): void
+    {
+        $user = create_user();
+
+        $this
+            ->getJson("/rest/getAlbumList2.view?apiKey={$user->subsonic_api_key}&f=json&type=byYear")
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.status', 'failed')
+            ->assertJsonPath('subsonic-response.error.code', 10);
+    }
+
+    #[Test]
+    public function missingTypeReturnsCode10(): void
+    {
+        $user = create_user();
+
+        $this
+            ->getJson("/rest/getAlbumList2.view?apiKey={$user->subsonic_api_key}&f=json")
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.status', 'failed')
+            ->assertJsonPath('subsonic-response.error.code', 10);
+    }
+}

--- a/tests/Feature/Subsonic/GetAlbumList2Test.php
+++ b/tests/Feature/Subsonic/GetAlbumList2Test.php
@@ -2,7 +2,9 @@
 
 namespace Tests\Feature\Subsonic;
 
+use App\Enums\FavoriteableType;
 use App\Models\Album;
+use App\Models\Favorite;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -59,6 +61,43 @@ class GetAlbumList2Test extends TestCase
         )->assertOk();
 
         self::assertCount(3, $response->json('subsonic-response.albumList2.album'));
+    }
+
+    #[Test]
+    public function starredReturnsOnlyFavoritedAlbums(): void
+    {
+        $user = create_user();
+
+        $favorited = Album::factory()->createOne(['name' => 'Liked', 'user_id' => $user->id]);
+        Album::factory()->createOne(['name' => 'NotLiked', 'user_id' => $user->id]);
+
+        Favorite::factory()->createOne([
+            'user_id' => $user->id,
+            'favoriteable_type' => FavoriteableType::ALBUM->value,
+            'favoriteable_id' => $favorited->id,
+        ]);
+
+        $response = $this->getJson(
+            "/rest/getAlbumList2.view?apiKey={$user->subsonic_api_key}&f=json&type=starred",
+        )->assertOk();
+
+        $names = array_column($response->json('subsonic-response.albumList2.album') ?? [], 'name');
+        self::assertSame(['Liked'], $names);
+    }
+
+    #[Test]
+    public function frequentReturnsAtMostRequestedSize(): void
+    {
+        $user = create_user();
+
+        Album::factory()->count(3)->create(['user_id' => $user->id]);
+
+        $response = $this
+            ->getJson("/rest/getAlbumList2.view?apiKey={$user->subsonic_api_key}&f=json&type=frequent&size=2")
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.status', 'ok');
+
+        self::assertLessThanOrEqual(2, count($response->json('subsonic-response.albumList2.album') ?? []));
     }
 
     #[Test]

--- a/tests/Feature/Subsonic/Search3Test.php
+++ b/tests/Feature/Subsonic/Search3Test.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Tests\Feature\Subsonic;
+
+use App\Models\Album;
+use App\Models\Artist;
+use App\Models\Song;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+use function Tests\create_user;
+
+class Search3Test extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('scout.driver', 'collection');
+    }
+
+    protected function tearDown(): void
+    {
+        config()->set('scout.driver', null);
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function returnsArtistAlbumAndSongMatches(): void
+    {
+        $user = create_user();
+
+        $artist = Artist::factory()->createOne(['name' => 'Radiohead', 'user_id' => $user->id]);
+        $album = Album::factory()->createOne([
+            'name' => 'In Rainbows',
+            'artist_id' => $artist->id,
+            'artist_name' => $artist->name,
+            'user_id' => $user->id,
+        ]);
+        Song::factory()->createOne([
+            'title' => 'Radiohead Karma',
+            'album_id' => $album->id,
+            'owner_id' => $user->id,
+        ]);
+
+        $response = $this
+            ->getJson("/rest/search3.view?apiKey={$user->subsonic_api_key}&f=json&query=Radiohead")
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.status', 'ok');
+
+        $payload = $response->json('subsonic-response.searchResult3');
+
+        self::assertContains('Radiohead', array_column($payload['artist'] ?? [], 'name'));
+    }
+
+    #[Test]
+    public function missingQueryReturnsCode10(): void
+    {
+        $user = create_user();
+
+        $this
+            ->getJson("/rest/search3.view?apiKey={$user->subsonic_api_key}&f=json")
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.status', 'failed')
+            ->assertJsonPath('subsonic-response.error.code', 10);
+    }
+
+    #[Test]
+    public function honorsArtistCountLimit(): void
+    {
+        $user = create_user();
+
+        foreach (['Pearl Jam', 'Pearl Harbor', 'Pearl S Buck'] as $name) {
+            $artist = Artist::factory()->createOne(['name' => $name, 'user_id' => $user->id]);
+            Album::factory()->createOne([
+                'artist_id' => $artist->id,
+                'artist_name' => $artist->name,
+                'user_id' => $user->id,
+            ]);
+        }
+
+        $response = $this->getJson(
+            "/rest/search3.view?apiKey={$user->subsonic_api_key}&f=json&query=Pearl&artistCount=1",
+        )->assertOk();
+
+        self::assertCount(1, $response->json('subsonic-response.searchResult3.artist') ?? []);
+    }
+}


### PR DESCRIPTION
## Summary

Phase 3 of the Subsonic API — search + album listing. Builds on #2517 and #2518.

New endpoints under `/rest/`:

- `search3.view` — universal search across artists, albums, and songs. Each result type can be sized independently via `artistCount`/`albumCount`/`songCount` (default 20 each).
- `getAlbumList2.view` — list albums by criteria. Supported `type` values: `newest`, `frequent`, `random`, `starred`, `alphabeticalByName`. Honors `size` (default 10, max 500) and `offset` (default 0, for `alphabeticalByName`).

## Design notes

### New `AlbumRepository` methods

Three new methods, all mirroring existing `SongRepository` patterns:

- `getFavorites(?User)` — albums the user has starred (sorted by favorite position). Backs `getAlbumList2.view?type=starred`.
- `getRandom(int $limit, ?User)` — random album selection. Backs `type=random`.
- `getOrdered(string $sortColumn, string $sortDirection, int $limit, int $offset, ?User)` — offset-paginated ordered listing. Backs `type=alphabeticalByName`.

The existing `getRecentlyAdded` and `getMostPlayed` already covered `newest` and `frequent`.

### `Offset` params in `search3` are ignored

Subsonic's `search3` spec includes `artistOffset`/`albumOffset`/`songOffset`. koel's Scout-based `search()` methods don't take offsets — they `take($limit)` from Scout's ordered results. Clients still see the first N matches via `*Count`, which is what the search dialog needs. Offset support belongs in a follow-up alongside any other Scout-paginated endpoints.

### Unsupported `getAlbumList2` types

Held back: `recent` (would need a "recently played albums" repo method), `byYear`, `byGenre`, `alphabeticalByArtist`. The FormRequest's `in:` rule rejects them with Subsonic error code 10 — clients can detect feature support by trying once and falling back. Follow-up PR.

### Legacy v1.x variants (`search2`, `getAlbumList`) not included

Modern clients use the ID3-era endpoints. The v1.0/v1.4 variants are mostly identical handlers with a different response shape; they can be added if a real client needs them.

## Test plan

- [x] `php artisan test --compact tests/Feature/Subsonic/` — 30 passed, 106 assertions
- [x] `composer cs` / `composer lint` / `composer analyze` all green
- [ ] Manually verify from a Subsonic client (search dialog + "newest"/"random" album views)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Subsonic search v3 endpoint enabling searches across artists, albums, and songs with customizable result counts.
  * Added album list v2 endpoint supporting multiple listing types: newest, frequent, random, starred, and alphabetical.

* **Validation**
  * New request validations for both endpoints (query/counts for search; type/size/offset for album list).

* **Tests**
  * Added feature tests covering search3 and getAlbumList2 behaviors, parameter validation, and result limits.

* **Routing**
  * Endpoints exposed on the Subsonic REST routes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2519?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->