### PR TITLE
fix: silent OOM on Searchable save with TNT driver on Laravel 13

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -10708,16 +10708,16 @@
         },
         {
             "name": "teamtnt/laravel-scout-tntsearch-driver",
-            "version": "v15.1.0",
+            "version": "v15.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phanan-forks/laravel-scout-tntsearch-driver.git",
-                "reference": "9d9d11593533f8b4edc90894f3afedf337feb73c"
+                "reference": "e086eae67c5af9a9e7f5e6235df4f6eb06dd6ace"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phanan-forks/laravel-scout-tntsearch-driver/zipball/9d9d11593533f8b4edc90894f3afedf337feb73c",
-                "reference": "9d9d11593533f8b4edc90894f3afedf337feb73c",
+                "url": "https://api.github.com/repos/phanan-forks/laravel-scout-tntsearch-driver/zipball/e086eae67c5af9a9e7f5e6235df4f6eb06dd6ace",
+                "reference": "e086eae67c5af9a9e7f5e6235df4f6eb06dd6ace",
                 "shasum": ""
             },
             "require": {
@@ -10776,7 +10776,7 @@
                 "tntsearch"
             ],
             "support": {
-                "source": "https://github.com/phanan-forks/laravel-scout-tntsearch-driver/tree/v15.1.0"
+                "source": "https://github.com/phanan-forks/laravel-scout-tntsearch-driver/tree/v15.1.1"
             },
             "funding": [
                 {
@@ -10784,7 +10784,7 @@
                     "url": "https://github.com/teamtnt"
                 }
             ],
-            "time": "2026-03-24T13:08:08+00:00"
+            "time": "2026-05-28T23:49:35+00:00"
         },
         {
             "name": "teamtnt/tntsearch",


### PR DESCRIPTION
## Summary

Hotfix for the silent OOM that lands on **every save of a Searchable model** (playlist creation, song re-indexing, etc.) on koel since the Laravel 13 upgrade in #2501. Reported externally as silent 500s with empty response bodies, no log entries, and the OS killing the PHP process.

Bumps `teamtnt/laravel-scout-tntsearch-driver` from `v15.1.0` → `v15.1.1` to pick up the rebind fix.

## Root cause

Laravel 13 added `Illuminate\Support\RebindsCallbacksToSelf`. `Manager::extend` now rebinds the closure's `$this` AND its scope to the Manager via `Closure::bind($this, static::class)`.

The TNT scout driver's `TNTSearchScoutServiceProvider::boot()` registers an extend closure that does `$this->setFuzziness($tnt)` and `$this->setAsYouType($tnt)`. After the rebind:

- `$this` inside the closure is the `EngineManager`, not the service provider.
- `EngineManager` has no such methods.
- PHP routes the call through `Illuminate\Support\Manager::__call`, which proxies any unknown method to `$this->driver()->$method(...)`.
- `$this->driver()` resolves the default driver — `tntsearch` for anyone affected.
- That re-invokes this same extend closure. Infinite recursion. Each iteration allocates a fresh `TNTSearch` instance plus the config-resolution intermediates (~6 KB), never unwinds, exhausts memory.

The reason it manifests as a silent 500 with no log line is that the OS kills the process by OOM before PHP shutdown handlers fire. Bumping `memory_limit` just moves the wall further out; PHP's fatal-error line is somewhere arbitrary in the TNT init code, not at the actual loop site.

## Upstream

Fix submitted to the package: https://github.com/teamtnt/laravel-scout-tntsearch-driver/pull/387 (addresses #384).

While that PR is in review, this koel hotfix points `composer.lock` at the same commit on `phanan-forks/laravel-scout-tntsearch-driver` (the fork koel already uses for Scout-11 compat). When upstream merges and tags, the fork pin can come out in a follow-up.

## Verification

Repro (any Laravel 13 + `SCOUT_DRIVER=tntsearch` koel install):

```bash
curl 'http://localhost:8000/rest/createPlaylist.view?apiKey=<key>&f=json&name=test'
```

- **Before**: HTTP 500, empty body, no log entry.
- **After**: HTTP 200, valid Subsonic response with the new playlist id. Process memory delta ~3 MB.

The koel web UI's playlist-create flow is also fixed by the same change — the Subsonic endpoint just happened to be the path I exercised first.

## Scope

This PR is intentionally **just the composer.lock bump** — no other changes. It's a hotfix candidate for a patch release. The broader Subsonic API improvements I had in flight (#2527) stay separate; they will rebase on master after this lands.

## Test plan

- [ ] Create a playlist from the koel web UI — succeeds with a confirmation, playlist appears in sidebar.
- [ ] Run `php artisan scout:import "App\Models\Song"` (re-index from CLI) — completes without OOM.
- [ ] Existing test suite stays green.
