### PR TITLE
fix: normalize legacy 'list' view mode for albums and artists

### DIFF
--- a/app/Values/User/Preferences/AlbumsViewModePreference.php
+++ b/app/Values/User/Preferences/AlbumsViewModePreference.php
@@ -18,6 +18,10 @@ class AlbumsViewModePreference extends Preference
 
     protected function cast(mixed $value): mixed
     {
-        return $value === 'thumbnails' ? 'grid' : $value;
+        return match ($value) {
+            'thumbnails' => 'grid',
+            'list' => 'table',
+            default => $value,
+        };
     }
 }

--- a/app/Values/User/Preferences/ArtistsViewModePreference.php
+++ b/app/Values/User/Preferences/ArtistsViewModePreference.php
@@ -18,6 +18,10 @@ class ArtistsViewModePreference extends Preference
 
     protected function cast(mixed $value): mixed
     {
-        return $value === 'thumbnails' ? 'grid' : $value;
+        return match ($value) {
+            'thumbnails' => 'grid',
+            'list' => 'table',
+            default => $value,
+        };
     }
 }

--- a/tests/Unit/Values/User/Preferences/PreferenceBehaviorTest.php
+++ b/tests/Unit/Values/User/Preferences/PreferenceBehaviorTest.php
@@ -54,9 +54,10 @@ class PreferenceBehaviorTest extends TestCase
     }
 
     #[Test]
-    public function albumsViewModeNormalizesLegacyThumbnailsToGrid(): void
+    public function albumsViewModeNormalizesLegacyValues(): void
     {
         self::assertSame('grid', AlbumsViewModePreference::make('thumbnails')->getValue());
+        self::assertSame('table', AlbumsViewModePreference::make('list')->getValue());
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

Hotfix for #2541. That PR tightened `AlbumsViewModePreference` and `ArtistsViewModePreference` to `['grid', 'table']` and normalized the old `'thumbnails'` default to `'grid'`. But existing users whose stored preference was `'list'` (the previous list-layout option that the album/artist screens no longer offer) now hit a hard assertion error every time their preferences load:

> `Expected one of: "grid", "table". Got: "list"`

This extends the `cast()` on both preferences to also map `'list'` → `'table'`. `'table'` is the semantic successor — both are vertical, record-style layouts, and it's what the screens render today instead of the old list mode.

## Test plan

- [ ] An existing user row with `albums_view_mode = 'list'` (or `artists_view_mode = 'list'`) loads without throwing, with the value normalized to `'table'`.
- [ ] `php artisan test tests/Unit/Values/User/Preferences/PreferenceBehaviorTest.php tests/Integration/Casts/UserPreferencesCastTest.php` is green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed handling of legacy view mode preferences for albums and artists. Saved preferences for "list" view mode now correctly convert to "table" view, and "thumbnails" mode converts to "grid" view, ensuring users' view preferences display as intended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->