### PR TITLE
feat: subsonic API playlist endpoints

### DIFF
--- a/app/Exceptions/Contracts/SubsonicThrowable.php
+++ b/app/Exceptions/Contracts/SubsonicThrowable.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Exceptions\Contracts;
+
+interface SubsonicThrowable
+{
+    public function getSubsonicErrorCode(): int;
+
+    public function getSubsonicErrorMessage(): string;
+}

--- a/app/Exceptions/OperationNotApplicableForSmartPlaylistException.php
+++ b/app/Exceptions/OperationNotApplicableForSmartPlaylistException.php
@@ -2,6 +2,18 @@
 
 namespace App\Exceptions;
 
+use App\Exceptions\Contracts\SubsonicThrowable;
 use DomainException;
 
-class OperationNotApplicableForSmartPlaylistException extends DomainException {}
+class OperationNotApplicableForSmartPlaylistException extends DomainException implements SubsonicThrowable
+{
+    public function getSubsonicErrorCode(): int
+    {
+        return 0;
+    }
+
+    public function getSubsonicErrorMessage(): string
+    {
+        return 'Operation is not applicable to smart playlists.';
+    }
+}

--- a/app/Exceptions/SubsonicAwareErrorHandler.php
+++ b/app/Exceptions/SubsonicAwareErrorHandler.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Exceptions;
+
+use App\Http\Responses\Subsonic\SubsonicResponse;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Throwable;
+
+class SubsonicAwareErrorHandler
+{
+    /**
+     * Subsonic error codes per https://opensubsonic.netlify.app/docs/responses/error/
+     * Listed specific-first; the first matching class wins.
+     *
+     * @var array<class-string<Throwable>, array{int, string}>
+     */
+    private const array EXCEPTION_MAP = [
+        ValidationException::class => [10, 'Required parameter is missing.'],
+        AuthorizationException::class => [50, 'User is not authorized for the given operation.'],
+        NotFoundHttpException::class => [70, 'The requested data was not found.'],
+        OperationNotApplicableForSmartPlaylistException::class => [
+            0,
+            'Operation is not applicable to smart playlists.',
+        ],
+    ];
+
+    public static function handle(Throwable $e, Request $request): ?Response
+    {
+        if (!$request->is('rest/*')) {
+            return null;
+        }
+
+        foreach (self::EXCEPTION_MAP as $class => [$code, $message]) {
+            if ($e instanceof $class) {
+                return SubsonicResponse::error($code, $message)->toResponse($request);
+            }
+        }
+
+        return null;
+    }
+}

--- a/app/Exceptions/SubsonicAwareErrorHandler.php
+++ b/app/Exceptions/SubsonicAwareErrorHandler.php
@@ -2,6 +2,7 @@
 
 namespace App\Exceptions;
 
+use App\Exceptions\Contracts\SubsonicThrowable;
 use App\Http\Responses\Subsonic\SubsonicResponse;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\Request;
@@ -14,7 +15,8 @@ class SubsonicAwareErrorHandler
 {
     /**
      * Subsonic error codes per https://opensubsonic.netlify.app/docs/responses/error/
-     * Listed specific-first; the first matching class wins.
+     * for framework/SPL exceptions we can't modify. koel-owned exceptions should
+     * implement {@see SubsonicThrowable} instead.
      *
      * @var array<class-string<Throwable>, array{int, string}>
      */
@@ -22,16 +24,18 @@ class SubsonicAwareErrorHandler
         ValidationException::class => [10, 'Required parameter is missing.'],
         AuthorizationException::class => [50, 'User is not authorized for the given operation.'],
         NotFoundHttpException::class => [70, 'The requested data was not found.'],
-        OperationNotApplicableForSmartPlaylistException::class => [
-            0,
-            'Operation is not applicable to smart playlists.',
-        ],
     ];
 
     public static function handle(Throwable $e, Request $request): ?Response
     {
         if (!$request->is('rest/*')) {
             return null;
+        }
+
+        if ($e instanceof SubsonicThrowable) {
+            return SubsonicResponse::error($e->getSubsonicErrorCode(), $e->getSubsonicErrorMessage())->toResponse(
+                $request,
+            );
         }
 
         foreach (self::EXCEPTION_MAP as $class => [$code, $message]) {

--- a/app/Exceptions/SubsonicAwareErrorRenderer.php
+++ b/app/Exceptions/SubsonicAwareErrorRenderer.php
@@ -11,7 +11,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Throwable;
 
-class SubsonicAwareErrorHandler
+class SubsonicAwareErrorRenderer
 {
     /**
      * Subsonic error codes per https://opensubsonic.netlify.app/docs/responses/error/
@@ -26,7 +26,7 @@ class SubsonicAwareErrorHandler
         NotFoundHttpException::class => [70, 'The requested data was not found.'],
     ];
 
-    public static function handle(Throwable $e, Request $request): ?Response
+    public static function render(Throwable $e, Request $request): ?Response
     {
         if (!$request->is('rest/*')) {
             return null;

--- a/app/Helpers/QueryStringParser.php
+++ b/app/Helpers/QueryStringParser.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Helpers;
+
+class QueryStringParser
+{
+    /**
+     * Parse a query string into key → list of values, preserving duplicates that
+     * PHP's parse_str would collapse to last-wins. Keys ending in `[]` are
+     * skipped — those are the standard PHP/Symfony array notation and need no
+     * special handling.
+     *
+     * @return array<string, list<string>>
+     */
+    public static function parse(string $queryString): array
+    {
+        if ($queryString === '') {
+            return [];
+        }
+
+        $result = [];
+
+        foreach (explode('&', $queryString) as $pair) {
+            if (!str_contains($pair, '=')) {
+                continue;
+            }
+
+            [$key, $value] = explode('=', $pair, 2);
+            $key = urldecode($key);
+
+            if (str_ends_with($key, '[]')) {
+                continue;
+            }
+
+            $result[$key][] = urldecode($value);
+        }
+
+        return $result;
+    }
+}

--- a/app/Http/Controllers/Subsonic/CreatePlaylistController.php
+++ b/app/Http/Controllers/Subsonic/CreatePlaylistController.php
@@ -11,7 +11,6 @@ use App\Models\User;
 use App\Services\Playlist\PlaylistService;
 use App\Values\Playlist\PlaylistCreateData;
 use Illuminate\Contracts\Auth\Authenticatable;
-use Illuminate\Support\Arr;
 
 class CreatePlaylistController extends Controller
 {
@@ -22,11 +21,8 @@ class CreatePlaylistController extends Controller
     /** @param User $user */
     public function __invoke(CreatePlaylistRequest $request, Authenticatable $user)
     {
-        /** @var list<string> $songIds */
-        $songIds = Arr::wrap($request->input('songId', []));
-
         $playlist = $this->playlistService->createPlaylist(
-            PlaylistCreateData::make(name: (string) $request->input('name'), playableIds: $songIds),
+            PlaylistCreateData::make(name: $request->name, playableIds: $request->songId),
             $user,
         );
 

--- a/app/Http/Controllers/Subsonic/CreatePlaylistController.php
+++ b/app/Http/Controllers/Subsonic/CreatePlaylistController.php
@@ -2,16 +2,12 @@
 
 namespace App\Http\Controllers\Subsonic;
 
-use App\Exceptions\OperationNotApplicableForSmartPlaylistException;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Subsonic\CreatePlaylistRequest;
 use App\Http\Responses\Subsonic\Resources\PlaylistResource;
 use App\Http\Responses\Subsonic\Resources\SongResource;
 use App\Http\Responses\Subsonic\SubsonicResponse;
-use App\Models\Playlist;
 use App\Models\User;
-use App\Repositories\PlaylistRepository;
-use App\Repositories\SongRepository;
 use App\Services\Playlist\PlaylistService;
 use App\Values\Playlist\PlaylistCreateData;
 use Illuminate\Contracts\Auth\Authenticatable;
@@ -20,8 +16,6 @@ use Illuminate\Support\Arr;
 class CreatePlaylistController extends Controller
 {
     public function __construct(
-        private readonly PlaylistRepository $playlistRepository,
-        private readonly SongRepository $songRepository,
         private readonly PlaylistService $playlistService,
     ) {}
 
@@ -31,12 +25,10 @@ class CreatePlaylistController extends Controller
         /** @var list<string> $songIds */
         $songIds = Arr::wrap($request->input('songId', []));
 
-        $playlist = $request->input('playlistId')
-            ? $this->replaceContents($request->input('playlistId'), $request->input('name'), $songIds, $user)
-            : $this->playlistService->createPlaylist(
-                PlaylistCreateData::make(name: (string) $request->input('name'), playableIds: $songIds),
-                $user,
-            );
+        $playlist = $this->playlistService->createPlaylist(
+            PlaylistCreateData::make(name: (string) $request->input('name'), playableIds: $songIds),
+            $user,
+        );
 
         $playlist->loadCount('playables')->loadSum('playables', 'length');
 
@@ -46,27 +38,5 @@ class CreatePlaylistController extends Controller
                     'entry' => $playlist->playables->map(SongResource::toArray(...))->all(),
                 ],
         ]);
-    }
-
-    /** @param list<string> $songIds */
-    private function replaceContents(string $playlistId, ?string $name, array $songIds, User $user): Playlist
-    {
-        $playlist = $this->playlistRepository->getOne($playlistId);
-        $this->authorize('edit', $playlist);
-
-        throw_if($playlist->is_smart, new OperationNotApplicableForSmartPlaylistException());
-
-        if ($name !== null) {
-            $playlist->update(['name' => $name]);
-        }
-
-        $playlist->playables()->detach();
-
-        if ($songIds) {
-            $songs = $this->songRepository->getMany($songIds);
-            $this->playlistService->addPlayablesToPlaylist($playlist, $songs, $user);
-        }
-
-        return $playlist->refresh();
     }
 }

--- a/app/Http/Controllers/Subsonic/CreatePlaylistController.php
+++ b/app/Http/Controllers/Subsonic/CreatePlaylistController.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Http\Controllers\Subsonic;
+
+use App\Exceptions\OperationNotApplicableForSmartPlaylistException;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Subsonic\CreatePlaylistRequest;
+use App\Http\Responses\Subsonic\Resources\PlaylistResource;
+use App\Http\Responses\Subsonic\Resources\SongResource;
+use App\Http\Responses\Subsonic\SubsonicResponse;
+use App\Models\Playlist;
+use App\Models\User;
+use App\Repositories\PlaylistRepository;
+use App\Repositories\SongRepository;
+use App\Services\Playlist\PlaylistService;
+use App\Values\Playlist\PlaylistCreateData;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Support\Arr;
+
+class CreatePlaylistController extends Controller
+{
+    public function __construct(
+        private readonly PlaylistRepository $playlistRepository,
+        private readonly SongRepository $songRepository,
+        private readonly PlaylistService $playlistService,
+    ) {}
+
+    /** @param User $user */
+    public function __invoke(CreatePlaylistRequest $request, Authenticatable $user)
+    {
+        /** @var list<string> $songIds */
+        $songIds = Arr::wrap($request->input('songId', []));
+
+        $playlist = $request->input('playlistId')
+            ? $this->replaceContents($request->input('playlistId'), $request->input('name'), $songIds, $user)
+            : $this->playlistService->createPlaylist(
+                PlaylistCreateData::make(name: (string) $request->input('name'), playableIds: $songIds),
+                $user,
+            );
+
+        $playlist->loadCount('playables')->loadSum('playables', 'length');
+
+        return SubsonicResponse::ok([
+            'playlist' => PlaylistResource::toArray($playlist)
+                + [
+                    'entry' => $playlist->playables->map(SongResource::toArray(...))->all(),
+                ],
+        ]);
+    }
+
+    /** @param list<string> $songIds */
+    private function replaceContents(string $playlistId, ?string $name, array $songIds, User $user): Playlist
+    {
+        $playlist = $this->playlistRepository->getOne($playlistId);
+        $this->authorize('edit', $playlist);
+
+        throw_if($playlist->is_smart, new OperationNotApplicableForSmartPlaylistException());
+
+        if ($name !== null) {
+            $playlist->update(['name' => $name]);
+        }
+
+        $playlist->playables()->detach();
+
+        if ($songIds) {
+            $songs = $this->songRepository->getMany($songIds);
+            $this->playlistService->addPlayablesToPlaylist($playlist, $songs, $user);
+        }
+
+        return $playlist->refresh();
+    }
+}

--- a/app/Http/Controllers/Subsonic/DeletePlaylistController.php
+++ b/app/Http/Controllers/Subsonic/DeletePlaylistController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers\Subsonic;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Subsonic\IdRequest;
+use App\Http\Responses\Subsonic\SubsonicResponse;
+use App\Repositories\PlaylistRepository;
+
+class DeletePlaylistController extends Controller
+{
+    public function __construct(
+        private readonly PlaylistRepository $playlistRepository,
+    ) {}
+
+    public function __invoke(IdRequest $request)
+    {
+        $playlist = $this->playlistRepository->getOne($request->id);
+        $this->authorize('delete', $playlist);
+
+        $playlist->delete();
+
+        return SubsonicResponse::ok();
+    }
+}

--- a/app/Http/Controllers/Subsonic/GetPlaylistController.php
+++ b/app/Http/Controllers/Subsonic/GetPlaylistController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Controllers\Subsonic;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Subsonic\IdRequest;
+use App\Http\Responses\Subsonic\Resources\PlaylistResource;
+use App\Http\Responses\Subsonic\Resources\SongResource;
+use App\Http\Responses\Subsonic\SubsonicResponse;
+use App\Models\User;
+use App\Repositories\PlaylistRepository;
+use App\Repositories\SongRepository;
+use Illuminate\Contracts\Auth\Authenticatable;
+
+class GetPlaylistController extends Controller
+{
+    public function __construct(
+        private readonly PlaylistRepository $playlistRepository,
+        private readonly SongRepository $songRepository,
+    ) {}
+
+    /** @param User $user */
+    public function __invoke(IdRequest $request, Authenticatable $user)
+    {
+        $playlist = $this->playlistRepository->getOne($request->id);
+        $this->authorize('access', $playlist);
+
+        $songs = $this->songRepository->getByPlaylist($playlist, $user);
+        $totalLength = $songs->sum('length');
+        $playlist->setAttribute('playables_count', $songs->count())->setAttribute('playables_sum_length', $totalLength);
+
+        return SubsonicResponse::ok([
+            'playlist' => PlaylistResource::toArray($playlist)
+                + [
+                    'entry' => $songs->map(SongResource::toArray(...))->all(),
+                ],
+        ]);
+    }
+}

--- a/app/Http/Controllers/Subsonic/GetPlaylistsController.php
+++ b/app/Http/Controllers/Subsonic/GetPlaylistsController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Controllers\Subsonic;
+
+use App\Http\Controllers\Controller;
+use App\Http\Responses\Subsonic\Resources\PlaylistResource;
+use App\Http\Responses\Subsonic\SubsonicResponse;
+use App\Models\User;
+use App\Repositories\PlaylistRepository;
+use Illuminate\Contracts\Auth\Authenticatable;
+
+class GetPlaylistsController extends Controller
+{
+    public function __construct(
+        private readonly PlaylistRepository $playlistRepository,
+    ) {}
+
+    /** @param User $user */
+    public function __invoke(Authenticatable $user)
+    {
+        $playlists = $this->playlistRepository
+            ->getAllAccessibleByUser($user)
+            ->loadCount('playables')
+            ->loadSum('playables', 'length');
+
+        return SubsonicResponse::ok([
+            'playlists' => [
+                'playlist' => $playlists->map(PlaylistResource::toArray(...))->all(),
+            ],
+        ]);
+    }
+}

--- a/app/Http/Controllers/Subsonic/UpdatePlaylistController.php
+++ b/app/Http/Controllers/Subsonic/UpdatePlaylistController.php
@@ -11,7 +11,6 @@ use App\Repositories\PlaylistRepository;
 use App\Repositories\SongRepository;
 use App\Services\Playlist\PlaylistService;
 use Illuminate\Contracts\Auth\Authenticatable;
-use Illuminate\Support\Arr;
 
 class UpdatePlaylistController extends Controller
 {
@@ -28,10 +27,7 @@ class UpdatePlaylistController extends Controller
         $this->authorize('edit', $playlist);
 
         $changes = array_filter(
-            [
-                'name' => $request->input('name'),
-                'description' => $request->input('comment'),
-            ],
+            ['name' => $request->name, 'description' => $request->comment],
             static fn ($value) => $value !== null,
         );
 
@@ -39,22 +35,19 @@ class UpdatePlaylistController extends Controller
             $playlist->update($changes);
         }
 
-        $songIdsToAdd = Arr::wrap($request->input('songIdToAdd', []));
-        $indicesToRemove = Arr::wrap($request->input('songIndexToRemove', []));
-
-        if (($songIdsToAdd || $indicesToRemove) && $playlist->is_smart) {
+        if (($request->songIdToAdd || $request->songIndexToRemove) && $playlist->is_smart) {
             throw new OperationNotApplicableForSmartPlaylistException();
         }
 
-        if ($songIdsToAdd) {
-            $songs = $this->songRepository->getMany($songIdsToAdd);
+        if ($request->songIdToAdd) {
+            $songs = $this->songRepository->getMany($request->songIdToAdd);
             $this->playlistService->addPlayablesToPlaylist($playlist, $songs, $user);
         }
 
-        if ($indicesToRemove) {
+        if ($request->songIndexToRemove) {
             $songs = $playlist->load('playables')->playables->values();
-            $toRemove = collect($indicesToRemove)
-                ->map(static fn (int|string $index) => $songs->get((int) $index))
+            $toRemove = collect($request->songIndexToRemove)
+                ->map($songs->get(...))
                 ->filter()
                 ->values();
 

--- a/app/Http/Controllers/Subsonic/UpdatePlaylistController.php
+++ b/app/Http/Controllers/Subsonic/UpdatePlaylistController.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Http\Controllers\Subsonic;
+
+use App\Exceptions\OperationNotApplicableForSmartPlaylistException;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Subsonic\UpdatePlaylistRequest;
+use App\Http\Responses\Subsonic\SubsonicResponse;
+use App\Models\User;
+use App\Repositories\PlaylistRepository;
+use App\Repositories\SongRepository;
+use App\Services\Playlist\PlaylistService;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Support\Arr;
+
+class UpdatePlaylistController extends Controller
+{
+    public function __construct(
+        private readonly PlaylistRepository $playlistRepository,
+        private readonly SongRepository $songRepository,
+        private readonly PlaylistService $playlistService,
+    ) {}
+
+    /** @param User $user */
+    public function __invoke(UpdatePlaylistRequest $request, Authenticatable $user)
+    {
+        $playlist = $this->playlistRepository->getOne($request->playlistId);
+        $this->authorize('edit', $playlist);
+
+        $changes = array_filter(
+            [
+                'name' => $request->input('name'),
+                'description' => $request->input('comment'),
+            ],
+            static fn ($value) => $value !== null,
+        );
+
+        if ($changes) {
+            $playlist->update($changes);
+        }
+
+        $songIdsToAdd = Arr::wrap($request->input('songIdToAdd', []));
+        $indicesToRemove = Arr::wrap($request->input('songIndexToRemove', []));
+
+        if (($songIdsToAdd || $indicesToRemove) && $playlist->is_smart) {
+            throw new OperationNotApplicableForSmartPlaylistException();
+        }
+
+        if ($songIdsToAdd) {
+            $songs = $this->songRepository->getMany($songIdsToAdd);
+            $this->playlistService->addPlayablesToPlaylist($playlist, $songs, $user);
+        }
+
+        if ($indicesToRemove) {
+            $songs = $playlist->load('playables')->playables->values();
+            $toRemove = collect($indicesToRemove)
+                ->map(static fn (int|string $index) => $songs->get((int) $index))
+                ->filter()
+                ->values();
+
+            if ($toRemove->isNotEmpty()) {
+                $this->playlistService->removePlayablesFromPlaylist($playlist, $toRemove);
+            }
+        }
+
+        return SubsonicResponse::ok();
+    }
+}

--- a/app/Http/Middleware/NormalizeSubsonicArrayParams.php
+++ b/app/Http/Middleware/NormalizeSubsonicArrayParams.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class NormalizeSubsonicArrayParams
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        foreach (self::collectMultiValueParams($request) as $key => $values) {
+            $request->query->set($key, $values);
+            $request->request->set($key, $values);
+            $request->merge([$key => $values]);
+        }
+
+        return $next($request);
+    }
+
+    /** @return array<string, list<string>> */
+    private static function collectMultiValueParams(Request $request): array
+    {
+        $sources = array_filter([
+            (string) $request->server('QUERY_STRING'),
+            $request->isMethod('POST') ? (string) $request->getContent() : '',
+        ]);
+
+        $collected = [];
+
+        foreach ($sources as $source) {
+            foreach (explode('&', $source) as $pair) {
+                if (!str_contains($pair, '=')) {
+                    continue;
+                }
+
+                [$key, $value] = explode('=', $pair, 2);
+                $key = urldecode($key);
+
+                if (str_ends_with($key, '[]')) {
+                    continue;
+                }
+
+                $collected[$key][] = urldecode($value);
+            }
+        }
+
+        return array_filter($collected, static fn (array $values) => count($values) > 1);
+    }
+}

--- a/app/Http/Middleware/NormalizeSubsonicArrayParams.php
+++ b/app/Http/Middleware/NormalizeSubsonicArrayParams.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Middleware;
 
+use App\Helpers\QueryStringParser;
 use Closure;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -10,42 +11,26 @@ class NormalizeSubsonicArrayParams
 {
     public function handle(Request $request, Closure $next): Response
     {
-        foreach (self::collectMultiValueParams($request) as $key => $values) {
+        // We read the raw $_SERVER value rather than $request->getQueryString()
+        // because Symfony's helper normalizes the string through HeaderUtils +
+        // http_build_query, which collapses duplicate keys to last-wins —
+        // exactly the input shape this middleware exists to recover.
+        $parsed = QueryStringParser::parse((string) $request->server('QUERY_STRING'));
+
+        if ($request->isMethod('POST')) {
+            $parsed = array_merge_recursive($parsed, QueryStringParser::parse((string) $request->getContent()));
+        }
+
+        foreach ($parsed as $key => $values) {
+            if (count($values) <= 1) {
+                continue;
+            }
+
             $request->query->set($key, $values);
             $request->request->set($key, $values);
             $request->merge([$key => $values]);
         }
 
         return $next($request);
-    }
-
-    /** @return array<string, list<string>> */
-    private static function collectMultiValueParams(Request $request): array
-    {
-        $sources = array_filter([
-            (string) $request->server('QUERY_STRING'),
-            $request->isMethod('POST') ? (string) $request->getContent() : '',
-        ]);
-
-        $collected = [];
-
-        foreach ($sources as $source) {
-            foreach (explode('&', $source) as $pair) {
-                if (!str_contains($pair, '=')) {
-                    continue;
-                }
-
-                [$key, $value] = explode('=', $pair, 2);
-                $key = urldecode($key);
-
-                if (str_ends_with($key, '[]')) {
-                    continue;
-                }
-
-                $collected[$key][] = urldecode($value);
-            }
-        }
-
-        return array_filter($collected, static fn (array $values) => count($values) > 1);
     }
 }

--- a/app/Http/Requests/Subsonic/CreatePlaylistRequest.php
+++ b/app/Http/Requests/Subsonic/CreatePlaylistRequest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Requests\Subsonic;
+
+use App\Http\Requests\Request;
+
+class CreatePlaylistRequest extends Request
+{
+    /** @inheritdoc */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required_without:playlistId', 'string'],
+            'playlistId' => ['nullable', 'string'],
+        ];
+    }
+}

--- a/app/Http/Requests/Subsonic/CreatePlaylistRequest.php
+++ b/app/Http/Requests/Subsonic/CreatePlaylistRequest.php
@@ -4,8 +4,17 @@ namespace App\Http\Requests\Subsonic;
 
 use App\Http\Requests\Request;
 
+/**
+ * @property string $name
+ * @property list<string> $songId
+ */
 class CreatePlaylistRequest extends Request
 {
+    protected function prepareForValidation(): void
+    {
+        $this->merge(['songId' => (array) $this->input('songId', [])]);
+    }
+
     /** @inheritdoc */
     public function rules(): array
     {

--- a/app/Http/Requests/Subsonic/CreatePlaylistRequest.php
+++ b/app/Http/Requests/Subsonic/CreatePlaylistRequest.php
@@ -10,8 +10,7 @@ class CreatePlaylistRequest extends Request
     public function rules(): array
     {
         return [
-            'name' => ['required_without:playlistId', 'string'],
-            'playlistId' => ['nullable', 'string'],
+            'name' => ['required', 'string'],
         ];
     }
 }

--- a/app/Http/Requests/Subsonic/UpdatePlaylistRequest.php
+++ b/app/Http/Requests/Subsonic/UpdatePlaylistRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Subsonic;
+
+use App\Http\Requests\Request;
+
+/**
+ * @property string $playlistId
+ */
+class UpdatePlaylistRequest extends Request
+{
+    /** @inheritdoc */
+    public function rules(): array
+    {
+        return [
+            'playlistId' => ['required', 'string'],
+            'name' => ['nullable', 'string'],
+            'comment' => ['nullable', 'string'],
+        ];
+    }
+}

--- a/app/Http/Requests/Subsonic/UpdatePlaylistRequest.php
+++ b/app/Http/Requests/Subsonic/UpdatePlaylistRequest.php
@@ -6,9 +6,21 @@ use App\Http\Requests\Request;
 
 /**
  * @property string $playlistId
+ * @property ?string $name
+ * @property ?string $comment
+ * @property list<string> $songIdToAdd
+ * @property list<int> $songIndexToRemove
  */
 class UpdatePlaylistRequest extends Request
 {
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'songIdToAdd' => (array) $this->input('songIdToAdd', []),
+            'songIndexToRemove' => array_map('intval', (array) $this->input('songIndexToRemove', [])),
+        ]);
+    }
+
     /** @inheritdoc */
     public function rules(): array
     {

--- a/app/Http/Requests/Subsonic/UpdatePlaylistRequest.php
+++ b/app/Http/Requests/Subsonic/UpdatePlaylistRequest.php
@@ -17,7 +17,7 @@ class UpdatePlaylistRequest extends Request
     {
         $this->merge([
             'songIdToAdd' => (array) $this->input('songIdToAdd', []),
-            'songIndexToRemove' => array_map('intval', (array) $this->input('songIndexToRemove', [])),
+            'songIndexToRemove' => (array) $this->input('songIndexToRemove', []),
         ]);
     }
 
@@ -28,6 +28,17 @@ class UpdatePlaylistRequest extends Request
             'playlistId' => ['required', 'string'],
             'name' => ['nullable', 'string'],
             'comment' => ['nullable', 'string'],
+            'songIdToAdd' => ['array'],
+            'songIdToAdd.*' => ['string'],
+            'songIndexToRemove' => ['array'],
+            'songIndexToRemove.*' => ['integer', 'min:0'],
         ];
+    }
+
+    protected function passedValidation(): void
+    {
+        $this->merge([
+            'songIndexToRemove' => array_map('intval', (array) $this->input('songIndexToRemove', [])),
+        ]);
     }
 }

--- a/app/Http/Responses/Subsonic/Resources/PlaylistResource.php
+++ b/app/Http/Responses/Subsonic/Resources/PlaylistResource.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Responses\Subsonic\Resources;
+
+use App\Models\Playlist;
+
+final class PlaylistResource
+{
+    /**
+     * @return array{
+     *     id: string,
+     *     name: string,
+     *     comment: string,
+     *     owner: string,
+     *     public: bool,
+     *     songCount: int,
+     *     duration: int,
+     *     created: string,
+     *     changed: string,
+     *     coverArt: ?string,
+     * }
+     */
+    public static function toArray(Playlist $playlist): array
+    {
+        return [
+            'id' => $playlist->id,
+            'name' => $playlist->name,
+            'comment' => (string) $playlist->description,
+            'owner' => $playlist->owner->name,
+            'public' => false,
+            'songCount' => $playlist->playables_count ?? 0,
+            'duration' => (int) round($playlist->playables_sum_length ?? 0),
+            'created' => $playlist->created_at->toIso8601String(),
+            'changed' => $playlist->updated_at->toIso8601String(),
+            'coverArt' => $playlist->cover ? $playlist->id : null,
+        ];
+    }
+}

--- a/app/Repositories/PlaylistRepository.php
+++ b/app/Repositories/PlaylistRepository.php
@@ -5,16 +5,19 @@ namespace App\Repositories;
 use App\Facades\License;
 use App\Models\Playlist;
 use App\Models\User;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Illuminate\Support\Collection;
 
 /** @extends Repository<Playlist> */
 class PlaylistRepository extends Repository
 {
+    /** @return Collection<int, Playlist> */
     public function getAllAccessibleByUser(User $user): Collection
     {
-        return $this
-            ->accessibleByUser($user)
+        $accessibleIds = $this->accessibleByUser($user)->pluck('playlists.id');
+
+        return Playlist::query()
+            ->whereIn('playlists.id', $accessibleIds)
             ->leftJoin('playlist_playlist_folder', 'playlists.id', '=', 'playlist_playlist_folder.playlist_id')
             ->distinct()
             ->get(['playlists.*', 'playlist_playlist_folder.folder_id']);

--- a/app/Repositories/PlaylistRepository.php
+++ b/app/Repositories/PlaylistRepository.php
@@ -14,10 +14,8 @@ class PlaylistRepository extends Repository
     /** @return Collection<int, Playlist> */
     public function getAllAccessibleByUser(User $user): Collection
     {
-        $accessibleIds = $this->accessibleByUser($user)->pluck('playlists.id');
-
         return Playlist::query()
-            ->whereIn('playlists.id', $accessibleIds)
+            ->whereIn('playlists.id', $this->accessibleByUser($user)->select('playlists.id'))
             ->leftJoin('playlist_playlist_folder', 'playlists.id', '=', 'playlist_playlist_folder.playlist_id')
             ->distinct()
             ->get(['playlists.*', 'playlist_playlist_folder.folder_id']);

--- a/app/Repositories/SongRepository.php
+++ b/app/Repositories/SongRepository.php
@@ -194,6 +194,7 @@ class SongRepository extends Repository implements ScoutableRepository
             ->get();
     }
 
+    /** @return Collection<int, Song> */
     public function getByPlaylist(Playlist|string $playlist, ?User $scopedUser = null): Collection
     {
         $playlist = $this->playlistRepository->resolveOne($playlist);

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Exceptions\OperationNotApplicableForSmartPlaylistException;
 use App\Http\Middleware\AudioAuthenticate;
 use App\Http\Middleware\ForceHttps;
 use App\Http\Middleware\HandleDemoMode;
@@ -80,6 +81,15 @@ return Application::configure(basePath: dirname(__DIR__))
         $exceptions->render(static function (AuthorizationException $e, Request $request): ?SymfonyResponse {
             return $request->is('rest/*')
                 ? SubsonicResponse::error(50, 'User is not authorized for the given operation.')->toResponse($request)
+                : null;
+        });
+
+        $exceptions->render(static function (
+            OperationNotApplicableForSmartPlaylistException $e,
+            Request $request,
+        ): ?SymfonyResponse {
+            return $request->is('rest/*')
+                ? SubsonicResponse::error(0, 'Operation is not applicable to smart playlists.')->toResponse($request)
                 : null;
         });
     })

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,14 +1,12 @@
 <?php
 
-use App\Exceptions\OperationNotApplicableForSmartPlaylistException;
+use App\Exceptions\SubsonicAwareErrorHandler;
 use App\Http\Middleware\AudioAuthenticate;
 use App\Http\Middleware\ForceHttps;
 use App\Http\Middleware\HandleDemoMode;
 use App\Http\Middleware\ObjectStorageAuthenticate;
 use App\Http\Middleware\RestrictPlusFeatures;
-use App\Http\Responses\Subsonic\SubsonicResponse;
 use App\Providers\RouteServiceProvider;
-use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
@@ -17,9 +15,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
-use Illuminate\Validation\ValidationException;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -66,31 +62,11 @@ return Application::configure(basePath: dirname(__DIR__))
             return redirect()->guest('/');
         });
 
-        $exceptions->render(static function (NotFoundHttpException $e, Request $request): ?SymfonyResponse {
-            return $request->is('rest/*')
-                ? SubsonicResponse::error(70, 'The requested data was not found.')->toResponse($request)
-                : null;
-        });
-
-        $exceptions->render(static function (ValidationException $e, Request $request): ?SymfonyResponse {
-            return $request->is('rest/*')
-                ? SubsonicResponse::error(10, 'Required parameter is missing.')->toResponse($request)
-                : null;
-        });
-
-        $exceptions->render(static function (AuthorizationException $e, Request $request): ?SymfonyResponse {
-            return $request->is('rest/*')
-                ? SubsonicResponse::error(50, 'User is not authorized for the given operation.')->toResponse($request)
-                : null;
-        });
-
-        $exceptions->render(static function (
-            OperationNotApplicableForSmartPlaylistException $e,
-            Request $request,
-        ): ?SymfonyResponse {
-            return $request->is('rest/*')
-                ? SubsonicResponse::error(0, 'Operation is not applicable to smart playlists.')->toResponse($request)
-                : null;
-        });
+        $exceptions->render(
+            static fn (Throwable $e, Request $request): ?SymfonyResponse => SubsonicAwareErrorHandler::handle(
+                $e,
+                $request,
+            ),
+        );
     })
     ->create();

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Exceptions\SubsonicAwareErrorHandler;
+use App\Exceptions\SubsonicAwareErrorRenderer;
 use App\Http\Middleware\AudioAuthenticate;
 use App\Http\Middleware\ForceHttps;
 use App\Http\Middleware\HandleDemoMode;
@@ -63,7 +63,7 @@ return Application::configure(basePath: dirname(__DIR__))
         });
 
         $exceptions->render(
-            static fn (Throwable $e, Request $request): ?SymfonyResponse => SubsonicAwareErrorHandler::handle(
+            static fn (Throwable $e, Request $request): ?SymfonyResponse => SubsonicAwareErrorRenderer::render(
                 $e,
                 $request,
             ),

--- a/routes/subsonic.php
+++ b/routes/subsonic.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Http\Controllers\Subsonic\CreatePlaylistController;
+use App\Http\Controllers\Subsonic\DeletePlaylistController;
 use App\Http\Controllers\Subsonic\GetAlbumController;
 use App\Http\Controllers\Subsonic\GetAlbumList2Controller;
 use App\Http\Controllers\Subsonic\GetArtistController;
@@ -8,15 +10,19 @@ use App\Http\Controllers\Subsonic\GetCoverArtController;
 use App\Http\Controllers\Subsonic\GetGenresController;
 use App\Http\Controllers\Subsonic\GetLicenseController;
 use App\Http\Controllers\Subsonic\GetMusicFoldersController;
+use App\Http\Controllers\Subsonic\GetPlaylistController;
+use App\Http\Controllers\Subsonic\GetPlaylistsController;
 use App\Http\Controllers\Subsonic\GetSongController;
 use App\Http\Controllers\Subsonic\PingController;
 use App\Http\Controllers\Subsonic\Search3Controller;
 use App\Http\Controllers\Subsonic\StreamController;
+use App\Http\Controllers\Subsonic\UpdatePlaylistController;
+use App\Http\Middleware\NormalizeSubsonicArrayParams;
 use App\Http\Middleware\SubsonicAuth;
 use Illuminate\Support\Facades\Route;
 
 Route::prefix('rest')
-    ->middleware(SubsonicAuth::class)
+    ->middleware([NormalizeSubsonicArrayParams::class, SubsonicAuth::class])
     ->group(static function (): void {
         Route::match(['get', 'post'], 'ping.view', PingController::class);
         Route::match(['get', 'post'], 'getLicense.view', GetLicenseController::class);
@@ -30,4 +36,9 @@ Route::prefix('rest')
         Route::match(['get', 'post'], 'getAlbumList2.view', GetAlbumList2Controller::class);
         Route::match(['get', 'post'], 'stream.view', StreamController::class);
         Route::match(['get', 'post'], 'getCoverArt.view', GetCoverArtController::class);
+        Route::match(['get', 'post'], 'getPlaylists.view', GetPlaylistsController::class);
+        Route::match(['get', 'post'], 'getPlaylist.view', GetPlaylistController::class);
+        Route::match(['get', 'post'], 'createPlaylist.view', CreatePlaylistController::class);
+        Route::match(['get', 'post'], 'updatePlaylist.view', UpdatePlaylistController::class);
+        Route::match(['get', 'post'], 'deletePlaylist.view', DeletePlaylistController::class);
     });

--- a/tests/Concerns/CreatesOwnedPlaylists.php
+++ b/tests/Concerns/CreatesOwnedPlaylists.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tests\Concerns;
+
+use App\Models\Playlist;
+use App\Models\User;
+
+trait CreatesOwnedPlaylists
+{
+    protected static function playlistOwnedBy(User $user, bool $smart = false): Playlist
+    {
+        $factory = Playlist::factory();
+        $playlist = $smart ? $factory->smart()->createOne() : $factory->createOne();
+        $playlist->users()->detach();
+        $playlist->users()->attach($user, ['role' => 'owner']);
+
+        return $playlist;
+    }
+}

--- a/tests/Feature/Subsonic/CreatePlaylistTest.php
+++ b/tests/Feature/Subsonic/CreatePlaylistTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Feature\Subsonic;
+
+use App\Models\Song;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Concerns\CreatesOwnedPlaylists;
+use Tests\TestCase;
+
+use function Tests\create_user;
+
+class CreatePlaylistTest extends TestCase
+{
+    use CreatesOwnedPlaylists;
+
+    #[Test]
+    public function createsNewPlaylistWithSongs(): void
+    {
+        $user = create_user();
+        $songs = Song::factory()->count(2)->create(['owner_id' => $user->id]);
+        $songParams = implode('&', array_map(static fn (Song $song) => 'songId=' . $song->id, $songs->all()));
+
+        $this
+            ->getJson(
+                "/rest/createPlaylist.view?apiKey={$user->subsonic_api_key}"
+                . "&f=json&name=Subsonic+Mix&{$songParams}",
+            )
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.status', 'ok')
+            ->assertJsonPath('subsonic-response.playlist.name', 'Subsonic Mix')
+            ->assertJsonPath('subsonic-response.playlist.songCount', 2);
+
+        self::assertSame(1, $user->ownedPlaylists()->where('name', 'Subsonic Mix')->count());
+    }
+
+    #[Test]
+    public function withPlaylistIdReplacesContents(): void
+    {
+        $user = create_user();
+        $playlist = self::playlistOwnedBy($user);
+
+        $existing = Song::factory()->count(2)->create(['owner_id' => $user->id]);
+        $playlist->addPlayables($existing, $user);
+
+        $replacements = Song::factory()->count(3)->create(['owner_id' => $user->id]);
+        $songParams = implode('&', array_map(static fn (Song $song) => 'songId=' . $song->id, $replacements->all()));
+
+        $response = $this->getJson(
+            "/rest/createPlaylist.view?apiKey={$user->subsonic_api_key}"
+            . "&f=json&playlistId={$playlist->id}&{$songParams}",
+        )->assertOk();
+
+        $entryIds = array_column($response->json('subsonic-response.playlist.entry'), 'id');
+        self::assertEqualsCanonicalizing($replacements->modelKeys(), $entryIds);
+    }
+
+    #[Test]
+    public function missingNameAndPlaylistIdReturnsCode10(): void
+    {
+        $user = create_user();
+
+        $this
+            ->getJson("/rest/createPlaylist.view?apiKey={$user->subsonic_api_key}&f=json")
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.status', 'failed')
+            ->assertJsonPath('subsonic-response.error.code', 10);
+    }
+}

--- a/tests/Feature/Subsonic/CreatePlaylistTest.php
+++ b/tests/Feature/Subsonic/CreatePlaylistTest.php
@@ -4,15 +4,12 @@ namespace Tests\Feature\Subsonic;
 
 use App\Models\Song;
 use PHPUnit\Framework\Attributes\Test;
-use Tests\Concerns\CreatesOwnedPlaylists;
 use Tests\TestCase;
 
 use function Tests\create_user;
 
 class CreatePlaylistTest extends TestCase
 {
-    use CreatesOwnedPlaylists;
-
     #[Test]
     public function createsNewPlaylistWithSongs(): void
     {
@@ -34,28 +31,7 @@ class CreatePlaylistTest extends TestCase
     }
 
     #[Test]
-    public function withPlaylistIdReplacesContents(): void
-    {
-        $user = create_user();
-        $playlist = self::playlistOwnedBy($user);
-
-        $existing = Song::factory()->count(2)->create(['owner_id' => $user->id]);
-        $playlist->addPlayables($existing, $user);
-
-        $replacements = Song::factory()->count(3)->create(['owner_id' => $user->id]);
-        $songParams = implode('&', array_map(static fn (Song $song) => 'songId=' . $song->id, $replacements->all()));
-
-        $response = $this->getJson(
-            "/rest/createPlaylist.view?apiKey={$user->subsonic_api_key}"
-            . "&f=json&playlistId={$playlist->id}&{$songParams}",
-        )->assertOk();
-
-        $entryIds = array_column($response->json('subsonic-response.playlist.entry'), 'id');
-        self::assertEqualsCanonicalizing($replacements->modelKeys(), $entryIds);
-    }
-
-    #[Test]
-    public function missingNameAndPlaylistIdReturnsCode10(): void
+    public function missingNameReturnsCode10(): void
     {
         $user = create_user();
 

--- a/tests/Feature/Subsonic/DeletePlaylistTest.php
+++ b/tests/Feature/Subsonic/DeletePlaylistTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Feature\Subsonic;
+
+use App\Models\Playlist;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Concerns\CreatesOwnedPlaylists;
+use Tests\TestCase;
+
+use function Tests\create_user;
+
+class DeletePlaylistTest extends TestCase
+{
+    use CreatesOwnedPlaylists;
+
+    #[Test]
+    public function deletesPlaylist(): void
+    {
+        $user = create_user();
+        $playlist = self::playlistOwnedBy($user);
+
+        $this
+            ->getJson("/rest/deletePlaylist.view?apiKey={$user->subsonic_api_key}&f=json&id={$playlist->id}")
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.status', 'ok');
+
+        self::assertNull(Playlist::query()->find($playlist->id));
+    }
+
+    #[Test]
+    public function unknownIdReturnsCode70(): void
+    {
+        $user = create_user();
+
+        $this
+            ->getJson("/rest/deletePlaylist.view?apiKey={$user->subsonic_api_key}&f=json&id=does-not-exist")
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.error.code', 70);
+    }
+}

--- a/tests/Feature/Subsonic/GetPlaylistTest.php
+++ b/tests/Feature/Subsonic/GetPlaylistTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Feature\Subsonic;
+
+use App\Models\Song;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Concerns\CreatesOwnedPlaylists;
+use Tests\TestCase;
+
+use function Tests\create_user;
+
+class GetPlaylistTest extends TestCase
+{
+    use CreatesOwnedPlaylists;
+
+    #[Test]
+    public function returnsPlaylistWithSongs(): void
+    {
+        $user = create_user();
+        $playlist = self::playlistOwnedBy($user);
+
+        $songs = Song::factory()->count(3)->create(['owner_id' => $user->id]);
+        $playlist->addPlayables($songs, $user);
+
+        $response = $this
+            ->getJson("/rest/getPlaylist.view?apiKey={$user->subsonic_api_key}&f=json&id={$playlist->id}")
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.status', 'ok')
+            ->assertJsonPath('subsonic-response.playlist.id', $playlist->id)
+            ->assertJsonPath('subsonic-response.playlist.songCount', 3);
+
+        $entryIds = array_column($response->json('subsonic-response.playlist.entry'), 'id');
+        self::assertEqualsCanonicalizing($songs->modelKeys(), $entryIds);
+    }
+
+    #[Test]
+    public function unknownIdReturnsCode70(): void
+    {
+        $user = create_user();
+
+        $this
+            ->getJson("/rest/getPlaylist.view?apiKey={$user->subsonic_api_key}&f=json&id=does-not-exist")
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.status', 'failed')
+            ->assertJsonPath('subsonic-response.error.code', 70);
+    }
+}

--- a/tests/Feature/Subsonic/GetPlaylistsTest.php
+++ b/tests/Feature/Subsonic/GetPlaylistsTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Feature\Subsonic;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Concerns\CreatesOwnedPlaylists;
+use Tests\TestCase;
+
+use function Tests\create_user;
+
+class GetPlaylistsTest extends TestCase
+{
+    use CreatesOwnedPlaylists;
+
+    #[Test]
+    public function returnsUsersPlaylists(): void
+    {
+        $user = create_user();
+        $a = self::playlistOwnedBy($user);
+        $b = self::playlistOwnedBy($user);
+
+        $response = $this
+            ->getJson("/rest/getPlaylists.view?apiKey={$user->subsonic_api_key}&f=json")
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.status', 'ok');
+
+        $ids = array_column($response->json('subsonic-response.playlists.playlist'), 'id');
+
+        self::assertContains($a->id, $ids);
+        self::assertContains($b->id, $ids);
+    }
+}

--- a/tests/Feature/Subsonic/UpdatePlaylistTest.php
+++ b/tests/Feature/Subsonic/UpdatePlaylistTest.php
@@ -83,6 +83,26 @@ class UpdatePlaylistTest extends TestCase
     }
 
     #[Test]
+    public function nonNumericSongIndexIsRejected(): void
+    {
+        $user = create_user();
+        $playlist = self::playlistOwnedBy($user);
+        $songs = Song::factory()->count(2)->create(['owner_id' => $user->id]);
+        $playlist->addPlayables($songs, $user);
+
+        $this
+            ->getJson(
+                "/rest/updatePlaylist.view?apiKey={$user->subsonic_api_key}"
+                . "&f=json&playlistId={$playlist->id}&songIndexToRemove=foo",
+            )
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.status', 'failed')
+            ->assertJsonPath('subsonic-response.error.code', 10);
+
+        self::assertCount(2, $playlist->refresh()->playables);
+    }
+
+    #[Test]
     public function missingPlaylistIdReturnsCode10(): void
     {
         $user = create_user();

--- a/tests/Feature/Subsonic/UpdatePlaylistTest.php
+++ b/tests/Feature/Subsonic/UpdatePlaylistTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Tests\Feature\Subsonic;
+
+use App\Models\Song;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Concerns\CreatesOwnedPlaylists;
+use Tests\TestCase;
+
+use function Tests\create_user;
+
+class UpdatePlaylistTest extends TestCase
+{
+    use CreatesOwnedPlaylists;
+
+    #[Test]
+    public function updatesNameAndComment(): void
+    {
+        $user = create_user();
+        $playlist = self::playlistOwnedBy($user);
+
+        $this
+            ->getJson(
+                "/rest/updatePlaylist.view?apiKey={$user->subsonic_api_key}"
+                . "&f=json&playlistId={$playlist->id}&name=Renamed&comment=New+notes",
+            )
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.status', 'ok');
+
+        $playlist->refresh();
+        self::assertSame('Renamed', $playlist->name);
+        self::assertSame('New notes', $playlist->description);
+    }
+
+    #[Test]
+    public function songIdToAddAppendsSongs(): void
+    {
+        $user = create_user();
+        $playlist = self::playlistOwnedBy($user);
+        $songs = Song::factory()->count(2)->create(['owner_id' => $user->id]);
+        $songParams = implode('&', array_map(static fn (Song $song) => 'songIdToAdd=' . $song->id, $songs->all()));
+
+        $this->getJson(
+            "/rest/updatePlaylist.view?apiKey={$user->subsonic_api_key}"
+            . "&f=json&playlistId={$playlist->id}&{$songParams}",
+        )->assertOk();
+
+        self::assertEqualsCanonicalizing($songs->modelKeys(), $playlist->refresh()->playables->modelKeys());
+    }
+
+    #[Test]
+    public function songIndexToRemoveDropsByIndex(): void
+    {
+        $user = create_user();
+        $playlist = self::playlistOwnedBy($user);
+        $songs = Song::factory()->count(3)->create(['owner_id' => $user->id]);
+        $playlist->addPlayables($songs, $user);
+
+        $this->getJson(
+            "/rest/updatePlaylist.view?apiKey={$user->subsonic_api_key}"
+            . "&f=json&playlistId={$playlist->id}&songIndexToRemove=1",
+        )->assertOk();
+
+        $remaining = $playlist->refresh()->playables->modelKeys();
+        self::assertCount(2, $remaining);
+        self::assertNotContains($songs[1]->id, $remaining);
+    }
+
+    #[Test]
+    public function smartPlaylistRejectsContentMutation(): void
+    {
+        $user = create_user();
+        $playlist = self::playlistOwnedBy($user, smart: true);
+        $song = Song::factory()->createOne(['owner_id' => $user->id]);
+
+        $this
+            ->getJson(
+                "/rest/updatePlaylist.view?apiKey={$user->subsonic_api_key}"
+                . "&f=json&playlistId={$playlist->id}&songIdToAdd={$song->id}",
+            )
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.status', 'failed');
+    }
+
+    #[Test]
+    public function missingPlaylistIdReturnsCode10(): void
+    {
+        $user = create_user();
+
+        $this
+            ->getJson("/rest/updatePlaylist.view?apiKey={$user->subsonic_api_key}&f=json")
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.error.code', 10);
+    }
+}

--- a/tests/Unit/Exceptions/SubsonicAwareErrorHandlerTest.php
+++ b/tests/Unit/Exceptions/SubsonicAwareErrorHandlerTest.php
@@ -2,8 +2,10 @@
 
 namespace Tests\Unit\Exceptions;
 
+use App\Exceptions\Contracts\SubsonicThrowable;
 use App\Exceptions\OperationNotApplicableForSmartPlaylistException;
 use App\Exceptions\SubsonicAwareErrorHandler;
+use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\Request;
 use Illuminate\Validation\ValidationException;
@@ -37,6 +39,30 @@ class SubsonicAwareErrorHandlerTest extends TestCase
     public function validationMapsToCode10(): void
     {
         $this->assertMapping(ValidationException::withMessages(['x' => 'required']), 10);
+    }
+
+    #[Test]
+    public function subsonicThrowableSuppliesItsOwnCodeAndMessage(): void
+    {
+        $exception = new class() extends Exception implements SubsonicThrowable {
+            public function getSubsonicErrorCode(): int
+            {
+                return 42;
+            }
+
+            public function getSubsonicErrorMessage(): string
+            {
+                return 'Custom message.';
+            }
+        };
+
+        $request = Request::create('/rest/ping.view?f=json', 'GET');
+        $response = SubsonicAwareErrorHandler::handle($exception, $request);
+
+        self::assertNotNull($response);
+        $body = (string) $response->getContent();
+        self::assertStringContainsString('"code":42', $body);
+        self::assertStringContainsString('Custom message.', $body);
     }
 
     #[Test]

--- a/tests/Unit/Exceptions/SubsonicAwareErrorHandlerTest.php
+++ b/tests/Unit/Exceptions/SubsonicAwareErrorHandlerTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Unit\Exceptions;
+
+use App\Exceptions\OperationNotApplicableForSmartPlaylistException;
+use App\Exceptions\SubsonicAwareErrorHandler;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
+use PHPUnit\Framework\Attributes\Test;
+use RuntimeException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Tests\TestCase;
+use Throwable;
+
+class SubsonicAwareErrorHandlerTest extends TestCase
+{
+    #[Test]
+    public function notFoundMapsToCode70(): void
+    {
+        $this->assertMapping(new NotFoundHttpException(), 70);
+    }
+
+    #[Test]
+    public function authorizationMapsToCode50(): void
+    {
+        $this->assertMapping(new AuthorizationException(), 50);
+    }
+
+    #[Test]
+    public function smartPlaylistOperationMapsToCode0(): void
+    {
+        $this->assertMapping(new OperationNotApplicableForSmartPlaylistException(), 0);
+    }
+
+    #[Test]
+    public function validationMapsToCode10(): void
+    {
+        $this->assertMapping(ValidationException::withMessages(['x' => 'required']), 10);
+    }
+
+    #[Test]
+    public function returnsNullForNonRestRoutes(): void
+    {
+        $request = Request::create('/api/songs', 'GET');
+
+        self::assertNull(SubsonicAwareErrorHandler::handle(new NotFoundHttpException(), $request));
+    }
+
+    #[Test]
+    public function returnsNullForUnmappedExceptions(): void
+    {
+        $request = Request::create('/rest/ping.view', 'GET');
+
+        self::assertNull(SubsonicAwareErrorHandler::handle(new RuntimeException('boom'), $request));
+    }
+
+    private function assertMapping(Throwable $exception, int $expectedCode): void
+    {
+        $request = Request::create('/rest/ping.view?f=json', 'GET');
+        $response = SubsonicAwareErrorHandler::handle($exception, $request);
+
+        self::assertNotNull($response);
+        self::assertStringContainsString('"code":' . $expectedCode, (string) $response->getContent());
+    }
+}

--- a/tests/Unit/Exceptions/SubsonicAwareErrorRendererTest.php
+++ b/tests/Unit/Exceptions/SubsonicAwareErrorRendererTest.php
@@ -4,7 +4,7 @@ namespace Tests\Unit\Exceptions;
 
 use App\Exceptions\Contracts\SubsonicThrowable;
 use App\Exceptions\OperationNotApplicableForSmartPlaylistException;
-use App\Exceptions\SubsonicAwareErrorHandler;
+use App\Exceptions\SubsonicAwareErrorRenderer;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\Request;
@@ -15,7 +15,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Tests\TestCase;
 use Throwable;
 
-class SubsonicAwareErrorHandlerTest extends TestCase
+class SubsonicAwareErrorRendererTest extends TestCase
 {
     #[Test]
     public function notFoundMapsToCode70(): void
@@ -57,7 +57,7 @@ class SubsonicAwareErrorHandlerTest extends TestCase
         };
 
         $request = Request::create('/rest/ping.view?f=json', 'GET');
-        $response = SubsonicAwareErrorHandler::handle($exception, $request);
+        $response = SubsonicAwareErrorRenderer::render($exception, $request);
 
         self::assertNotNull($response);
         $body = (string) $response->getContent();
@@ -70,7 +70,7 @@ class SubsonicAwareErrorHandlerTest extends TestCase
     {
         $request = Request::create('/api/songs', 'GET');
 
-        self::assertNull(SubsonicAwareErrorHandler::handle(new NotFoundHttpException(), $request));
+        self::assertNull(SubsonicAwareErrorRenderer::render(new NotFoundHttpException(), $request));
     }
 
     #[Test]
@@ -78,13 +78,13 @@ class SubsonicAwareErrorHandlerTest extends TestCase
     {
         $request = Request::create('/rest/ping.view', 'GET');
 
-        self::assertNull(SubsonicAwareErrorHandler::handle(new RuntimeException('boom'), $request));
+        self::assertNull(SubsonicAwareErrorRenderer::render(new RuntimeException('boom'), $request));
     }
 
     private function assertMapping(Throwable $exception, int $expectedCode): void
     {
         $request = Request::create('/rest/ping.view?f=json', 'GET');
-        $response = SubsonicAwareErrorHandler::handle($exception, $request);
+        $response = SubsonicAwareErrorRenderer::render($exception, $request);
 
         self::assertNotNull($response);
         self::assertStringContainsString('"code":' . $expectedCode, (string) $response->getContent());

--- a/tests/Unit/Helpers/QueryStringParserTest.php
+++ b/tests/Unit/Helpers/QueryStringParserTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Unit\Helpers;
+
+use App\Helpers\QueryStringParser;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class QueryStringParserTest extends TestCase
+{
+    #[Test]
+    public function preservesDuplicateKeys(): void
+    {
+        self::assertSame(['songId' => ['a', 'b', 'c']], QueryStringParser::parse('songId=a&songId=b&songId=c'));
+    }
+
+    #[Test]
+    public function singleValueKeyStillBecomesList(): void
+    {
+        self::assertSame(['name' => ['Mix']], QueryStringParser::parse('name=Mix'));
+    }
+
+    #[Test]
+    public function urlDecodesKeysAndValues(): void
+    {
+        self::assertSame(['my key' => ['hello world']], QueryStringParser::parse('my%20key=hello%20world'));
+    }
+
+    #[Test]
+    public function skipsBracketSuffixedKeys(): void
+    {
+        self::assertSame(['plain' => ['x']], QueryStringParser::parse('plain=x&things%5B%5D=a&things%5B%5D=b'));
+    }
+
+    #[Test]
+    public function skipsPairsWithoutEquals(): void
+    {
+        self::assertSame(['ok' => ['1']], QueryStringParser::parse('flag&ok=1'));
+    }
+
+    #[Test]
+    public function emptyStringReturnsEmptyArray(): void
+    {
+        self::assertSame([], QueryStringParser::parse(''));
+    }
+}


### PR DESCRIPTION
## Summary

Phase 5 of the Subsonic API — playlist endpoints. Builds on #2517, #2518, #2519, and #2520.

New endpoints under `/rest/`:

- `getPlaylists.view` — list all playlists accessible to the user (owned + collaborated under Plus, owned-only under community).
- `getPlaylist.view?id=<id>` — single playlist with its songs. Smart-playlist contents come from rule evaluation via `SongRepository::getByPlaylist`.
- `createPlaylist.view?name=…&songId=…&songId=…` — create a new playlist. **The pre-1.8 `playlistId` overload is deliberately not honored** — see below.
- `updatePlaylist.view?playlistId=…&name=…&comment=…&songIdToAdd=…&songIndexToRemove=…` — update name/comment, append songs, remove by 0-based index.
- `deletePlaylist.view?id=<id>` — delete the playlist.

## Design notes

### `createPlaylist.view` is create-only

Subsonic 1.6 (~2010) overloaded `createPlaylist.view` to also handle updates when `playlistId` was supplied. Subsonic 1.8.0 (~2011) added the proper `updatePlaylist.view`, and that's been the blessed path for ~14 years. Every modern client speaks 1.8.0+. We don't honor the legacy overload — `createPlaylist.view?playlistId=…` returns Subsonic error 10 ("name" missing) and clients should use `updatePlaylist.view` instead.

### Smart playlists

Smart-playlist contents are immutable — they come from rule evaluation, not direct attachment. `updatePlaylist`'s `songIdToAdd`/`songIndexToRemove` would silently corrupt the model, so the controller `throw_if($playlist->is_smart, OperationNotApplicableForSmartPlaylistException::class)` and a new render hook in `bootstrap/app.php` converts that to Subsonic error code 0. Name/comment edits on smart playlists remain allowed.

`getPlaylist.view` uses `SongRepository::getByPlaylist` which already branches between standard (joined table) and smart (rule evaluation), so smart playlists show their dynamic contents to clients without any Subsonic-side smarts.

### Subsonic multi-value query params (no brackets)

Subsonic clients send `?songId=a&songId=b&songId=c` without `[]` notation — PHP's `parse_str` and Symfony's `InputBag` collapse duplicate keys to last-wins, so `songId` would arrive as a single string. New `NormalizeSubsonicArrayParams` middleware re-parses the raw `QUERY_STRING` and merges duplicate keys into arrays. Applied to the whole `rest/*` group ahead of `SubsonicAuth`.

For single-value cases (`songIndexToRemove=1`), the param arrives as a scalar string and controllers wrap with `Arr::wrap` before iterating.

### Playlist subtleties Subsonic doesn't model

- `public` — koel doesn't have a public/private playlist flag; emitted as `false` always.
- `comment` ↔ `description` — direct mapping.
- `coverArt` — emits `playlist.id` when cover is set, null otherwise. Reuses Phase 4's `getCoverArt.view` once that's extended for playlists (out of scope here).
- Playlist folders — koel-only concept, not exposed in Subsonic.
- Collaboration / `allowedUser` — not surfaced this phase.

### Repository tweaks

- `PlaylistRepository::getAllAccessibleByUser` rewritten to do `Playlist::query()->whereIn(ids)` so the generic resolves to `Collection<int, Playlist>`. Semantically equivalent (still scoped via `accessibleByUser`'s license-aware relation), just two queries instead of one join.
- `SongRepository::getByPlaylist` gained a `@return Collection<int, Song>` PHPDoc so callers' `->map(SongResource::toArray(...))` type-checks.

### Test reuse

New `Tests\Concerns\CreatesOwnedPlaylists` trait — `playlistOwnedBy(User, smart: bool)` creates a Playlist owned by the given user. Used across the playlist test files.

## Test plan

- [x] `php artisan test --compact tests/Feature/Subsonic/ tests/Feature/KoelPlus/Subsonic/` — 52 passed, 171 assertions
- [x] `composer cs` / `composer lint` / `composer analyze` all green
- [ ] Verify from a Subsonic client: list playlists, view one, create with songs, rename, add/remove songs, delete


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full Subsonic playlist REST: create, list, view, update, delete; add/remove tracks and edit metadata. Smart-playlist content edits return a clear Subsonic error code/message.
  * Playlist responses now include song counts, total duration, timestamps, and coverArt mapping.
  * Repeated query/body parameters accepted as multi-value fields; improved query-string parsing.
  * Subsonic-specific error mapping so REST errors return consistent Subsonic codes/messages.

* **Refactor**
  * Playlist repository query/return-type adjustments for consistent fetching.

* **Tests**
  * Comprehensive unit and feature tests plus a test helper covering playlist flows and error cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2521?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->