### PR TITLE
feat: accept legacy Subsonic auth schemes against the API key

### DIFF
--- a/app/Http/Middleware/SubsonicAuth.php
+++ b/app/Http/Middleware/SubsonicAuth.php
@@ -3,12 +3,14 @@
 namespace App\Http\Middleware;
 
 use App\Http\Responses\Subsonic\SubsonicResponse;
+use App\Models\User;
 use App\Repositories\UserRepository;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Symfony\Component\HttpFoundation\Response;
 
+// @mago-ignore lint:cyclomatic-complexity
 class SubsonicAuth
 {
     public function __construct(
@@ -17,20 +19,110 @@ class SubsonicAuth
 
     public function handle(Request $request, Closure $next): Response
     {
-        $apiKey = $request->input('apiKey');
+        $attempts = [
+            fn (): User|Response|null => $this->authenticateViaApiKey($request),
+            fn (): User|Response|null => $this->authenticateViaToken($request),
+            fn (): User|Response|null => $this->authenticateViaPassword($request),
+        ];
 
-        if (!$apiKey) {
-            return SubsonicResponse::error(10, 'Required parameter is missing.')->toResponse($request);
+        foreach ($attempts as $attempt) {
+            $result = $attempt();
+
+            if ($result instanceof User) {
+                Auth::setUser($result);
+
+                return $next($request);
+            }
+
+            if ($result instanceof Response) {
+                return $result;
+            }
         }
 
-        $user = $this->userRepository->findOneBySubsonicApiKey($apiKey);
+        return self::missingParameter($request);
+    }
+
+    private function authenticateViaApiKey(Request $request): User|Response|null
+    {
+        $apiKey = self::stringInput($request, 'apiKey');
+
+        if ($apiKey === '') {
+            return null;
+        }
+
+        return $this->userRepository->findOneBySubsonicApiKey($apiKey) ?? self::wrongCredentials($request);
+    }
+
+    private function authenticateViaToken(Request $request): User|Response|null
+    {
+        $username = self::stringInput($request, 'u');
+        $token = self::stringInput($request, 't');
+
+        if ($username === '' || $token === '') {
+            return null;
+        }
+
+        $salt = self::stringInput($request, 's');
+
+        if ($salt === '') {
+            return self::missingParameter($request);
+        }
+
+        $user = $this->userRepository->findOneByEmail($username);
 
         if (!$user) {
-            return SubsonicResponse::error(40, 'Wrong username or password.')->toResponse($request);
+            return self::wrongCredentials($request);
         }
 
-        Auth::setUser($user);
+        $expected = md5($user->subsonic_api_key . $salt);
 
-        return $next($request);
+        return hash_equals($expected, strtolower($token)) ? $user : self::wrongCredentials($request);
+    }
+
+    private function authenticateViaPassword(Request $request): User|Response|null
+    {
+        $username = self::stringInput($request, 'u');
+        $password = self::stringInput($request, 'p');
+
+        if ($username === '' || $password === '') {
+            return null;
+        }
+
+        $candidate = $password;
+
+        if (str_starts_with($candidate, 'enc:')) {
+            $hex = substr($candidate, 4);
+
+            if ($hex === '' || (strlen($hex) % 2) !== 0 || !ctype_xdigit($hex)) {
+                return self::wrongCredentials($request);
+            }
+
+            $candidate = hex2bin($hex);
+        }
+
+        $user = $this->userRepository->findOneByEmail($username);
+
+        if (!$user) {
+            return self::wrongCredentials($request);
+        }
+
+        return hash_equals($user->subsonic_api_key, $candidate) ? $user : self::wrongCredentials($request);
+    }
+
+    private static function stringInput(Request $request, string $key): string
+    {
+        $value = $request->input($key);
+
+        return is_string($value) ? $value : '';
+    }
+
+    private static function missingParameter(Request $request): Response
+    {
+        return SubsonicResponse::error(10, 'Required parameter is missing.')->toResponse($request);
+    }
+
+    private static function wrongCredentials(Request $request): Response
+    {
+        return SubsonicResponse::error(40, 'Wrong username or password.')->toResponse($request);
     }
 }

--- a/tests/Feature/Subsonic/LegacyAuthTest.php
+++ b/tests/Feature/Subsonic/LegacyAuthTest.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace Tests\Feature\Subsonic;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+use function Tests\create_user;
+
+class LegacyAuthTest extends TestCase
+{
+    #[Test]
+    public function clearTextPasswordWithEmailUsernameSucceeds(): void
+    {
+        $user = create_user();
+
+        $this
+            ->getJson(sprintf('/rest/ping.view?u=%s&p=%s&f=json', urlencode($user->email), $user->subsonic_api_key))
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.status', 'ok');
+    }
+
+    #[Test]
+    public function clearTextPasswordWithWrongKeyIsRejected(): void
+    {
+        $user = create_user();
+
+        $this
+            ->getJson(sprintf('/rest/ping.view?u=%s&p=not-the-real-key&f=json', urlencode($user->email)))
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.error.code', 40);
+    }
+
+    #[Test]
+    public function hexEncodedPasswordSucceeds(): void
+    {
+        $user = create_user();
+
+        $this
+            ->getJson(sprintf(
+                '/rest/ping.view?u=%s&p=enc:%s&f=json',
+                urlencode($user->email),
+                bin2hex($user->subsonic_api_key),
+            ))
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.status', 'ok');
+    }
+
+    #[Test]
+    public function hexEncodedPasswordWithInvalidHexIsRejected(): void
+    {
+        $user = create_user();
+
+        $this
+            ->getJson(sprintf('/rest/ping.view?u=%s&p=enc:nothex&f=json', urlencode($user->email)))
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.error.code', 40);
+    }
+
+    #[Test]
+    public function hexEncodedPasswordWithWrongKeyIsRejected(): void
+    {
+        $user = create_user();
+
+        $this
+            ->getJson(sprintf(
+                '/rest/ping.view?u=%s&p=enc:%s&f=json',
+                urlencode($user->email),
+                bin2hex('not-the-real-key'),
+            ))
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.error.code', 40);
+    }
+
+    #[Test]
+    public function saltedTokenSucceeds(): void
+    {
+        $user = create_user();
+        $salt = 'c19b2d';
+        $token = md5($user->subsonic_api_key . $salt);
+
+        $this
+            ->getJson(sprintf('/rest/ping.view?u=%s&t=%s&s=%s&f=json', urlencode($user->email), $token, $salt))
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.status', 'ok');
+    }
+
+    #[Test]
+    public function saltedTokenAcceptsUppercaseHexFromClient(): void
+    {
+        $user = create_user();
+        $salt = 'C19B2D';
+        $token = strtoupper(md5($user->subsonic_api_key . $salt));
+
+        $this
+            ->getJson(sprintf('/rest/ping.view?u=%s&t=%s&s=%s&f=json', urlencode($user->email), $token, $salt))
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.status', 'ok');
+    }
+
+    #[Test]
+    public function saltedTokenWithWrongHashIsRejected(): void
+    {
+        $user = create_user();
+
+        $this
+            ->getJson(sprintf(
+                '/rest/ping.view?u=%s&t=%s&s=%s&f=json',
+                urlencode($user->email),
+                md5('wrong-key.c19b2d'),
+                'c19b2d',
+            ))
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.error.code', 40);
+    }
+
+    #[Test]
+    public function tokenWithoutSaltIsRejectedAsMissingParameter(): void
+    {
+        $user = create_user();
+
+        $this
+            ->getJson(sprintf(
+                '/rest/ping.view?u=%s&t=%s&f=json',
+                urlencode($user->email),
+                md5($user->subsonic_api_key . 'irrelevant'),
+            ))
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.error.code', 10);
+    }
+
+    #[Test]
+    public function unknownUsernameIsRejected(): void
+    {
+        create_user();
+
+        $this
+            ->getJson('/rest/ping.view?u=ghost@example.com&p=anything&f=json')
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.error.code', 40);
+    }
+
+    #[Test]
+    public function missingUsernameIsRejectedAsMissingParameter(): void
+    {
+        $this
+            ->getJson('/rest/ping.view?p=anything&f=json')
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.error.code', 10);
+    }
+
+    #[Test]
+    public function usernameWithoutAnyCredentialIsRejectedAsMissingParameter(): void
+    {
+        $user = create_user();
+
+        $this
+            ->getJson(sprintf('/rest/ping.view?u=%s&f=json', urlencode($user->email)))
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.error.code', 10);
+    }
+
+    #[Test]
+    public function apiKeyTakesPrecedenceOverLegacyCredentials(): void
+    {
+        $user = create_user();
+
+        $this
+            ->getJson(sprintf(
+                '/rest/ping.view?apiKey=%s&u=ghost@example.com&p=anything&f=json',
+                $user->subsonic_api_key,
+            ))
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.status', 'ok');
+    }
+
+    #[Test]
+    public function tokenTakesPrecedenceOverPasswordWhenBothPresent(): void
+    {
+        $user = create_user();
+        $salt = 'c19b2d';
+        $token = md5($user->subsonic_api_key . $salt);
+
+        $this
+            ->getJson(sprintf(
+                '/rest/ping.view?u=%s&t=%s&s=%s&p=wrong-but-ignored&f=json',
+                urlencode($user->email),
+                $token,
+                $salt,
+            ))
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.status', 'ok');
+    }
+}


### PR DESCRIPTION
## Summary

Phase 9's Profile panel tells users their Subsonic API key works as either an "API-key or password field." Until now, `SubsonicAuth` only honored the OpenSubsonic `apiKey=` query parameter (≥1.16.1), so a client authenticating via the recommended salted-token scheme (`u`+`t`+`s`, Subsonic API ≥1.13.0) or the legacy clear-text/`enc:`-hex password (`u`+`p`) was rejected with code 40 even with a valid key.

This PR teaches the middleware all four schemes, using `subsonic_api_key` as the single secret in every case. One key in the user's profile now works with every Subsonic-compatible client — Symfonium, Feishin, substreamer, Sonixd, DSub, play:Sub, Ultrasonic, etc.

## Behavior

`SubsonicAuth::handle()` dispatches lazily through three per-scheme methods in this fixed precedence:

1. **`authenticateViaApiKey`** — unchanged. Empty `apiKey=` → scheme skipped; unknown key → code 40.
2. **`authenticateViaToken`** — `u` + `t` + `s`. Spec computes `t = md5(password + salt)`; koel substitutes the API key for password. Server-side: `hash_equals(md5($user->subsonic_api_key . $salt), strtolower($t))`. The lower-case normalization lets clients that uppercase-emit MD5 hex still authenticate. Missing `s` while `t` is present → code 10; unknown user → code 40.
3. **`authenticateViaPassword`** — `u` + `p`. `enc:HEX` prefix triggers hex validation (non-empty, even length, `ctype_xdigit`) before `hex2bin`, so malformed hex shorts to code 40 without emitting a PHP warning. Clear-text `p` compares directly via `hash_equals`.

Each `authenticateVia*` returns `User|Response|null`:
- `User` → success, middleware sets `Auth::setUser($user)` and continues.
- `Response` → explicit rejection (the right Subsonic error code already shaped).
- `null` → scheme not attempted, try the next.

If all three return null, the middleware emits code 10 (missing parameter) — the catch-all when the client supplied no recognizable credentials.

## Why `subsonic_api_key` is the universal secret

Subsonic's token scheme requires the server to know the plaintext password. koel stores only bcrypt hashes for login passwords, so reconstructing `password` is impossible. Navidrome/Airsonic/Gonic solve this by keeping a separate plaintext "subsonic password" per user. koel takes a smaller-surface approach: the `subsonic_api_key` (UUID, 128 bits of entropy) **is** the user's Subsonic credential. One key, one rotation, four schemes.

This also makes the Phase 9 panel's UI copy honest — "Configure the client with your email as the username and this key in the API-key or password field" now matches behavior end-to-end.

## Tests

`tests/Feature/Subsonic/LegacyAuthTest.php` (14 tests):

- Clear-text password: success + wrong key.
- Hex-encoded `enc:`: success + invalid-hex + wrong key.
- Salted token: success + uppercase-hex tolerance + wrong-hash + missing-salt.
- Identity errors: unknown username, missing username, username-without-credential.
- Precedence: `apiKey` > legacy when both present, token > password when both present.

The precedence tests are load-bearing — they pin the documented ordering so a future refactor that swaps the dispatch array would visibly break them. Existing `PingTest` (apiKey-scheme) and the full Subsonic feature sweep (105 tests) still pass.

## Implementation notes

- The class carries `// @mago-ignore lint:cyclomatic-complexity`, matching `SongRepository`'s precedent. Each scheme method is shallow on its own; the class-level metric trips only because there are three of them. Splitting into per-scheme classes would be over-engineering for one middleware.
- The three pure helpers (`stringInput`, `missingParameter`, `wrongCredentials`) are `private static`, matching the convention `ChecksControllerAttributes` uses. They have no `$this` access and no mockable behavior, so the DI-service carve-out for instance methods doesn't apply.
- No salt-length enforcement (spec says ≥6 chars). The salt's job for a 128-bit UUID is replay prevention, not password strengthening; rejecting a 5-char salt would break a perfectly-secure client without buying anything.
- No timing-safe username comparison — usernames are emails, publicly discoverable. `hash_equals` is reserved for the secret comparisons.

## Test plan

- [ ] Configure a client supporting only the legacy token scheme (DSub, Sonixd, older Symfonium builds) with email as username and the API key as the password; verify it connects and lists songs.
- [ ] Same with an OpenSubsonic-aware client that prefers `apiKey=` (Feishin, current Symfonium); verify it still works unchanged.
- [ ] Configure a client using clear-text `u`+`p` (Ultrasonic, play:Sub); verify auth succeeds.
- [ ] Rotate the key from the Profile → Subsonic panel; confirm the next request from any client using the previous key fails immediately (no session to invalidate).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subsonic API now supports multiple authentication methods: API key, token-based (with salt validation), and password authentication (plaintext and hex-encoded formats).
  * Proper authentication precedence handling when multiple credential types are provided.

* **Tests**
  * Added comprehensive test coverage for legacy authentication scenarios and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koel/koel/pull/2526?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->