### PR TITLE
fix: use heart icon consistently for favorite affordances

### DIFF
--- a/docs/usage/subsonic.md
+++ b/docs/usage/subsonic.md
@@ -14,7 +14,7 @@ Koel speaks the [Subsonic / OpenSubsonic API](https://opensubsonic.netlify.app/)
 2. Switch to the **Subsonic** tab.
 3. Reveal or copy the key.
 
-The key is created for you the first time you open this tab and stays the same until you regenerate it.
+Your Subsonic API key was generated automatically when your account was created. It stays the same until you regenerate it.
 
 ## Connect a Client
 

--- a/resources/assets/js/components/layout/main-wrapper/sidebar/PlaylistSidebarItem.vue
+++ b/resources/assets/js/components/layout/main-wrapper/sidebar/PlaylistSidebarItem.vue
@@ -15,7 +15,7 @@
   >
     <template #icon>
       <Icon v-if="isRecentlyPlayedList(list)" :icon="faClockRotateLeft" fixed-width />
-      <Icon v-else-if="isFavoriteList(list)" :icon="faStar" fixed-width />
+      <Icon v-else-if="isFavoriteList(list)" :icon="faHeart" fixed-width />
       <Icon v-else-if="list.is_smart" :icon="faWandMagicSparkles" fixed-width />
       <Icon v-else-if="list.is_collaborative" :icon="faUsers" fixed-width />
       <ListMusicIcon v-else :size="16" />
@@ -25,7 +25,7 @@
 </template>
 
 <script lang="ts" setup>
-import { faClockRotateLeft, faStar, faUsers, faWandMagicSparkles } from '@fortawesome/free-solid-svg-icons'
+import { faClockRotateLeft, faHeart, faUsers, faWandMagicSparkles } from '@fortawesome/free-solid-svg-icons'
 import isMobile from 'ismobilejs'
 import { ListMusicIcon } from 'lucide-vue-next'
 import { computed, ref, toRefs } from 'vue'

--- a/resources/assets/js/components/playable/PlayableContextMenu.vue
+++ b/resources/assets/js/components/playable/PlayableContextMenu.vue
@@ -81,7 +81,6 @@
       >
         <StarRating :rating="playables[0].rating" @rate="rate(playables[0] as Song, $event)" />
       </li>
-      <Separator />
     </template>
 
     <template v-if="isQueueScreen">

--- a/resources/assets/js/components/screens/AlbumListScreen.vue
+++ b/resources/assets/js/components/screens/AlbumListScreen.vue
@@ -13,8 +13,8 @@
               @click.prevent="toggleFavoritesOnly"
             >
               <Icon
-                :icon="preferences.albums_favorites_only ? faStar : faEmptyStar"
-                :class="preferences.albums_favorites_only && 'text-k-highlight'"
+                :icon="preferences.albums_favorites_only ? faHeart : faEmptyHeart"
+                :class="preferences.albums_favorites_only && 'text-k-love'"
               />
             </Btn>
 
@@ -80,8 +80,8 @@
 </template>
 
 <script lang="ts" setup>
-import { faStar as faEmptyStar } from '@fortawesome/free-regular-svg-icons'
-import { faCompactDisc, faStar } from '@fortawesome/free-solid-svg-icons'
+import { faHeart as faEmptyHeart } from '@fortawesome/free-regular-svg-icons'
+import { faCompactDisc, faHeart } from '@fortawesome/free-solid-svg-icons'
 import { computed, nextTick, onMounted, ref, toRef } from 'vue'
 import { albumStore } from '@/stores/albumStore'
 import { commonStore } from '@/stores/commonStore'

--- a/resources/assets/js/components/screens/ArtistListScreen.vue
+++ b/resources/assets/js/components/screens/ArtistListScreen.vue
@@ -13,8 +13,8 @@
               @click.prevent="toggleFavoritesOnly"
             >
               <Icon
-                :icon="preferences.artists_favorites_only ? faStar : faEmptyStar"
-                :class="preferences.artists_favorites_only && 'text-k-highlight'"
+                :icon="preferences.artists_favorites_only ? faHeart : faEmptyHeart"
+                :class="preferences.artists_favorites_only && 'text-k-love'"
               />
             </Btn>
 
@@ -76,8 +76,8 @@
 </template>
 
 <script lang="ts" setup>
-import { faMicrophoneSlash, faStar } from '@fortawesome/free-solid-svg-icons'
-import { faStar as faEmptyStar } from '@fortawesome/free-regular-svg-icons'
+import { faMicrophoneSlash, faHeart } from '@fortawesome/free-solid-svg-icons'
+import { faHeart as faEmptyHeart } from '@fortawesome/free-regular-svg-icons'
 import { computed, nextTick, onMounted, ref, toRef } from 'vue'
 import { artistStore } from '@/stores/artistStore'
 import { commonStore } from '@/stores/commonStore'

--- a/resources/assets/js/components/screens/FavoritesScreen.vue
+++ b/resources/assets/js/components/screens/FavoritesScreen.vue
@@ -57,7 +57,7 @@
       No favorites yet.
       <span class="secondary block">
         Click the&nbsp;
-        <Icon :icon="faStar" />&nbsp; icon to mark a song as favorite.
+        <Icon :icon="faHeart" />&nbsp; icon to mark a song as favorite.
       </span>
     </ScreenEmptyState>
   </ScreenBase>
@@ -65,7 +65,7 @@
 
 <script lang="ts" setup>
 import { faHeartBroken } from '@fortawesome/free-solid-svg-icons'
-import { faStar } from '@fortawesome/free-regular-svg-icons'
+import { faHeart } from '@fortawesome/free-regular-svg-icons'
 import { computed, ref } from 'vue'
 import { pluralize } from '@/utils/formatters'
 import { playableStore } from '@/stores/playableStore'

--- a/resources/assets/js/components/screens/PodcastListScreen.vue
+++ b/resources/assets/js/components/screens/PodcastListScreen.vue
@@ -14,8 +14,8 @@
               @click.prevent="toggleFavoritesOnly"
             >
               <Icon
-                :icon="preferences.podcasts_favorites_only ? faStar : faEmptyStar"
-                :class="preferences.podcasts_favorites_only && 'text-k-highlight'"
+                :icon="preferences.podcasts_favorites_only ? faHeart : faEmptyHeart"
+                :class="preferences.podcasts_favorites_only && 'text-k-love'"
                 size="sm"
               />
             </Btn>
@@ -60,8 +60,8 @@
 </template>
 
 <script setup lang="ts">
-import { faAdd, faPodcast, faStar } from '@fortawesome/free-solid-svg-icons'
-import { faStar as faEmptyStar } from '@fortawesome/free-regular-svg-icons'
+import { faAdd, faPodcast, faHeart } from '@fortawesome/free-solid-svg-icons'
+import { faHeart as faEmptyHeart } from '@fortawesome/free-regular-svg-icons'
 import { orderBy } from 'lodash-es'
 import { computed, onMounted, provide, ref } from 'vue'
 import { podcastStore } from '@/stores/podcastStore'

--- a/resources/assets/js/components/screens/RadioStationListScreen.vue
+++ b/resources/assets/js/components/screens/RadioStationListScreen.vue
@@ -15,8 +15,8 @@
               @click.prevent="toggleFavoritesOnly"
             >
               <Icon
-                :icon="preferences.radio_stations_favorites_only ? faStar : faEmptyStar"
-                :class="preferences.radio_stations_favorites_only && 'text-k-highlight'"
+                :icon="preferences.radio_stations_favorites_only ? faHeart : faEmptyHeart"
+                :class="preferences.radio_stations_favorites_only && 'text-k-love'"
                 size="sm"
               />
             </Btn>
@@ -73,9 +73,9 @@
 </template>
 
 <script setup lang="ts">
-import { faAdd, faStar } from '@fortawesome/free-solid-svg-icons'
+import { faAdd, faHeart } from '@fortawesome/free-solid-svg-icons'
 import { RadioIcon } from 'lucide-vue-next'
-import { faStar as faEmptyStar } from '@fortawesome/free-regular-svg-icons'
+import { faHeart as faEmptyHeart } from '@fortawesome/free-regular-svg-icons'
 
 import { computed, onMounted, provide, ref } from 'vue'
 import { preferenceStore as preferences } from '@/stores/preferenceStore'

--- a/resources/assets/js/remote/components/RemoteFooter.vue
+++ b/resources/assets/js/remote/components/RemoteFooter.vue
@@ -1,11 +1,11 @@
 <template>
   <footer class="h-[18vh] w-screen flex justify-around items-center border-t border-solid border-t-k-fg-10 py-4">
     <button
-      class="text-[5vmin] has-[.yep]:text-k-fg-70"
+      class="text-[5vmin] has-[.yep]:text-k-love"
       data-testid="btn-toggle-favorite"
       @click.prevent="toggleFavorite"
     >
-      <Icon :class="streamable.favorite && 'yep'" :icon="streamable.favorite ? faStar : faEmptyStar" />
+      <Icon :class="streamable.favorite && 'yep'" :icon="streamable.favorite ? faHeart : faEmptyHeart" />
     </button>
 
     <button
@@ -39,8 +39,8 @@
 </template>
 
 <script lang="ts" setup>
-import { faPause, faPlay, faStar, faStepBackward, faStepForward } from '@fortawesome/free-solid-svg-icons'
-import { faStar as faEmptyStar } from '@fortawesome/free-regular-svg-icons'
+import { faHeart, faPause, faPlay, faStepBackward, faStepForward } from '@fortawesome/free-solid-svg-icons'
+import { faHeart as faEmptyHeart } from '@fortawesome/free-regular-svg-icons'
 import { computed, toRefs } from 'vue'
 import { socketService } from '@/services/socketService'
 import { isRadioStation } from '@/utils/typeGuards'


### PR DESCRIPTION
## Summary

Follow-up to #2536. Sweeps the rest of the codebase so every "favorite" affordance is a heart in `text-k-love`, not a star — and corrects a misleading line in the Subsonic docs while in the neighborhood.

### Icon swap
Every remaining `faStar` / `faEmptyStar` tied to favorites becomes `faHeart` / `faEmptyHeart`:

* **Favorites-only filter buttons** on `AlbumListScreen`, `ArtistListScreen`, `PodcastListScreen`, `RadioStationListScreen` — active state now `text-k-love` instead of `text-k-highlight`.
* **Sidebar Favorites entry** (`PlaylistSidebarItem.vue`).
* **Favorites screen empty-state hint** — the "Click the [icon] to mark a song as favorite" line.
* **Remote control footer** (`RemoteFooter.vue`) — favorite toggle plus its `.yep` active class.

`StarRating.vue` is intentionally untouched — those are actual stars (the rating widget from #2536).

### Context menu cleanup
Removed a trailing `<Separator />` after the rating row in `PlayableContextMenu.vue` that was producing a double separator with the next section's leading separator.

### Doc fix
`docs/usage/subsonic.md` claimed the Subsonic API key is generated the first time you open the Subsonic tab. Not true — `app/Observers/UserObserver.php::creating` assigns it the moment the user account is created. Reworded to match implementation.

## Test plan

- [ ] Heart icon shows in `text-k-love` red/pink when the favorites-only filter is on (and outline-only when off) across Albums, Artists, Podcasts, Radio Stations screens.
- [ ] Sidebar Favorites entry shows a heart.
- [ ] Favorites screen empty-state shows a heart in the instruction copy.
- [ ] Remote control footer favorite button is a heart, turns pink when the current track is favorited.
- [ ] Right-clicking a song in a list shows exactly one separator between Add To Playlist and the rating row.
- [ ] StarRating widget still uses literal stars (no change).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Subsonic API key generation timing in documentation.

* **Style**
  * Updated favorite icons from stars to hearts across multiple screens (albums, artists, podcasts, radio stations, and favorites list).
  * Refined context menu layout by removing an unnecessary separator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->