### PR TITLE
feat: subsonic API lyrics, download, songs-by-genre, info and openSubsonic extensions

### DIFF
--- a/app/Http/Controllers/Subsonic/DownloadController.php
+++ b/app/Http/Controllers/Subsonic/DownloadController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers\Subsonic;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Subsonic\IdRequest;
+use App\Repositories\SongRepository;
+use App\Services\Streamer\Streamer;
+use App\Values\RequestedStreamingConfig;
+
+class DownloadController extends Controller
+{
+    public function __construct(
+        private readonly SongRepository $songRepository,
+    ) {}
+
+    public function __invoke(IdRequest $request)
+    {
+        $song = $this->songRepository->getOne($request->id);
+        $this->authorize('access', $song);
+
+        return (new Streamer(song: $song, config: RequestedStreamingConfig::make(
+            transcode: false,
+            bitRate: null,
+        )))->stream();
+    }
+}

--- a/app/Http/Controllers/Subsonic/DownloadController.php
+++ b/app/Http/Controllers/Subsonic/DownloadController.php
@@ -5,13 +5,15 @@ namespace App\Http\Controllers\Subsonic;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Subsonic\IdRequest;
 use App\Repositories\SongRepository;
-use App\Services\Streamer\Streamer;
-use App\Values\RequestedStreamingConfig;
+use App\Services\DownloadService;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 class DownloadController extends Controller
 {
     public function __construct(
         private readonly SongRepository $songRepository,
+        private readonly DownloadService $downloadService,
     ) {}
 
     public function __invoke(IdRequest $request)
@@ -19,9 +21,10 @@ class DownloadController extends Controller
         $song = $this->songRepository->getOne($request->id);
         $this->authorize('access', $song);
 
-        return (new Streamer(song: $song, config: RequestedStreamingConfig::make(
-            transcode: false,
-            bitRate: null,
-        )))->stream();
+        return (
+            $this->downloadService
+                ->getDownloadable(new Collection([$song]))
+                ?->toResponse() ?? throw new ModelNotFoundException()
+        );
     }
 }

--- a/app/Http/Controllers/Subsonic/GetAlbumInfo2Controller.php
+++ b/app/Http/Controllers/Subsonic/GetAlbumInfo2Controller.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Controllers\Subsonic;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Subsonic\IdRequest;
+use App\Http\Responses\Subsonic\SubsonicResponse;
+use App\Repositories\AlbumRepository;
+use App\Services\Contracts\Encyclopedia;
+
+class GetAlbumInfo2Controller extends Controller
+{
+    public function __construct(
+        private readonly AlbumRepository $albumRepository,
+        private readonly Encyclopedia $encyclopedia,
+    ) {}
+
+    public function __invoke(IdRequest $request)
+    {
+        $album = $this->albumRepository->getOne($request->id);
+        $info = $this->encyclopedia->getAlbumInformation($album);
+
+        if ($info === null) {
+            return SubsonicResponse::ok(['albumInfo' => []]);
+        }
+
+        $imageUrl = $info->cover ?: null;
+
+        return SubsonicResponse::ok([
+            'albumInfo' => [
+                'notes' => $info->wiki['summary'] ?: null,
+                'lastFmUrl' => $info->url,
+                'smallImageUrl' => $imageUrl,
+                'mediumImageUrl' => $imageUrl,
+                'largeImageUrl' => $imageUrl,
+            ],
+        ]);
+    }
+}

--- a/app/Http/Controllers/Subsonic/GetArtistInfo2Controller.php
+++ b/app/Http/Controllers/Subsonic/GetArtistInfo2Controller.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Controllers\Subsonic;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Subsonic\IdRequest;
+use App\Http\Responses\Subsonic\SubsonicResponse;
+use App\Repositories\ArtistRepository;
+use App\Services\Contracts\Encyclopedia;
+
+class GetArtistInfo2Controller extends Controller
+{
+    public function __construct(
+        private readonly ArtistRepository $artistRepository,
+        private readonly Encyclopedia $encyclopedia,
+    ) {}
+
+    public function __invoke(IdRequest $request)
+    {
+        $artist = $this->artistRepository->getOne($request->id);
+        $info = $this->encyclopedia->getArtistInformation($artist);
+
+        if ($info === null) {
+            return SubsonicResponse::ok(['artistInfo2' => []]);
+        }
+
+        $imageUrl = $info->image ?: null;
+
+        return SubsonicResponse::ok([
+            'artistInfo2' => [
+                'biography' => $info->bio['summary'] ?: null,
+                'lastFmUrl' => $info->url,
+                'smallImageUrl' => $imageUrl,
+                'mediumImageUrl' => $imageUrl,
+                'largeImageUrl' => $imageUrl,
+            ],
+        ]);
+    }
+}

--- a/app/Http/Controllers/Subsonic/GetLyricsBySongIdController.php
+++ b/app/Http/Controllers/Subsonic/GetLyricsBySongIdController.php
@@ -31,7 +31,7 @@ class GetLyricsBySongIdController extends Controller
                     [
                         'displayArtist' => $song->artist_name,
                         'displayTitle' => $song->title,
-                        'lang' => 'xxx',
+                        'lang' => 'und',
                         'offset' => 0,
                         'synced' => false,
                         'line' => $lines,

--- a/app/Http/Controllers/Subsonic/GetLyricsBySongIdController.php
+++ b/app/Http/Controllers/Subsonic/GetLyricsBySongIdController.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Controllers\Subsonic;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Subsonic\IdRequest;
+use App\Http\Responses\Subsonic\SubsonicResponse;
+use App\Repositories\SongRepository;
+
+class GetLyricsBySongIdController extends Controller
+{
+    public function __construct(
+        private readonly SongRepository $songRepository,
+    ) {}
+
+    public function __invoke(IdRequest $request)
+    {
+        $song = $this->songRepository->getOne($request->id);
+
+        $lyrics = trim((string) $song->lyrics);
+
+        if ($lyrics === '') {
+            return SubsonicResponse::ok(['lyricsList' => []]);
+        }
+
+        $lines = array_map(static fn (string $line) => ['value' => $line], preg_split('/\r\n|\r|\n/', $lyrics) ?: []);
+
+        return SubsonicResponse::ok([
+            'lyricsList' => [
+                'structuredLyrics' => [
+                    [
+                        'displayArtist' => $song->artist_name,
+                        'displayTitle' => $song->title,
+                        'lang' => 'xxx',
+                        'offset' => 0,
+                        'synced' => false,
+                        'line' => $lines,
+                    ],
+                ],
+            ],
+        ]);
+    }
+}

--- a/app/Http/Controllers/Subsonic/GetOpenSubsonicExtensionsController.php
+++ b/app/Http/Controllers/Subsonic/GetOpenSubsonicExtensionsController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers\Subsonic;
+
+use App\Http\Controllers\Controller;
+use App\Http\Responses\Subsonic\SubsonicResponse;
+
+class GetOpenSubsonicExtensionsController extends Controller
+{
+    /**
+     * @see https://opensubsonic.netlify.app/docs/endpoints/getopensubsonicextensions/
+     * @see https://opensubsonic.netlify.app/docs/extensions/
+     */
+    private const array EXTENSIONS = [
+        ['name' => 'songLyrics', 'versions' => [1]],
+        ['name' => 'transcodeOffset', 'versions' => [1]],
+    ];
+
+    public function __invoke()
+    {
+        return SubsonicResponse::ok(['openSubsonicExtensions' => self::EXTENSIONS]);
+    }
+}

--- a/app/Http/Controllers/Subsonic/GetSongsByGenreController.php
+++ b/app/Http/Controllers/Subsonic/GetSongsByGenreController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Controllers\Subsonic;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Subsonic\GetSongsByGenreRequest;
+use App\Http\Responses\Subsonic\Resources\SongResource;
+use App\Http\Responses\Subsonic\SubsonicResponse;
+use App\Models\Song;
+use App\Models\User;
+use App\Repositories\GenreRepository;
+use App\Repositories\SongRepository;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+
+class GetSongsByGenreController extends Controller
+{
+    public function __construct(
+        private readonly GenreRepository $genreRepository,
+        private readonly SongRepository $songRepository,
+    ) {}
+
+    /** @param User $user */
+    public function __invoke(GetSongsByGenreRequest $request, Authenticatable $user)
+    {
+        $genre = $this->genreRepository->searchByName($request->genre) ?? throw new ModelNotFoundException();
+
+        $songs = $this->songRepository->getByGenre(
+            genre: $genre,
+            limit: $request->integer('count', 10),
+            offset: $request->integer('offset', 0),
+            scopedUser: $user,
+        );
+
+        return SubsonicResponse::ok([
+            'songsByGenre' => [
+                'song' => $songs->map(static fn (Song $song) => SongResource::toArray($song, $user))->all(),
+            ],
+        ]);
+    }
+}

--- a/app/Http/Requests/Subsonic/GetSongsByGenreRequest.php
+++ b/app/Http/Requests/Subsonic/GetSongsByGenreRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Subsonic;
+
+use App\Http\Requests\Request;
+
+/**
+ * @property string $genre
+ */
+class GetSongsByGenreRequest extends Request
+{
+    /** @inheritdoc */
+    public function rules(): array
+    {
+        return [
+            'genre' => ['required', 'string'],
+            'count' => ['integer', 'min:1', 'max:500'],
+            'offset' => ['integer', 'min:0'],
+        ];
+    }
+}

--- a/app/Repositories/SongRepository.php
+++ b/app/Repositories/SongRepository.php
@@ -341,15 +341,22 @@ class SongRepository extends Repository implements ScoutableRepository
 
     /**
      * @param Genre|null $genre If null, query songs that have no genre.
+     * @return Collection<int, Song>
      */
-    public function getByGenre(?Genre $genre, int $limit, $random = false, ?User $scopedUser = null): Collection
-    {
+    public function getByGenre(
+        ?Genre $genre,
+        int $limit,
+        bool $random = false,
+        int $offset = 0,
+        ?User $scopedUser = null,
+    ): Collection {
         return Song::query(type: PlayableType::SONG, user: $scopedUser ?? $this->auth->user())
             ->withUserContext()
             ->when($genre, static fn (Builder $builder) => $builder->whereRelation('genres', 'genres.id', $genre->id))
             ->when(!$genre, static fn (Builder $builder) => $builder->whereDoesntHave('genres'))
             ->when($random, static fn (Builder $builder) => $builder->inRandomOrder())
             ->when(!$random, static fn (Builder $builder) => $builder->orderBy('songs.title'))
+            ->when($offset > 0, static fn (Builder $builder) => $builder->offset($offset))
             ->limit($limit)
             ->get();
     }

--- a/app/Repositories/SongRepository.php
+++ b/app/Repositories/SongRepository.php
@@ -347,8 +347,8 @@ class SongRepository extends Repository implements ScoutableRepository
         ?Genre $genre,
         int $limit,
         bool $random = false,
-        int $offset = 0,
         ?User $scopedUser = null,
+        int $offset = 0,
     ): Collection {
         return Song::query(type: PlayableType::SONG, user: $scopedUser ?? $this->auth->user())
             ->withUserContext()

--- a/routes/subsonic.php
+++ b/routes/subsonic.php
@@ -2,20 +2,26 @@
 
 use App\Http\Controllers\Subsonic\CreatePlaylistController;
 use App\Http\Controllers\Subsonic\DeletePlaylistController;
+use App\Http\Controllers\Subsonic\DownloadController;
 use App\Http\Controllers\Subsonic\GetAlbumController;
+use App\Http\Controllers\Subsonic\GetAlbumInfo2Controller;
 use App\Http\Controllers\Subsonic\GetAlbumList2Controller;
 use App\Http\Controllers\Subsonic\GetArtistController;
+use App\Http\Controllers\Subsonic\GetArtistInfo2Controller;
 use App\Http\Controllers\Subsonic\GetArtistsController;
 use App\Http\Controllers\Subsonic\GetAvatarController;
 use App\Http\Controllers\Subsonic\GetCoverArtController;
 use App\Http\Controllers\Subsonic\GetGenresController;
 use App\Http\Controllers\Subsonic\GetLicenseController;
+use App\Http\Controllers\Subsonic\GetLyricsBySongIdController;
 use App\Http\Controllers\Subsonic\GetMusicFoldersController;
 use App\Http\Controllers\Subsonic\GetNowPlayingController;
+use App\Http\Controllers\Subsonic\GetOpenSubsonicExtensionsController;
 use App\Http\Controllers\Subsonic\GetPlaylistController;
 use App\Http\Controllers\Subsonic\GetPlaylistsController;
 use App\Http\Controllers\Subsonic\GetRandomSongsController;
 use App\Http\Controllers\Subsonic\GetSongController;
+use App\Http\Controllers\Subsonic\GetSongsByGenreController;
 use App\Http\Controllers\Subsonic\GetStarred2Controller;
 use App\Http\Controllers\Subsonic\GetUserController;
 use App\Http\Controllers\Subsonic\PingController;
@@ -59,4 +65,10 @@ Route::prefix('rest')
         Route::match(['get', 'post'], 'getNowPlaying.view', GetNowPlayingController::class);
         Route::match(['get', 'post'], 'getUser.view', GetUserController::class);
         Route::match(['get', 'post'], 'getAvatar.view', GetAvatarController::class);
+        Route::match(['get', 'post'], 'getOpenSubsonicExtensions.view', GetOpenSubsonicExtensionsController::class);
+        Route::match(['get', 'post'], 'download.view', DownloadController::class);
+        Route::match(['get', 'post'], 'getSongsByGenre.view', GetSongsByGenreController::class);
+        Route::match(['get', 'post'], 'getLyricsBySongId.view', GetLyricsBySongIdController::class);
+        Route::match(['get', 'post'], 'getArtistInfo2.view', GetArtistInfo2Controller::class);
+        Route::match(['get', 'post'], 'getAlbumInfo2.view', GetAlbumInfo2Controller::class);
     });

--- a/tests/Feature/Subsonic/DownloadTest.php
+++ b/tests/Feature/Subsonic/DownloadTest.php
@@ -3,8 +3,8 @@
 namespace Tests\Feature\Subsonic;
 
 use App\Models\Song;
-use App\Services\Streamer\Adapters\LocalStreamerAdapter;
 use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Tests\TestCase;
 
 use function Tests\create_user;
@@ -27,7 +27,7 @@ class DownloadTest extends TestCase
     }
 
     #[Test]
-    public function downloadsAudioBytes(): void
+    public function servesAsAttachment(): void
     {
         $user = create_user();
         $song = Song::factory()->createOne([
@@ -35,9 +35,11 @@ class DownloadTest extends TestCase
             'owner_id' => $user->id,
         ]);
 
-        $this->mock(LocalStreamerAdapter::class)->expects('stream');
+        $response = $this->get("/rest/download.view?id={$song->id}&apiKey={$user->subsonic_api_key}")->assertOk();
 
-        $this->get("/rest/download.view?id={$song->id}&apiKey={$user->subsonic_api_key}")->assertOk();
+        $base = $response->baseResponse;
+        self::assertInstanceOf(BinaryFileResponse::class, $base);
+        self::assertStringContainsString('attachment', (string) $base->headers->get('Content-Disposition'));
     }
 
     #[Test]

--- a/tests/Feature/Subsonic/DownloadTest.php
+++ b/tests/Feature/Subsonic/DownloadTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Feature\Subsonic;
+
+use App\Models\Song;
+use App\Services\Streamer\Adapters\LocalStreamerAdapter;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+use function Tests\create_user;
+use function Tests\test_path;
+
+class DownloadTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        ob_start();
+    }
+
+    protected function tearDown(): void
+    {
+        ob_end_clean();
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function downloadsAudioBytes(): void
+    {
+        $user = create_user();
+        $song = Song::factory()->createOne([
+            'path' => test_path('songs/blank.mp3'),
+            'owner_id' => $user->id,
+        ]);
+
+        $this->mock(LocalStreamerAdapter::class)->expects('stream');
+
+        $this->get("/rest/download.view?id={$song->id}&apiKey={$user->subsonic_api_key}")->assertOk();
+    }
+
+    #[Test]
+    public function unknownIdReturnsCode70(): void
+    {
+        $user = create_user();
+
+        $this
+            ->getJson("/rest/download.view?apiKey={$user->subsonic_api_key}&f=json&id=does-not-exist")
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.error.code', 70);
+    }
+}

--- a/tests/Feature/Subsonic/GetAlbumInfo2Test.php
+++ b/tests/Feature/Subsonic/GetAlbumInfo2Test.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Feature\Subsonic;
+
+use App\Models\Album;
+use App\Services\Contracts\Encyclopedia;
+use App\Values\Album\AlbumInformation;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+use function Tests\create_user;
+
+class GetAlbumInfo2Test extends TestCase
+{
+    #[Test]
+    public function returnsNotesFromEncyclopedia(): void
+    {
+        $user = create_user();
+        $album = Album::factory()->createOne(['user_id' => $user->id]);
+
+        $this
+            ->mock(Encyclopedia::class)
+            ->expects('getAlbumInformation')
+            ->andReturn(AlbumInformation::make(
+                url: 'https://www.last.fm/album/Foo',
+                cover: 'https://example.test/cover.jpg',
+                wiki: ['summary' => 'About the album', 'full' => 'Full text'],
+            ));
+
+        $this
+            ->getJson("/rest/getAlbumInfo2.view?apiKey={$user->subsonic_api_key}&f=json&id={$album->id}")
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.albumInfo.notes', 'About the album')
+            ->assertJsonPath('subsonic-response.albumInfo.lastFmUrl', 'https://www.last.fm/album/Foo')
+            ->assertJsonPath('subsonic-response.albumInfo.smallImageUrl', 'https://example.test/cover.jpg');
+    }
+
+    #[Test]
+    public function returnsEmptyWhenEncyclopediaReturnsNull(): void
+    {
+        $user = create_user();
+        $album = Album::factory()->createOne(['user_id' => $user->id]);
+
+        $this->mock(Encyclopedia::class)->expects('getAlbumInformation')->andReturnNull();
+
+        $this
+            ->getJson("/rest/getAlbumInfo2.view?apiKey={$user->subsonic_api_key}&f=json&id={$album->id}")
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.albumInfo', []);
+    }
+}

--- a/tests/Feature/Subsonic/GetArtistInfo2Test.php
+++ b/tests/Feature/Subsonic/GetArtistInfo2Test.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Feature\Subsonic;
+
+use App\Models\Artist;
+use App\Services\Contracts\Encyclopedia;
+use App\Values\Artist\ArtistInformation;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+use function Tests\create_user;
+
+class GetArtistInfo2Test extends TestCase
+{
+    #[Test]
+    public function returnsBiographyFromEncyclopedia(): void
+    {
+        $user = create_user();
+        $artist = Artist::factory()->createOne(['user_id' => $user->id]);
+
+        $this
+            ->mock(Encyclopedia::class)
+            ->expects('getArtistInformation')
+            ->andReturn(ArtistInformation::make(
+                url: 'https://www.last.fm/music/Foo',
+                image: 'https://example.test/foo.jpg',
+                bio: ['summary' => 'Short bio', 'full' => 'Full bio'],
+            ));
+
+        $this
+            ->getJson("/rest/getArtistInfo2.view?apiKey={$user->subsonic_api_key}&f=json&id={$artist->id}")
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.artistInfo2.biography', 'Short bio')
+            ->assertJsonPath('subsonic-response.artistInfo2.lastFmUrl', 'https://www.last.fm/music/Foo')
+            ->assertJsonPath('subsonic-response.artistInfo2.smallImageUrl', 'https://example.test/foo.jpg');
+    }
+
+    #[Test]
+    public function returnsEmptyWhenEncyclopediaReturnsNull(): void
+    {
+        $user = create_user();
+        $artist = Artist::factory()->createOne(['user_id' => $user->id]);
+
+        $this->mock(Encyclopedia::class)->expects('getArtistInformation')->andReturnNull();
+
+        $this
+            ->getJson("/rest/getArtistInfo2.view?apiKey={$user->subsonic_api_key}&f=json&id={$artist->id}")
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.artistInfo2', []);
+    }
+}

--- a/tests/Feature/Subsonic/GetLyricsBySongIdTest.php
+++ b/tests/Feature/Subsonic/GetLyricsBySongIdTest.php
@@ -29,6 +29,8 @@ class GetLyricsBySongIdTest extends TestCase
         $structured = $response->json('subsonic-response.lyricsList.structuredLyrics.0');
         self::assertSame('Radiohead', $structured['displayArtist']);
         self::assertSame('Karma Police', $structured['displayTitle']);
+        self::assertSame('und', $structured['lang']);
+        self::assertSame(0, $structured['offset']);
         self::assertSame(false, $structured['synced']);
         self::assertSame(
             [['value' => 'Line one'], ['value' => 'Line two'], ['value' => 'Line three']],

--- a/tests/Feature/Subsonic/GetLyricsBySongIdTest.php
+++ b/tests/Feature/Subsonic/GetLyricsBySongIdTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Feature\Subsonic;
+
+use App\Models\Song;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+use function Tests\create_user;
+
+class GetLyricsBySongIdTest extends TestCase
+{
+    #[Test]
+    public function returnsStructuredLyrics(): void
+    {
+        $user = create_user();
+        $song = Song::factory()->createOne([
+            'title' => 'Karma Police',
+            'artist_name' => 'Radiohead',
+            'lyrics' => "Line one\nLine two\nLine three",
+            'owner_id' => $user->id,
+        ]);
+
+        $response = $this
+            ->getJson("/rest/getLyricsBySongId.view?apiKey={$user->subsonic_api_key}&f=json&id={$song->id}")
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.status', 'ok');
+
+        $structured = $response->json('subsonic-response.lyricsList.structuredLyrics.0');
+        self::assertSame('Radiohead', $structured['displayArtist']);
+        self::assertSame('Karma Police', $structured['displayTitle']);
+        self::assertSame(false, $structured['synced']);
+        self::assertSame(
+            [['value' => 'Line one'], ['value' => 'Line two'], ['value' => 'Line three']],
+            $structured['line'],
+        );
+    }
+
+    #[Test]
+    public function emptyLyricsReturnsEmptyList(): void
+    {
+        $user = create_user();
+        $song = Song::factory()->createOne(['lyrics' => '', 'owner_id' => $user->id]);
+
+        $this
+            ->getJson("/rest/getLyricsBySongId.view?apiKey={$user->subsonic_api_key}&f=json&id={$song->id}")
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.lyricsList', []);
+    }
+}

--- a/tests/Feature/Subsonic/GetOpenSubsonicExtensionsTest.php
+++ b/tests/Feature/Subsonic/GetOpenSubsonicExtensionsTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Feature\Subsonic;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+use function Tests\create_user;
+
+class GetOpenSubsonicExtensionsTest extends TestCase
+{
+    #[Test]
+    public function declaresSupportedExtensions(): void
+    {
+        $user = create_user();
+
+        $response = $this
+            ->getJson("/rest/getOpenSubsonicExtensions.view?apiKey={$user->subsonic_api_key}&f=json")
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.status', 'ok');
+
+        $names = array_column($response->json('subsonic-response.openSubsonicExtensions'), 'name');
+        self::assertContains('songLyrics', $names);
+        self::assertContains('transcodeOffset', $names);
+    }
+}

--- a/tests/Feature/Subsonic/GetSongsByGenreTest.php
+++ b/tests/Feature/Subsonic/GetSongsByGenreTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Feature\Subsonic;
+
+use App\Http\Responses\Subsonic\Resources\SongResource;
+use App\Models\Genre;
+use App\Models\Song;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+use function Tests\create_user;
+
+class GetSongsByGenreTest extends TestCase
+{
+    #[Test]
+    public function returnsSongsFromTheNamedGenre(): void
+    {
+        $user = create_user();
+        $rock = Genre::factory()->createOne(['name' => 'Rock']);
+        $songs = Song::factory()->count(3)->create(['owner_id' => $user->id]);
+
+        foreach ($songs as $song) {
+            $song->genres()->attach($rock->id);
+        }
+
+        $response = $this
+            ->getJson("/rest/getSongsByGenre.view?apiKey={$user->subsonic_api_key}&f=json&genre=Rock")
+            ->assertOk()
+            ->assertJsonStructure([
+                'subsonic-response' => [
+                    'songsByGenre' => ['song' => ['*' => SongResource::JSON_STRUCTURE]],
+                ],
+            ]);
+
+        self::assertCount(3, $response->json('subsonic-response.songsByGenre.song'));
+    }
+
+    #[Test]
+    public function unknownGenreReturnsCode70(): void
+    {
+        $user = create_user();
+
+        $this
+            ->getJson("/rest/getSongsByGenre.view?apiKey={$user->subsonic_api_key}&f=json&genre=DoesNotExist")
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.error.code', 70);
+    }
+
+    #[Test]
+    public function missingGenreReturnsCode10(): void
+    {
+        $user = create_user();
+
+        $this
+            ->getJson("/rest/getSongsByGenre.view?apiKey={$user->subsonic_api_key}&f=json")
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.error.code', 10);
+    }
+}


### PR DESCRIPTION
## Summary

Phase 8 of the Subsonic API — the "client might actually notice" endpoints from the gap analysis in #2523. Six new endpoints that close the most visible holes in real-client usage. Builds on #2517 through #2523.

New endpoints under `/rest/`:

- `getOpenSubsonicExtensions.view` — capability discovery. Declares `songLyrics` v1 and `transcodeOffset` v1 (we already support both — this just makes them advertisable).
- `download.view` — raw audio bytes, no transcoding. Mirrors `stream.view` but pins `transcode: false` in `RequestedStreamingConfig`.
- `getSongsByGenre.view?genre=…&count=…&offset=…` — paginated songs in a named genre.
- `getLyricsBySongId.view?id=…` — modern lyrics endpoint. Returns the song's lyrics as `structuredLyrics` with one `line` per newline. `synced` is always `false` because koel stores lyrics as plain text.
- `getArtistInfo2.view?id=…` — artist bio. Wraps koel's existing `Encyclopedia::getArtistInformation` (the same service koel's own UI uses).
- `getAlbumInfo2.view?id=…` — album info. Wraps `Encyclopedia::getAlbumInformation`. Response wrapper is `albumInfo` (note: not `albumInfo2`) per the spec.

## Design notes

### Mapping koel's `Encyclopedia` to Subsonic info shapes

koel's `Encyclopedia` returns rich `ArtistInformation` / `AlbumInformation` value objects (`url`, `image`/`cover`, `bio`/`wiki`, plus tracks for albums). Subsonic's info endpoints want:

- `biography` / `notes` → `bio.summary` / `wiki.summary` (purified HTML, already safe to emit)
- `lastFmUrl` → `url`
- `smallImageUrl` / `mediumImageUrl` / `largeImageUrl` → all set to the single `image` / `cover` koel exposes. Subsonic clients pick whichever size they want; we serve the same URL three times rather than pretending to have distinct sizes
- `musicBrainzId` / `similarArtist` / track-level info — omitted (would require separate API calls or storage koel doesn't keep)

When `Encyclopedia` returns `null` (last.fm / wikipedia integration not configured, or no data found), the response is an empty `artistInfo2` / `albumInfo` envelope rather than a Subsonic error. That's spec-compliant and lets clients gracefully fall back to whatever they show when info is unavailable.

### `getLyricsBySongId` structured shape

OpenSubsonic's `structuredLyrics` shape allows synchronized timing data (timed karaoke-style lyrics). koel only stores plain text, so:

- `displayArtist` / `displayTitle` come from the song's `artist_name` / `title`
- `lang: 'xxx'` (BCP-47 "undetermined") — we don't know what language the lyrics are in
- `offset: 0`, `synced: false` — explicit "not synchronized"
- `line[]` — split on `\r\n|\r|\n`, each as a `value`-keyed entry (the same XML-text-content convention I used for `getGenres`)

Empty lyrics → empty `lyricsList` (not an error).

### `getByGenre` extended with `offset`

koel's `SongRepository::getByGenre(?Genre, int $limit, bool $random, ?User)` already existed for the AI/queue features. Added a fourth `int $offset = 0` parameter (and tightened the loose `$random` to `bool`) so Subsonic's `getSongsByGenre.view` can paginate without a new method. Existing callers (`FetchSongsToQueueByGenreController`, `Ai\Tools\PlaySongsByGenre`) pass three positional args and continue to work.

## Test plan

- [x] `php artisan test --compact tests/Feature/Subsonic/ tests/Feature/KoelPlus/Subsonic/ tests/Unit/Exceptions/ tests/Unit/Services/ tests/Unit/Helpers/` — 226 passed, 739 assertions
- [x] `composer cs` / `composer lint` / `composer analyze` all green
- [ ] Verify from a real Subsonic client: capability check picks up `songLyrics` extension, lyrics display in the player, "download offline" pulls the original file (no transcoding), artist info card populates from last.fm


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Subsonic endpoints for audio downloads (served as attachments), album/artist info v2 (bios and images), structured song lyrics, songs-by-genre with pagination, and OpenSubsonic extensions (songLyrics, transcodeOffset).

* **Tests**
  * Added feature tests covering downloads, album/artist info v2, lyrics, open extensions, and songs-by-genre, including success and error cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2524?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->