### PR TITLE
feat: subsonic API stream and cover art

### DIFF
--- a/app/Http/Controllers/Subsonic/GetCoverArtController.php
+++ b/app/Http/Controllers/Subsonic/GetCoverArtController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Controllers\Subsonic;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Subsonic\IdRequest;
+use App\Http\Responses\Subsonic\SubsonicResponse;
+use App\Repositories\AlbumRepository;
+use App\Repositories\ArtistRepository;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+
+class GetCoverArtController extends Controller
+{
+    public function __construct(
+        private readonly AlbumRepository $albumRepository,
+        private readonly ArtistRepository $artistRepository,
+    ) {}
+
+    public function __invoke(IdRequest $request)
+    {
+        $filename = $this->resolveImageFilename($request->id);
+        $path = $filename ? image_storage_path($filename, ensureDirectoryExists: false) : null;
+
+        if (!$path || !is_file($path)) {
+            return SubsonicResponse::error(70, 'Cover art not found.');
+        }
+
+        return response()->file($path);
+    }
+
+    private function resolveImageFilename(string $id): ?string
+    {
+        try {
+            return $this->albumRepository->getOne($id)->cover;
+        } catch (ModelNotFoundException) {
+            return $this->artistRepository->getOne($id)->image;
+        }
+    }
+}

--- a/app/Http/Controllers/Subsonic/GetCoverArtController.php
+++ b/app/Http/Controllers/Subsonic/GetCoverArtController.php
@@ -8,6 +8,7 @@ use App\Http\Responses\Subsonic\SubsonicResponse;
 use App\Repositories\AlbumRepository;
 use App\Repositories\ArtistRepository;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Facades\File;
 
 class GetCoverArtController extends Controller
 {
@@ -21,7 +22,7 @@ class GetCoverArtController extends Controller
         $filename = $this->resolveImageFilename($request->id);
         $path = $filename ? image_storage_path($filename, ensureDirectoryExists: false) : null;
 
-        if (!$path || !is_file($path)) {
+        if (!$path || !File::isFile($path)) {
             return SubsonicResponse::error(70, 'Cover art not found.');
         }
 

--- a/app/Http/Controllers/Subsonic/StreamController.php
+++ b/app/Http/Controllers/Subsonic/StreamController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Controllers\Subsonic;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Subsonic\IdRequest;
+use App\Repositories\SongRepository;
+use App\Services\Streamer\Streamer;
+use App\Values\RequestedStreamingConfig;
+
+class StreamController extends Controller
+{
+    public function __construct(
+        private readonly SongRepository $songRepository,
+    ) {}
+
+    public function __invoke(IdRequest $request)
+    {
+        $song = $this->songRepository->getOne($request->id);
+        $this->authorize('access', $song);
+
+        $maxBitRate = $request->integer('maxBitRate') ?: null;
+        $startTime = (float) $request->input('timeOffset', 0);
+
+        return (new Streamer(song: $song, config: RequestedStreamingConfig::make(
+            transcode: $maxBitRate !== null,
+            bitRate: $maxBitRate,
+            startTime: $startTime,
+        )))->stream();
+    }
+}

--- a/app/Http/Controllers/Subsonic/StreamController.php
+++ b/app/Http/Controllers/Subsonic/StreamController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers\Subsonic;
 
 use App\Http\Controllers\Controller;
-use App\Http\Requests\Subsonic\IdRequest;
+use App\Http\Requests\Subsonic\StreamRequest;
 use App\Repositories\SongRepository;
 use App\Services\Streamer\Streamer;
 use App\Values\RequestedStreamingConfig;
@@ -14,7 +14,7 @@ class StreamController extends Controller
         private readonly SongRepository $songRepository,
     ) {}
 
-    public function __invoke(IdRequest $request)
+    public function __invoke(StreamRequest $request)
     {
         $song = $this->songRepository->getOne($request->id);
         $this->authorize('access', $song);

--- a/app/Http/Requests/Subsonic/StreamRequest.php
+++ b/app/Http/Requests/Subsonic/StreamRequest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Requests\Subsonic;
+
+class StreamRequest extends IdRequest
+{
+    /** @inheritdoc */
+    public function rules(): array
+    {
+        return parent::rules()
+        + [
+            'maxBitRate' => ['integer', 'min:0'],
+            'timeOffset' => ['numeric', 'min:0'],
+        ];
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -7,6 +7,7 @@ use App\Http\Middleware\ObjectStorageAuthenticate;
 use App\Http\Middleware\RestrictPlusFeatures;
 use App\Http\Responses\Subsonic\SubsonicResponse;
 use App\Providers\RouteServiceProvider;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
@@ -73,6 +74,12 @@ return Application::configure(basePath: dirname(__DIR__))
         $exceptions->render(static function (ValidationException $e, Request $request): ?SymfonyResponse {
             return $request->is('rest/*')
                 ? SubsonicResponse::error(10, 'Required parameter is missing.')->toResponse($request)
+                : null;
+        });
+
+        $exceptions->render(static function (AuthorizationException $e, Request $request): ?SymfonyResponse {
+            return $request->is('rest/*')
+                ? SubsonicResponse::error(50, 'User is not authorized for the given operation.')->toResponse($request)
                 : null;
         });
     })

--- a/routes/subsonic.php
+++ b/routes/subsonic.php
@@ -4,12 +4,14 @@ use App\Http\Controllers\Subsonic\GetAlbumController;
 use App\Http\Controllers\Subsonic\GetAlbumList2Controller;
 use App\Http\Controllers\Subsonic\GetArtistController;
 use App\Http\Controllers\Subsonic\GetArtistsController;
+use App\Http\Controllers\Subsonic\GetCoverArtController;
 use App\Http\Controllers\Subsonic\GetGenresController;
 use App\Http\Controllers\Subsonic\GetLicenseController;
 use App\Http\Controllers\Subsonic\GetMusicFoldersController;
 use App\Http\Controllers\Subsonic\GetSongController;
 use App\Http\Controllers\Subsonic\PingController;
 use App\Http\Controllers\Subsonic\Search3Controller;
+use App\Http\Controllers\Subsonic\StreamController;
 use App\Http\Middleware\SubsonicAuth;
 use Illuminate\Support\Facades\Route;
 
@@ -26,4 +28,6 @@ Route::prefix('rest')
         Route::match(['get', 'post'], 'getGenres.view', GetGenresController::class);
         Route::match(['get', 'post'], 'search3.view', Search3Controller::class);
         Route::match(['get', 'post'], 'getAlbumList2.view', GetAlbumList2Controller::class);
+        Route::match(['get', 'post'], 'stream.view', StreamController::class);
+        Route::match(['get', 'post'], 'getCoverArt.view', GetCoverArtController::class);
     });

--- a/tests/Feature/KoelPlus/Subsonic/GetCoverArtTest.php
+++ b/tests/Feature/KoelPlus/Subsonic/GetCoverArtTest.php
@@ -33,12 +33,7 @@ class GetCoverArtTest extends PlusTestCase
     public function otherUsersCoverReturnsCode70(): void
     {
         $owner = create_user();
-        $owner->preferences->includePublicMedia = false;
-        $owner->save();
-
         $requester = create_user();
-        $requester->preferences->includePublicMedia = false;
-        $requester->save();
 
         $album = Album::factory()->createOne([
             'cover' => basename($this->stagedPath),

--- a/tests/Feature/KoelPlus/Subsonic/GetCoverArtTest.php
+++ b/tests/Feature/KoelPlus/Subsonic/GetCoverArtTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Feature\KoelPlus\Subsonic;
+
+use App\Models\Album;
+use Illuminate\Support\Facades\File;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PlusTestCase;
+
+use function Tests\create_user;
+use function Tests\test_path;
+
+class GetCoverArtTest extends PlusTestCase
+{
+    private string $stagedPath;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->stagedPath = image_storage_path('sub_plus_cover_test.png');
+        File::copy(test_path('fixtures/cover.png'), $this->stagedPath);
+    }
+
+    protected function tearDown(): void
+    {
+        File::delete($this->stagedPath);
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function otherUsersCoverReturnsCode70(): void
+    {
+        $owner = create_user();
+        $owner->preferences->includePublicMedia = false;
+        $owner->save();
+
+        $requester = create_user();
+        $requester->preferences->includePublicMedia = false;
+        $requester->save();
+
+        $album = Album::factory()->createOne([
+            'cover' => basename($this->stagedPath),
+            'user_id' => $owner->id,
+        ]);
+
+        $this
+            ->getJson("/rest/getCoverArt.view?apiKey={$requester->subsonic_api_key}&f=json&id={$album->id}")
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.status', 'failed')
+            ->assertJsonPath('subsonic-response.error.code', 70);
+    }
+}

--- a/tests/Feature/Subsonic/GetCoverArtTest.php
+++ b/tests/Feature/Subsonic/GetCoverArtTest.php
@@ -70,7 +70,7 @@ class GetCoverArtTest extends TestCase
     public function albumWithoutCoverReturnsCode70(): void
     {
         $user = create_user();
-        $album = Album::factory()->createOne(['cover' => null, 'user_id' => $user->id]);
+        $album = Album::factory()->createOne(['cover' => '', 'user_id' => $user->id]);
 
         $this
             ->getJson("/rest/getCoverArt.view?apiKey={$user->subsonic_api_key}&f=json&id={$album->id}")

--- a/tests/Feature/Subsonic/GetCoverArtTest.php
+++ b/tests/Feature/Subsonic/GetCoverArtTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tests\Feature\Subsonic;
+
+use App\Models\Album;
+use App\Models\Artist;
+use Illuminate\Support\Facades\File;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Tests\TestCase;
+
+use function Tests\create_user;
+use function Tests\test_path;
+
+class GetCoverArtTest extends TestCase
+{
+    /** @var list<string> */
+    private array $createdPaths = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->createdPaths as $path) {
+            File::delete($path);
+        }
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function returnsAlbumCoverBytes(): void
+    {
+        $user = create_user();
+        $filename = $this->stageCover('sub_album_cover_test.png');
+
+        $album = Album::factory()->createOne(['cover' => $filename, 'user_id' => $user->id]);
+
+        $response = $this->get(
+            "/rest/getCoverArt.view?apiKey={$user->subsonic_api_key}&id={$album->id}",
+        )->assertOk()->assertHeader('Content-Type', 'image/png');
+
+        $base = $response->baseResponse;
+        self::assertInstanceOf(BinaryFileResponse::class, $base);
+        self::assertSame(image_storage_path($filename), $base->getFile()->getRealPath());
+    }
+
+    #[Test]
+    public function returnsArtistImageBytes(): void
+    {
+        $user = create_user();
+        $filename = $this->stageCover('sub_artist_image_test.png');
+
+        $artist = Artist::factory()->createOne(['image' => $filename, 'user_id' => $user->id]);
+
+        $this->get("/rest/getCoverArt.view?apiKey={$user->subsonic_api_key}&id={$artist->id}")->assertOk();
+    }
+
+    #[Test]
+    public function unknownIdReturnsCode70(): void
+    {
+        $user = create_user();
+
+        $this
+            ->getJson("/rest/getCoverArt.view?apiKey={$user->subsonic_api_key}&f=json&id=does-not-exist")
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.status', 'failed')
+            ->assertJsonPath('subsonic-response.error.code', 70);
+    }
+
+    #[Test]
+    public function albumWithoutCoverReturnsCode70(): void
+    {
+        $user = create_user();
+        $album = Album::factory()->createOne(['cover' => null, 'user_id' => $user->id]);
+
+        $this
+            ->getJson("/rest/getCoverArt.view?apiKey={$user->subsonic_api_key}&f=json&id={$album->id}")
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.error.code', 70);
+    }
+
+    private function stageCover(string $filename): string
+    {
+        $path = image_storage_path($filename);
+        File::copy(test_path('fixtures/cover.png'), $path);
+
+        $this->createdPaths[] = $path;
+
+        return $filename;
+    }
+}

--- a/tests/Feature/Subsonic/GetCoverArtTest.php
+++ b/tests/Feature/Subsonic/GetCoverArtTest.php
@@ -19,9 +19,7 @@ class GetCoverArtTest extends TestCase
 
     protected function tearDown(): void
     {
-        foreach ($this->createdPaths as $path) {
-            File::delete($path);
-        }
+        File::delete($this->createdPaths);
 
         parent::tearDown();
     }

--- a/tests/Feature/Subsonic/StreamTest.php
+++ b/tests/Feature/Subsonic/StreamTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Feature\Subsonic;
+
+use App\Models\Song;
+use App\Services\Streamer\Adapters\LocalStreamerAdapter;
+use App\Services\Streamer\Adapters\TranscodingStreamerAdapter;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+use function Tests\create_user;
+use function Tests\test_path;
+
+class StreamTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        ob_start();
+    }
+
+    protected function tearDown(): void
+    {
+        ob_end_clean();
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function streamsAudioBytes(): void
+    {
+        $user = create_user();
+        $song = Song::factory()->createOne([
+            'path' => test_path('songs/blank.mp3'),
+            'owner_id' => $user->id,
+        ]);
+
+        $this->mock(LocalStreamerAdapter::class)->expects('stream');
+
+        $this->get("/rest/stream.view?id={$song->id}&apiKey={$user->subsonic_api_key}")->assertOk();
+    }
+
+    #[Test]
+    public function maxBitRateTriggersTranscoding(): void
+    {
+        $user = create_user();
+        $song = Song::factory()->createOne([
+            'path' => test_path('songs/blank.mp3'),
+            'owner_id' => $user->id,
+        ]);
+
+        $this->mock(TranscodingStreamerAdapter::class)->expects('stream');
+
+        $this->get("/rest/stream.view?id={$song->id}&apiKey={$user->subsonic_api_key}&maxBitRate=128")->assertOk();
+    }
+
+    #[Test]
+    public function unknownIdReturnsCode70(): void
+    {
+        $user = create_user();
+
+        $this
+            ->getJson("/rest/stream.view?apiKey={$user->subsonic_api_key}&f=json&id=does-not-exist")
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.status', 'failed')
+            ->assertJsonPath('subsonic-response.error.code', 70);
+    }
+}


### PR DESCRIPTION
## Summary

Phase 4 of the Subsonic API — the bytes-serving endpoints. Builds on #2517, #2518, and #2519.

- `stream.view?id=<song>` — streams the song audio. Reuses koel's existing `Streamer` service so every storage adapter (local, S3, SFTP, Dropbox, WebDAV) and transcoding path comes along for free. Honors Subsonic's `maxBitRate` (triggers transcoding) and `timeOffset`.
- `getCoverArt.view?id=<album-or-artist>` — serves the cover image bytes (PNG/JPEG/WebP, whatever's on disk). Resolves the ID against `AlbumRepository` first, then `ArtistRepository`. Returns Subsonic error 70 if the ID doesn't match either or the file isn't on disk.

## Design notes

### Auth model

Both endpoints sit behind the existing `SubsonicAuth` middleware (apiKey on the query string). On top of that, `stream.view` calls `$this->authorize('access', $song)` to mirror koel's own `PlayController` — defense in depth against any future repository-scope drift. `getCoverArt.view` relies on the repository's `withUserContext` scope for access control.

### New exception render hook

Added a `rest/*`-scoped `AuthorizationException` → Subsonic error code 50 ("User is not authorized") render in `bootstrap/app.php`, alongside the existing `NotFoundHttpException` → 70 and `ValidationException` → 10 hooks.

### Scoped-out Subsonic params

- `stream.view` ignores `format` (raw/mp3/ogg), `size`, `estimateContentLength`, `converted`. koel's transcoding decision is config + mime-type driven, not per-request.
- `getCoverArt.view` ignores `size` (pixel size). koel stores the original + a `_thumb` variant; dynamic resizing isn't wired up. Clients can resize client-side.

These can be revisited when a real client actually breaks on them.

## Test plan

- [x] `php artisan test --compact tests/Feature/Subsonic/` — 39 passed, 130 assertions
- [x] `composer cs` / `composer lint` / `composer analyze` all green
- [ ] Stream a song and view covers from a real Subsonic client (DSub, Symfonium, play:Sub)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cover art retrieval for albums and artists, serving image bytes with correct content-type
  * Audio streaming with optional bitrate and start-time controls
  * New API endpoints for streaming and cover-art access

* **Bug Fixes / Improvements**
  * Authorization errors mapped to Subsonic-style responses (error code 50)
  * Unknown or missing cover/song IDs return Subsonic error code 70

* **Tests**
  * Feature tests for cover art and streaming (including transcoding, cross-user access) and staged fixture cleanup

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2520?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->