### PR TITLE
feat: let users discover and rotate their Subsonic API key

### DIFF
--- a/app/Http/Controllers/API/Me/RegenerateSubsonicApiKeyController.php
+++ b/app/Http/Controllers/API/Me/RegenerateSubsonicApiKeyController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Controllers\API\Me;
+
+use App\Helpers\Uuid;
+use App\Http\Controllers\Controller;
+use App\Http\Resources\UserResource;
+use App\Models\User;
+use Illuminate\Contracts\Auth\Authenticatable;
+
+class RegenerateSubsonicApiKeyController extends Controller
+{
+    /** @param User $user */
+    public function __invoke(Authenticatable $user)
+    {
+        $user->forceFill(['subsonic_api_key' => Uuid::generate()])->saveQuietly();
+
+        return UserResource::make($user->refresh());
+    }
+}

--- a/app/Http/Resources/UserResource.php
+++ b/app/Http/Resources/UserResource.php
@@ -22,6 +22,7 @@ class UserResource extends JsonResource
         'is_admin',
         'role',
         'abilities',
+        'subsonic_api_key',
         'permissions' => [
             'edit',
             'delete',
@@ -56,6 +57,7 @@ class UserResource extends JsonResource
                 ->getPermissionsViaRoles()
                 ->pluck('name')
                 ->toArray()),
+            'subsonic_api_key' => $this->when($isCurrentUser, fn () => $this->user->subsonic_api_key),
             'permissions' => [
                 'edit' => $currentUser->can('update', $this->user),
                 'delete' => $currentUser->can('destroy', $this->user),

--- a/app/Repositories/UserRepository.php
+++ b/app/Repositories/UserRepository.php
@@ -9,6 +9,7 @@ use App\Models\Organization;
 use App\Models\User;
 use App\Values\User\SsoUser;
 use Illuminate\Support\Facades\Hash;
+use SensitiveParameter;
 
 /**
  * @extends Repository<User>
@@ -41,7 +42,7 @@ class UserRepository extends Repository
         return User::query()->firstWhere('email', $email);
     }
 
-    public function findOneBySubsonicApiKey(#[\SensitiveParameter] string $apiKey): ?User
+    public function findOneBySubsonicApiKey(#[SensitiveParameter] string $apiKey): ?User
     {
         return User::query()->firstWhere('subsonic_api_key', $apiKey);
     }

--- a/resources/assets/js/components/profile-preferences/SubsonicCredentials.spec.ts
+++ b/resources/assets/js/components/profile-preferences/SubsonicCredentials.spec.ts
@@ -19,13 +19,24 @@ describe('subsonicCredentials.vue', () => {
     },
   })
 
-  it('renders the current key', async () => {
+  it('renders the key masked by default', async () => {
     h.render(Component)
-    const input = await screen.findByRole<HTMLInputElement>('textbox')
-    expect(input.value).toBe('original-key')
+    const input = await screen.findByDisplayValue<HTMLInputElement>('original-key')
+    expect(input.type).toBe('password')
   })
 
-  it('copies the key to the clipboard', async () => {
+  it('toggles between masked and revealed', async () => {
+    h.render(Component)
+    const input = await screen.findByDisplayValue<HTMLInputElement>('original-key')
+
+    await h.user.click(await screen.findByRole('button', { name: /reveal key/i }))
+    expect(input.type).toBe('text')
+
+    await h.user.click(await screen.findByRole('button', { name: /hide key/i }))
+    expect(input.type).toBe('password')
+  })
+
+  it('copies the key to the clipboard regardless of reveal state', async () => {
     h.mock(MessageToasterStub.value, 'success')
     h.render(Component)
 
@@ -45,8 +56,7 @@ describe('subsonicCredentials.vue', () => {
     h.render(Component)
     await h.user.click(await screen.findByRole('button', { name: /regenerate key/i }))
 
-    const input = await screen.findByRole<HTMLInputElement>('textbox')
-    expect(input.value).toBe('fresh-key')
+    await screen.findByDisplayValue('fresh-key')
   })
 
   it('does not regenerate when the confirm is dismissed', async () => {

--- a/resources/assets/js/components/profile-preferences/SubsonicCredentials.spec.ts
+++ b/resources/assets/js/components/profile-preferences/SubsonicCredentials.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vite-plus/test'
+import { screen } from '@testing-library/vue'
+import { createHarness } from '@/__tests__/TestHarness'
+import { DialogBoxStub, MessageToasterStub } from '@/__tests__/stubs'
+import { userStore } from '@/stores/userStore'
+import { copyText } from '@/utils/helpers'
+import Component from './SubsonicCredentials.vue'
+
+vi.mock('@/utils/helpers', async original => {
+  const mod = await original<typeof import('@/utils/helpers')>()
+  return { ...mod, copyText: vi.fn() }
+})
+
+describe('subsonicCredentials.vue', () => {
+  const h = createHarness({
+    beforeEach: () => {
+      h.actingAsUser()
+      userStore.state.current.subsonic_api_key = 'original-key'
+    },
+  })
+
+  it('renders the current key', async () => {
+    h.render(Component)
+    const input = await screen.findByRole<HTMLInputElement>('textbox')
+    expect(input.value).toBe('original-key')
+  })
+
+  it('copies the key to the clipboard', async () => {
+    h.mock(MessageToasterStub.value, 'success')
+    h.render(Component)
+
+    await h.user.click(await screen.findByRole('button', { name: /copy/i }))
+
+    expect(copyText).toHaveBeenCalledWith('original-key')
+  })
+
+  it('regenerates when confirmed and surfaces the new key', async () => {
+    h.mock(DialogBoxStub.value, 'confirm', true)
+    h.mock(MessageToasterStub.value, 'success')
+    h.mock(userStore, 'regenerateSubsonicApiKey').mockImplementation(async () => {
+      userStore.state.current.subsonic_api_key = 'fresh-key'
+      return 'fresh-key'
+    })
+
+    h.render(Component)
+    await h.user.click(await screen.findByRole('button', { name: /regenerate key/i }))
+
+    const input = await screen.findByRole<HTMLInputElement>('textbox')
+    expect(input.value).toBe('fresh-key')
+  })
+
+  it('does not regenerate when the confirm is dismissed', async () => {
+    h.mock(DialogBoxStub.value, 'confirm', false)
+    const regenMock = h.mock(userStore, 'regenerateSubsonicApiKey')
+
+    h.render(Component)
+    await h.user.click(await screen.findByRole('button', { name: /regenerate key/i }))
+
+    expect(regenMock).not.toHaveBeenCalled()
+  })
+})

--- a/resources/assets/js/components/profile-preferences/SubsonicCredentials.vue
+++ b/resources/assets/js/components/profile-preferences/SubsonicCredentials.vue
@@ -8,29 +8,36 @@
       Configure the client with your email as the username and this key in the API-key or password field.
     </p>
 
-    <div class="mt-4 space-y-2" data-testid="subsonic-credentials">
-      <label class="flex items-stretch gap-2 w-full lg:w-1/2">
-        <TextInput
-          id="subsonicApiKey"
-          :model-value="key"
-          :type="revealed ? 'text' : 'password'"
-          readonly
-          class="flex-1 font-mono"
-          @focus="onFocus"
-        />
-        <Btn
-          variant="ghost"
-          type="button"
-          :title="revealed ? 'Hide key' : 'Reveal key'"
-          @click.prevent="revealed = !revealed"
-        >
-          <EyeOffIcon v-if="revealed" :size="16" />
-          <EyeIcon v-else :size="16" />
-        </Btn>
-        <Btn variant="ghost" type="button" :title="copied ? 'Copied' : 'Copy'" @click.prevent="copyKey">
-          <CopyIcon :size="16" />
-        </Btn>
-      </label>
+    <div
+      class="mt-4 w-full lg:w-1/2 relative text-k-fg-70 flex items-stretch border border-k-fg-10 overflow-hidden rounded-md bg-k-bg-50 focus-within:border-k-highlight transition-[border,background-color] duration-200 ease-in-out"
+      data-testid="subsonic-credentials"
+    >
+      <TextInput
+        id="subsonicApiKey"
+        :model-value="key"
+        :type="revealed ? 'text' : 'password'"
+        readonly
+        aria-label="Subsonic API key"
+        class="flex-1 rounded-none border-0 focus-visible:outline-hidden px-4 font-mono read-only:!bg-transparent read-only:!text-current"
+        @focus="onFocus"
+      />
+      <button
+        type="button"
+        class="px-3 hover:bg-k-fg-5 border-l border-k-fg-10"
+        :title="revealed ? 'Hide key' : 'Reveal key'"
+        @click.prevent="revealed = !revealed"
+      >
+        <EyeOffIcon v-if="revealed" :size="16" />
+        <EyeIcon v-else :size="16" />
+      </button>
+      <button
+        type="button"
+        class="px-3 hover:bg-k-fg-5 border-l border-k-fg-10"
+        :title="copied ? 'Copied' : 'Copy'"
+        @click.prevent="copyKey"
+      >
+        <CopyIcon :size="16" />
+      </button>
     </div>
 
     <div class="mt-4">

--- a/resources/assets/js/components/profile-preferences/SubsonicCredentials.vue
+++ b/resources/assets/js/components/profile-preferences/SubsonicCredentials.vue
@@ -1,0 +1,81 @@
+<template>
+  <section>
+    <h3 class="text-2xl mb-2">Subsonic API Key</h3>
+
+    <p>
+      Use this key to connect Subsonic-compatible clients (Symfonium, Feishin, substreamer, etc.) to your
+      {{ appName }} library. <br />
+      Configure the client with your email as the username and this key in the API-key or password field.
+    </p>
+
+    <div class="mt-4 space-y-2" data-testid="subsonic-credentials">
+      <label class="flex items-stretch gap-2 w-full lg:w-1/2">
+        <TextInput id="subsonicApiKey" :model-value="key" readonly class="flex-1 font-mono" @focus="onFocus" />
+        <Btn variant="ghost" type="button" :title="copied ? 'Copied' : 'Copy'" @click.prevent="copyKey">
+          <CopyIcon :size="16" />
+        </Btn>
+      </label>
+    </div>
+
+    <div class="mt-4">
+      <Btn variant="destructive" type="button" :disabled="regenerating" @click.prevent="regenerate">
+        Regenerate Key
+      </Btn>
+    </div>
+  </section>
+</template>
+
+<script lang="ts" setup>
+import { CopyIcon } from 'lucide-vue-next'
+import { computed, defineAsyncComponent, ref } from 'vue'
+import { userStore } from '@/stores/userStore'
+import { useAuthorization } from '@/composables/useAuthorization'
+import { useBranding } from '@/composables/useBranding'
+import { useDialogBox } from '@/composables/useDialogBox'
+import { useMessageToaster } from '@/composables/useMessageToaster'
+import { copyText } from '@/utils/helpers'
+
+const Btn = defineAsyncComponent(() => import('@/components/ui/form/Btn.vue'))
+const TextInput = defineAsyncComponent(() => import('@/components/ui/form/TextInput.vue'))
+
+const { currentUser } = useAuthorization()
+const { name: appName } = useBranding()
+const { showConfirmDialog } = useDialogBox()
+const { toastSuccess, toastWarning } = useMessageToaster()
+
+const copied = ref(false)
+const regenerating = ref(false)
+
+const key = computed(() => currentUser.value.subsonic_api_key)
+
+const onFocus = (event: FocusEvent) => (event.target as HTMLInputElement).select()
+
+const copyKey = async () => {
+  await copyText(key.value)
+  copied.value = true
+  toastSuccess('Subsonic API key copied to clipboard.')
+  window.setTimeout(() => (copied.value = false), 2000)
+}
+
+const regenerate = async () => {
+  const confirmed = await showConfirmDialog(
+    'Regenerate Subsonic API key? Any client using the old key will stop working until reconfigured.',
+  )
+
+  if (!confirmed) {
+    return
+  }
+
+  regenerating.value = true
+
+  try {
+    await userStore.regenerateSubsonicApiKey()
+    toastSuccess('Subsonic API key regenerated.')
+  } catch (error: unknown) {
+    toastWarning('Failed to regenerate Subsonic API key.')
+    throw error
+  } finally {
+    regenerating.value = false
+  }
+}
+</script>

--- a/resources/assets/js/components/profile-preferences/SubsonicCredentials.vue
+++ b/resources/assets/js/components/profile-preferences/SubsonicCredentials.vue
@@ -50,13 +50,14 @@
 
 <script lang="ts" setup>
 import { CopyIcon, EyeIcon, EyeOffIcon } from 'lucide-vue-next'
-import { computed, defineAsyncComponent, ref } from 'vue'
+import { computed, defineAsyncComponent, onBeforeUnmount, ref } from 'vue'
 import { userStore } from '@/stores/userStore'
 import { useAuthorization } from '@/composables/useAuthorization'
 import { useBranding } from '@/composables/useBranding'
 import { useDialogBox } from '@/composables/useDialogBox'
 import { useMessageToaster } from '@/composables/useMessageToaster'
 import { copyText } from '@/utils/helpers'
+import { logger } from '@/utils/logger'
 
 const Btn = defineAsyncComponent(() => import('@/components/ui/form/Btn.vue'))
 const TextInput = defineAsyncComponent(() => import('@/components/ui/form/TextInput.vue'))
@@ -72,13 +73,27 @@ const revealed = ref(false)
 
 const key = computed(() => currentUser.value.subsonic_api_key)
 
+let copiedResetTimer: ReturnType<typeof window.setTimeout> | null = null
+
+const clearCopiedResetTimer = () => {
+  if (copiedResetTimer !== null) {
+    window.clearTimeout(copiedResetTimer)
+    copiedResetTimer = null
+  }
+}
+
 const onFocus = (event: FocusEvent) => (event.target as HTMLInputElement).select()
 
 const copyKey = async () => {
   await copyText(key.value)
   copied.value = true
   toastSuccess('Subsonic API key copied to clipboard.')
-  window.setTimeout(() => (copied.value = false), 2000)
+
+  clearCopiedResetTimer()
+  copiedResetTimer = window.setTimeout(() => {
+    copied.value = false
+    copiedResetTimer = null
+  }, 2000)
 }
 
 const regenerate = async () => {
@@ -96,10 +111,12 @@ const regenerate = async () => {
     await userStore.regenerateSubsonicApiKey()
     toastSuccess('Subsonic API key regenerated.')
   } catch (error: unknown) {
+    logger.error(error)
     toastWarning('Failed to regenerate Subsonic API key.')
-    throw error
   } finally {
     regenerating.value = false
   }
 }
+
+onBeforeUnmount(clearCopiedResetTimer)
 </script>

--- a/resources/assets/js/components/profile-preferences/SubsonicCredentials.vue
+++ b/resources/assets/js/components/profile-preferences/SubsonicCredentials.vue
@@ -10,7 +10,23 @@
 
     <div class="mt-4 space-y-2" data-testid="subsonic-credentials">
       <label class="flex items-stretch gap-2 w-full lg:w-1/2">
-        <TextInput id="subsonicApiKey" :model-value="key" readonly class="flex-1 font-mono" @focus="onFocus" />
+        <TextInput
+          id="subsonicApiKey"
+          :model-value="key"
+          :type="revealed ? 'text' : 'password'"
+          readonly
+          class="flex-1 font-mono"
+          @focus="onFocus"
+        />
+        <Btn
+          variant="ghost"
+          type="button"
+          :title="revealed ? 'Hide key' : 'Reveal key'"
+          @click.prevent="revealed = !revealed"
+        >
+          <EyeOffIcon v-if="revealed" :size="16" />
+          <EyeIcon v-else :size="16" />
+        </Btn>
         <Btn variant="ghost" type="button" :title="copied ? 'Copied' : 'Copy'" @click.prevent="copyKey">
           <CopyIcon :size="16" />
         </Btn>
@@ -26,7 +42,7 @@
 </template>
 
 <script lang="ts" setup>
-import { CopyIcon } from 'lucide-vue-next'
+import { CopyIcon, EyeIcon, EyeOffIcon } from 'lucide-vue-next'
 import { computed, defineAsyncComponent, ref } from 'vue'
 import { userStore } from '@/stores/userStore'
 import { useAuthorization } from '@/composables/useAuthorization'
@@ -45,6 +61,7 @@ const { toastSuccess, toastWarning } = useMessageToaster()
 
 const copied = ref(false)
 const regenerating = ref(false)
+const revealed = ref(false)
 
 const key = computed(() => currentUser.value.subsonic_api_key)
 

--- a/resources/assets/js/components/profile-preferences/SubsonicCredentials.vue
+++ b/resources/assets/js/components/profile-preferences/SubsonicCredentials.vue
@@ -23,7 +23,7 @@
       />
       <button
         type="button"
-        class="px-3 hover:bg-k-fg-5 border-l border-k-fg-10"
+        class="px-3 hover:bg-k-fg-5"
         :title="revealed ? 'Hide key' : 'Reveal key'"
         @click.prevent="revealed = !revealed"
       >

--- a/resources/assets/js/components/screens/ProfileScreen.vue
+++ b/resources/assets/js/components/screens/ProfileScreen.vue
@@ -37,6 +37,13 @@
         >
           Offline
         </TabButton>
+        <TabButton
+          :selected="currentTab === 'subsonic'"
+          aria-controls="profilePaneSubsonic"
+          @click="currentTab = 'subsonic'"
+        >
+          Subsonic
+        </TabButton>
         <TabButton :selected="currentTab === 'qr'" aria-controls="profilePaneQr" @click="currentTab = 'qr'">
           <QrCodeIcon :size="16" />
         </TabButton>
@@ -71,6 +78,10 @@
           <OfflineStorage />
         </TabPanel>
 
+        <TabPanel v-if="currentTab === 'subsonic'" id="profilePaneSubsonic" aria-labelledby="profilePaneSubsonic">
+          <SubsonicCredentials />
+        </TabPanel>
+
         <TabPanel v-if="currentTab === 'qr'" id="profilePaneQr" aria-labelledby="profilePaneQr">
           <QRLogin />
         </TabPanel>
@@ -98,12 +109,18 @@ const PreferencesForm = defineAsyncComponent(() => import('@/components/profile-
 const ThemeList = defineAsyncComponent(() => import('@/components/profile-preferences/theme/ThemePreferences.vue'))
 const Integrations = defineAsyncComponent(() => import('@/components/profile-preferences/Integrations.vue'))
 const OfflineStorage = defineAsyncComponent(() => import('@/components/profile-preferences/OfflineStorage.vue'))
+const SubsonicCredentials = defineAsyncComponent(
+  () => import('@/components/profile-preferences/SubsonicCredentials.vue'),
+)
 const QRLogin = defineAsyncComponent(() => import('@/components/profile-preferences/QRLogin.vue'))
 
 const { get, set } = useLocalStorage()
 
 const currentTab = ref(
-  get<'profile' | 'preferences' | 'themes' | 'integrations' | 'offline' | 'qr'>('profileScreenTab', 'profile'),
+  get<'profile' | 'preferences' | 'themes' | 'integrations' | 'offline' | 'subsonic' | 'qr'>(
+    'profileScreenTab',
+    'profile',
+  ),
 )
 
 watch(currentTab, tab => set('profileScreenTab', tab))

--- a/resources/assets/js/stores/userStore.ts
+++ b/resources/assets/js/stores/userStore.ts
@@ -76,4 +76,10 @@ export const userStore = {
     this.state.users = differenceBy(this.state.users, [user], 'id')
     this.vault.delete(user.id)
   },
+
+  async regenerateSubsonicApiKey() {
+    const updated = await http.post<CurrentUser>('me/subsonic-api-key/regenerate')
+    this.state.current.subsonic_api_key = updated.subsonic_api_key
+    return updated.subsonic_api_key
+  },
 }

--- a/resources/assets/js/types.d.ts
+++ b/resources/assets/js/types.d.ts
@@ -443,6 +443,11 @@ interface User {
    */
   abilities?: Ability[]
   /**
+   * The user's personal Subsonic API key. Only populated for the current user
+   * (their own /me response); never leaked through user listings.
+   */
+  subsonic_api_key?: string
+  /**
    * What the *current user* (the one making the request) is permitted to do
    * *to this user* — the result of running UserPolicy from their perspective.
    * Distinct from `abilities` above, which is the user's own globally-granted
@@ -457,6 +462,7 @@ interface User {
 type CurrentUser = User & {
   preferences: UserPreferences
   abilities: Ability[]
+  subsonic_api_key: string
 }
 
 interface Settings {

--- a/routes/api.base.php
+++ b/routes/api.base.php
@@ -33,6 +33,7 @@ use App\Http\Controllers\API\GenreController;
 use App\Http\Controllers\API\GetOneTimeTokenController;
 use App\Http\Controllers\API\LambdaSongController as S3SongController;
 use App\Http\Controllers\API\LikeMultipleSongsController;
+use App\Http\Controllers\API\Me\RegenerateSubsonicApiKeyController;
 use App\Http\Controllers\API\MediaBrowser\FetchFolderSongsController;
 use App\Http\Controllers\API\MediaBrowser\FetchRecursiveFolderSongsController;
 use App\Http\Controllers\API\MediaBrowser\FetchSubfoldersController;
@@ -211,6 +212,7 @@ Route::prefix('api')
             Route::patch('me/preferences', UpdateUserPreferenceController::class);
             Route::post('me/equalizer-presets', [EqualizerPresetController::class, 'store']);
             Route::delete('me/equalizer-presets/{id}', [EqualizerPresetController::class, 'destroy']);
+            Route::post('me/subsonic-api-key/regenerate', RegenerateSubsonicApiKeyController::class);
 
             // Last.fm-related routes
             Route::post('lastfm/session-key', SetLastfmSessionKeyController::class);

--- a/tests/Feature/SubsonicApiKeyTest.php
+++ b/tests/Feature/SubsonicApiKeyTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Feature;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+use function Tests\create_admin;
+use function Tests\create_user;
+
+class SubsonicApiKeyTest extends TestCase
+{
+    #[Test]
+    public function meExposesOwnSubsonicApiKey(): void
+    {
+        $user = create_user();
+
+        $this->getAs('api/me', $user)->assertOk()->assertJsonPath('subsonic_api_key', $user->subsonic_api_key);
+    }
+
+    #[Test]
+    public function userListingDoesNotLeakOtherUsersKeys(): void
+    {
+        $admin = create_admin();
+        $other = create_user();
+
+        $this
+            ->getAs('api/users', $admin)
+            ->assertOk()
+            ->assertJsonMissing(['subsonic_api_key' => $other->subsonic_api_key]);
+    }
+
+    #[Test]
+    public function regenerateRotatesAndReturnsNewKey(): void
+    {
+        $user = create_user();
+        $oldKey = $user->subsonic_api_key;
+
+        $response = $this->postAs('api/me/subsonic-api-key/regenerate', [], $user)->assertOk();
+
+        $newKey = $response->json('subsonic_api_key');
+        self::assertNotSame($oldKey, $newKey);
+        self::assertNotEmpty($newKey);
+        self::assertSame($newKey, $user->refresh()->subsonic_api_key);
+    }
+}


### PR DESCRIPTION
## Summary

Non-admin users currently have no way to retrieve their `subsonic_api_key` — the field is hidden on `/api/me`, and the artisan command from Phase 1 requires shell access. This PR closes that gap with a self-serve key panel.

- Expose `subsonic_api_key` on `/api/me` (and only there — the field stays hidden on other users' profiles).
- New endpoint `POST /api/me/subsonic-api-key/regenerate` rotates the current user's key and returns the refreshed `UserResource`.
- New **Subsonic** tab in Profile & Preferences that displays the key, copies it to clipboard, and offers a confirmed regenerate button.

A follow-up PR will extend `SubsonicAuth` to honor the legacy authentication schemes (`u`+`p`, `p=enc:`, `u`+`t`+`s`) against `subsonic_api_key`, so older clients that only support those schemes can connect — see the closing note below.

## Backend

- `UserResource::toArray` — adds `subsonic_api_key` conditionally via `$this->when($isCurrentUser, ...)` so admins listing users never see anyone else's key.
- `RegenerateSubsonicApiKeyController` — single-method invokable controller; generates a fresh UUID, persists with `saveQuietly()` to skip observers, returns `UserResource::make($user->refresh())`.
- New route registered as `me/subsonic-api-key/regenerate` on the authed `me/*` group.

## Frontend

- `subsonic_api_key` added to `User` (optional) and `CurrentUser` (required) types.
- `userStore.regenerateSubsonicApiKey()` posts to the new endpoint and writes the returned key back into `state.current`.
- `SubsonicCredentials.vue` renders the key in a read-only `TextInput` masked by default (`type="password"`), with a reveal toggle (eye icon) for shoulder-surfing / screencast protection. Copy + regenerate actions wired to `useDialogBox` and `useMessageToaster`.
- `ProfileScreen.vue` mounts the new component behind a "Subsonic" tab.

## Tests

- `tests/Feature/SubsonicApiKeyTest.php` — `/api/me` exposes own key, admin user listing does not leak other users' keys, regenerate rotates and returns the new key.
- `SubsonicCredentials.spec.ts` — renders the key masked by default, reveal toggle flips `type` between `password` and `text`, Copy hits the clipboard helper regardless of reveal state, regenerate updates the displayed key on confirm, no-ops on dismissed confirm.

## Follow-up: legacy auth

The Vue panel tells users their key works as either an "API-key or password field". Today, `SubsonicAuth` only accepts `apiKey=`, so a client that authenticates via `u`+`p` or `u`+`t`+`s` (the recommended scheme from Subsonic API 1.13.0+, used by most existing clients) will be rejected even with a valid key. A follow-up PR will:

- Accept `p=<key>` and `p=enc:<hex>` by string-equaling against `subsonic_api_key`.
- Accept `u`+`t`+`s` by recomputing `md5($user->subsonic_api_key . $salt)` and comparing with `hash_equals`.
- Look up the user by `u` via `findOneByEmail`.

Same one key, every scheme.

## Test plan

- [ ] Visit Profile & Preferences → Subsonic tab; verify the key renders masked, the eye toggle reveals/hides it, Copy fires a toast, Regenerate prompts confirm and updates the displayed key.
- [ ] Configure a client that supports the OpenSubsonic `apiKey` extension (Symfonium current, Feishin) with email + key; verify it connects and lists songs.
- [ ] Confirm a non-admin user can rotate their own key but cannot see anyone else's via admin user listing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subsonic tab on profile showing your Subsonic API key with masked/unmasked toggle, select-on-focus, copy-to-clipboard, and regenerate action with confirmation, progress state, and success/error toasts; key refreshes in the UI.

* **Privacy**
  * Subsonic API keys are only exposed to the current user and are not included in user listings.

* **Tests**
  * Tests added for viewing, copying, non-leakage in listings, and regeneration behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2525?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->