### PR TITLE
feat: table view mode for radio stations

### DIFF
--- a/app/Values/User/Preferences/RadioStationsViewModePreference.php
+++ b/app/Values/User/Preferences/RadioStationsViewModePreference.php
@@ -8,11 +8,20 @@ class RadioStationsViewModePreference extends Preference
 {
     public function getDefaultValue(): string
     {
-        return 'thumbnails';
+        return 'grid';
     }
 
     public function assert(): void
     {
-        Assert::oneOf($this->value, ['list', 'thumbnails']);
+        Assert::oneOf($this->value, ['grid', 'table']);
+    }
+
+    protected function cast(mixed $value): mixed
+    {
+        return match ($value) {
+            'thumbnails' => 'grid',
+            'list' => 'table',
+            default => $value,
+        };
     }
 }

--- a/resources/assets/js/components/radio/RadioStationRow.spec.ts
+++ b/resources/assets/js/components/radio/RadioStationRow.spec.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vite-plus/test'
+import type { Mock } from 'vite-plus/test'
+import { screen } from '@testing-library/vue'
+import { createHarness } from '@/__tests__/TestHarness'
+import { useContextMenu } from '@/composables/useContextMenu'
+import { playbackService } from '@/services/RadioPlaybackService'
+import { assertOpenContextMenu } from '@/__tests__/assertions'
+import RadioStationContextMenu from './RadioStationContextMenu.vue'
+import Component from './RadioStationRow.vue'
+
+vi.mock('@/composables/useContextMenu')
+
+describe('radioStationRow.vue', () => {
+  const h = createHarness()
+
+  const renderComponent = (overrides: Partial<RadioStation> = {}) => {
+    const station = h.factory('radio-station').make({
+      id: 'wcpe',
+      name: 'WCPE',
+      description: 'The Classical Station',
+      logo: 'https://example.com/wcpe.png',
+      favorite: false,
+      ...overrides,
+    })
+
+    return { station, ...h.render(Component, { props: { station } }) }
+  }
+
+  it('renders the station name and description', () => {
+    renderComponent()
+
+    screen.getByText('WCPE')
+    screen.getByText('The Classical Station')
+  })
+
+  it('emits toggle-favorite when the favorite button is clicked', async () => {
+    const { station, emitted } = renderComponent({ favorite: true })
+
+    await h.user.click(screen.getByRole('button', { name: 'Undo Favorite' }))
+
+    expect(emitted('toggle-favorite')?.[0]).toEqual([station])
+  })
+
+  it('toggles playback on double-click', async () => {
+    h.createAudioPlayer()
+    const playMock = h.mock(playbackService, 'play')
+    const { station } = renderComponent()
+
+    await h.user.dblClick(screen.getByTestId('radio-station-row'))
+
+    expect(playMock).toHaveBeenCalledWith(station)
+  })
+
+  it('opens the context menu on right-click', async () => {
+    const { openContextMenu } = useContextMenu()
+    const { station } = renderComponent()
+
+    await h.trigger(screen.getByTestId('radio-station-row'), 'contextMenu')
+
+    await assertOpenContextMenu(openContextMenu as Mock, RadioStationContextMenu, { station })
+  })
+})

--- a/resources/assets/js/components/radio/RadioStationRow.vue
+++ b/resources/assets/js/components/radio/RadioStationRow.vue
@@ -1,0 +1,97 @@
+<template>
+  <article
+    class="radio-station-row group pl-5 flex items-center h-[64px] border-b border-k-fg-10 hover:bg-k-fg-5 transition-colors"
+    data-testid="radio-station-row"
+    @contextmenu.prevent="onContextMenu"
+    @dblclick.prevent.stop="togglePlay"
+  >
+    <span class="name flex gap-3 items-center min-w-0">
+      <span
+        :style="{ backgroundImage: `url(${defaultCover})` }"
+        class="w-[48px] aspect-square rounded-sm bg-cover bg-center flex-none overflow-hidden"
+      >
+        <img v-if="station.logo" :src="station.logo" alt="" class="w-full aspect-square object-cover" loading="lazy" />
+      </span>
+      <span class="truncate" :title="station.name">{{ station.name }}</span>
+    </span>
+    <span v-if="shouldShowColumn('description')" class="description truncate" :title="station.description">
+      {{ station.description }}
+    </span>
+    <span v-if="shouldShowColumn('created_at')" class="created-at text-k-fg-50">{{ formatCreatedAt }}</span>
+    <span v-if="shouldShowColumn('favorite')" class="favorite">
+      <FavoriteButton :favorite="station.favorite" @toggle="emit('toggle-favorite', station)" />
+    </span>
+    <span class="extra">
+      <button class="text-k-fg-50 hover:text-k-fg p-1" title="More actions" @click="onContextMenu">
+        <Icon :icon="faEllipsis" />
+      </button>
+    </span>
+  </article>
+</template>
+
+<script lang="ts" setup>
+import { faEllipsis } from '@fortawesome/free-solid-svg-icons'
+import { computed } from 'vue'
+import { useContextMenu } from '@/composables/useContextMenu'
+import { useBranding } from '@/composables/useBranding'
+import { useTableColumnVisibility } from '@/composables/useTableColumnVisibility'
+import { radioStationTableColumnConfig } from '@/config/tables'
+import { playback } from '@/services/playbackManager'
+import { defineAsyncComponent } from '@/utils/helpers'
+
+import FavoriteButton from '@/components/ui/FavoriteButton.vue'
+
+const props = defineProps<{ station: RadioStation }>()
+
+const emit = defineEmits<{
+  (e: 'toggle-favorite', station: RadioStation): void
+}>()
+
+const ContextMenu = defineAsyncComponent(() => import('@/components/radio/RadioStationContextMenu.vue'))
+
+const { openContextMenu } = useContextMenu()
+const { cover: defaultCover } = useBranding()
+const { shouldShowColumn } = useTableColumnVisibility(radioStationTableColumnConfig)
+
+const formatCreatedAt = computed(() =>
+  props.station.created_at ? new Date(props.station.created_at).toLocaleDateString() : '—',
+)
+
+const onContextMenu = (event: MouseEvent) =>
+  openContextMenu<'RADIO_STATION'>(ContextMenu, event, { station: props.station })
+
+const togglePlay = () => {
+  if (props.station.playback_state === 'Playing') {
+    playback('radio').stop()
+  } else {
+    playback('radio').play(props.station)
+  }
+}
+</script>
+
+<style lang="postcss" scoped>
+@reference '@css/app.pcss';
+.radio-station-row > span {
+  @apply text-left p-2 align-middle truncate;
+
+  &.name {
+    @apply flex-1 min-w-0 flex items-center;
+  }
+
+  &.description {
+    @apply flex-[2_1_0%] min-w-0 text-k-fg-70;
+  }
+
+  &.created-at {
+    @apply basis-32;
+  }
+
+  &.favorite {
+    @apply basis-16 text-center;
+  }
+
+  &.extra {
+    @apply basis-12 text-center;
+  }
+}
+</style>

--- a/resources/assets/js/components/radio/RadioStationTable.spec.ts
+++ b/resources/assets/js/components/radio/RadioStationTable.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vite-plus/test'
+import { screen } from '@testing-library/vue'
+import { createHarness } from '@/__tests__/TestHarness'
+import Component from './RadioStationTable.vue'
+
+const virtualScrollerStub = {
+  name: 'VirtualScrollerStub',
+  props: ['items', 'itemHeight'],
+  template: '<div><template v-for="item in items" :key="item.id"><slot :item="item" /></template></div>',
+}
+
+describe('radioStationTable.vue', () => {
+  const h = createHarness()
+
+  const renderWithStations = (count = 3) => {
+    const stations = count === 0 ? [] : h.factory('radio-station').make(count)
+    return {
+      stations,
+      ...h.render(Component, {
+        props: { stations, field: 'name' as const, order: 'asc' as const },
+        global: { stubs: { VirtualScroller: virtualScrollerStub } },
+      }),
+    }
+  }
+
+  it('renders a sort-by-name header', () => {
+    renderWithStations(3)
+
+    screen.getByTitle('Sort by name')
+  })
+
+  it('emits sort with toggled order when a header is clicked', async () => {
+    const { emitted } = renderWithStations(0)
+
+    await h.user.click(screen.getByTitle('Sort by name'))
+
+    expect(emitted('sort')?.[0]).toEqual(['name', 'desc'])
+  })
+
+  it('shows a more-actions button in the header action menu', () => {
+    renderWithStations(0)
+
+    screen.getByRole('button', { name: 'Sort' })
+  })
+})

--- a/resources/assets/js/components/radio/RadioStationTable.vue
+++ b/resources/assets/js/components/radio/RadioStationTable.vue
@@ -1,0 +1,121 @@
+<template>
+  <div class="radio-station-table-wrap relative flex flex-col flex-1 overflow-auto" data-testid="radio-station-table">
+    <div class="radio-station-table-header sortable flex z-2 bg-k-fg-3 pl-5 sticky top-0">
+      <span
+        class="name"
+        role="button"
+        tabindex="0"
+        title="Sort by name"
+        @click="onSort('name')"
+        @keydown.enter.space.prevent="onSort('name')"
+      >
+        Name
+        <Icon v-if="field === 'name' && order === 'asc'" :icon="faCaretUp" class="ml-2 text-k-highlight" />
+        <Icon v-if="field === 'name' && order === 'desc'" :icon="faCaretDown" class="ml-2 text-k-highlight" />
+      </span>
+      <span v-if="shouldShowColumn('description')" class="description">Description</span>
+      <span
+        v-if="shouldShowColumn('created_at')"
+        class="created-at"
+        role="button"
+        tabindex="0"
+        title="Sort by date added"
+        @click="onSort('created_at')"
+        @keydown.enter.space.prevent="onSort('created_at')"
+      >
+        Date Added
+        <Icon v-if="field === 'created_at' && order === 'asc'" :icon="faCaretUp" class="ml-2 text-k-highlight" />
+        <Icon v-if="field === 'created_at' && order === 'desc'" :icon="faCaretDown" class="ml-2 text-k-highlight" />
+      </span>
+      <span
+        v-if="shouldShowColumn('favorite')"
+        class="favorite"
+        role="button"
+        tabindex="0"
+        title="Sort by favorite"
+        @click="onSort('favorite')"
+        @keydown.enter.space.prevent="onSort('favorite')"
+      >
+        <Icon :icon="faHeart" />
+        <Icon v-if="field === 'favorite' && order === 'asc'" :icon="faCaretUp" class="ml-2 text-k-highlight" />
+        <Icon v-if="field === 'favorite' && order === 'desc'" :icon="faCaretDown" class="ml-2 text-k-highlight" />
+      </span>
+      <span class="extra">
+        <RadioStationTableHeaderActionMenu :field :order @sort="onSort" />
+      </span>
+    </div>
+
+    <VirtualScroller :items="stations" :item-height="64">
+      <template #default="{ item }: { item: RadioStation }">
+        <RadioStationRow :station="item" @toggle-favorite="emit('toggle-favorite', $event)" />
+      </template>
+    </VirtualScroller>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { faCaretDown, faCaretUp, faHeart } from '@fortawesome/free-solid-svg-icons'
+import { toRefs } from 'vue'
+import { useTableColumnVisibility } from '@/composables/useTableColumnVisibility'
+import { radioStationTableColumnConfig } from '@/config/tables'
+
+import VirtualScroller from '@/components/ui/VirtualScroller.vue'
+import RadioStationRow from '@/components/radio/RadioStationRow.vue'
+import RadioStationTableHeaderActionMenu from '@/components/radio/RadioStationTableHeaderActionMenu.vue'
+
+const props = defineProps<{
+  stations: RadioStation[]
+  field: RadioStationListSortField
+  order: SortOrder
+}>()
+
+const emit = defineEmits<{
+  (e: 'sort', field: RadioStationListSortField, order: SortOrder): void
+  (e: 'toggle-favorite', station: RadioStation): void
+}>()
+
+const { shouldShowColumn } = useTableColumnVisibility(radioStationTableColumnConfig)
+const { field, order } = toRefs(props)
+
+const onSort = (clicked: RadioStationListSortField) => {
+  const nextOrder: SortOrder = field.value === clicked && order.value === 'asc' ? 'desc' : 'asc'
+  emit('sort', clicked, nextOrder)
+}
+</script>
+
+<style lang="postcss" scoped>
+@reference '@css/app.pcss';
+.radio-station-table-wrap {
+  .radio-station-table-header > span {
+    @apply text-left p-2 align-middle truncate;
+
+    &.name {
+      @apply flex-1 min-w-0 flex items-center;
+    }
+
+    &.description {
+      @apply flex-[2_1_0%] min-w-0;
+    }
+
+    &.created-at {
+      @apply basis-32;
+    }
+
+    &.favorite {
+      @apply basis-16 text-center;
+    }
+
+    &.extra {
+      @apply basis-12 text-center;
+    }
+  }
+
+  .radio-station-table-header {
+    @apply tracking-widest uppercase cursor-pointer text-k-fg-70;
+
+    .extra {
+      @apply px-0;
+    }
+  }
+}
+</style>

--- a/resources/assets/js/components/radio/RadioStationTableHeaderActionMenu.vue
+++ b/resources/assets/js/components/radio/RadioStationTableHeaderActionMenu.vue
@@ -1,0 +1,96 @@
+<template>
+  <article>
+    <button ref="button" class="w-full focus:text-k-highlight" title="Sort">
+      <Icon :icon="faSort" />
+    </button>
+    <Popover ref="popover" :anchor="button" placement="bottom-end" class="context-menu normal-case tracking-normal">
+      <menu>
+        <li
+          v-for="item in menuItems"
+          :key="item.label"
+          :class="field === item.field && 'active'"
+          class="cursor-pointer group flex justify-between pl-3! hover:bg-k-highlight! hover:text-k-highlight-fg!"
+          @click="sort(item.field)"
+        >
+          <label class="w-4 mr-2.5 flex items-center" @click.stop="toggle(item.column)">
+            <input
+              :checked="shouldShowColumn(item.column)"
+              :disabled="!isToggleable(item.column)"
+              :title="isToggleable(item.column) ? `Click to toggle the ${item.label} column` : ''"
+              class="disabled:opacity-20 disabled:cursor-not-allowed bg-k-fg group-hover:border-k-highlight-fg h-4 aspect-square rounded-sm checked:border-k-fg-70 checked:border-2 checked:bg-k-highlight"
+              type="checkbox"
+            />
+          </label>
+          <span class="flex-1 text-left">{{ item.label }}</span>
+          <span class="icon hidden ml-3">
+            <Icon v-if="order === 'asc'" :icon="faArrowUp" />
+            <Icon v-else :icon="faArrowDown" />
+          </span>
+        </li>
+      </menu>
+    </Popover>
+  </article>
+</template>
+
+<script lang="ts" setup>
+import { faArrowDown, faArrowUp, faSort } from '@fortawesome/free-solid-svg-icons'
+import { computed, ref } from 'vue'
+import { useTableColumnVisibility } from '@/composables/useTableColumnVisibility'
+import { radioStationTableColumnConfig } from '@/config/tables'
+
+import Popover from '@/components/ui/Popover.vue'
+
+defineProps<{
+  field: RadioStationListSortField
+  order: SortOrder
+}>()
+
+const emit = defineEmits<{ (e: 'sort', field: RadioStationListSortField): void }>()
+
+interface MenuItem {
+  column: RadioStationTableColumnName
+  label: string
+  field: RadioStationListSortField
+}
+
+const { shouldShowColumn, toggleColumn, isToggleable } = useTableColumnVisibility(radioStationTableColumnConfig)
+
+const button = ref<HTMLButtonElement>()
+const popover = ref<InstanceType<typeof Popover>>()
+
+const menuItems = computed<MenuItem[]>(() => [
+  { column: 'name', label: 'Name', field: 'name' },
+  { column: 'description', label: 'Description', field: 'name' },
+  { column: 'created_at', label: 'Date Added', field: 'created_at' },
+  { column: 'favorite', label: 'Favorite', field: 'favorite' },
+])
+
+const sort = (field: RadioStationListSortField) => {
+  emit('sort', field)
+  popover.value?.hide()
+}
+
+const toggle = (column: RadioStationTableColumnName) => {
+  if (!isToggleable(column)) {
+    return
+  }
+
+  toggleColumn(column)
+  popover.value?.hide()
+}
+</script>
+
+<style lang="postcss" scoped>
+@reference '@css/app.pcss';
+.active {
+  @apply bg-k-highlight text-k-highlight-fg;
+
+  .icon {
+    @apply block;
+  }
+
+  input {
+    @apply border-k-highlight-fg!;
+  }
+}
+</style>

--- a/resources/assets/js/components/radio/RadioStationTableHeaderActionMenu.vue
+++ b/resources/assets/js/components/radio/RadioStationTableHeaderActionMenu.vue
@@ -8,7 +8,7 @@
         <li
           v-for="item in menuItems"
           :key="item.label"
-          :class="field === item.field && 'active'"
+          :class="item.field && field === item.field && 'active'"
           class="cursor-pointer group flex justify-between pl-3! hover:bg-k-highlight! hover:text-k-highlight-fg!"
           @click="sort(item.field)"
         >
@@ -50,7 +50,7 @@ const emit = defineEmits<{ (e: 'sort', field: RadioStationListSortField): void }
 interface MenuItem {
   column: RadioStationTableColumnName
   label: string
-  field: RadioStationListSortField
+  field?: RadioStationListSortField
 }
 
 const { shouldShowColumn, toggleColumn, isToggleable } = useTableColumnVisibility(radioStationTableColumnConfig)
@@ -60,12 +60,16 @@ const popover = ref<InstanceType<typeof Popover>>()
 
 const menuItems = computed<MenuItem[]>(() => [
   { column: 'name', label: 'Name', field: 'name' },
-  { column: 'description', label: 'Description', field: 'name' },
+  { column: 'description', label: 'Description' },
   { column: 'created_at', label: 'Date Added', field: 'created_at' },
   { column: 'favorite', label: 'Favorite', field: 'favorite' },
 ])
 
-const sort = (field: RadioStationListSortField) => {
+const sort = (field?: RadioStationListSortField) => {
+  if (!field) {
+    return
+  }
+
   emit('sort', field)
   popover.value?.hide()
 }

--- a/resources/assets/js/components/radio/RadioStationTableRowSkeleton.vue
+++ b/resources/assets/js/components/radio/RadioStationTableRowSkeleton.vue
@@ -1,0 +1,8 @@
+<template>
+  <article class="skeleton flex items-center gap-3 pl-5 pr-2 h-[64px] border-b border-k-fg-10">
+    <span class="w-[48px] aspect-square rounded-sm pulse flex-none" />
+    <span class="h-5 flex-1 pulse" />
+    <span class="h-5 basis-96 pulse" />
+    <span class="h-5 pulse" />
+  </article>
+</template>

--- a/resources/assets/js/components/screens/RadioStationListScreen.spec.ts
+++ b/resources/assets/js/components/screens/RadioStationListScreen.spec.ts
@@ -52,23 +52,44 @@ describe('radioStationListScreen.vue', () => {
     await waitFor(() => screen.getByTestId('screen-empty-state'))
   })
 
-  it.each<[ViewMode]>([['list'], ['grid']])('sets layout from preferences', async mode => {
-    preferences.temporary.radio_stations_view_mode = mode
+  it('renders the grid by default', async () => {
+    preferences.temporary.radio_stations_view_mode = 'grid'
 
     await renderComponent()
 
-    await waitFor(() => expect(screen.getByTestId('radio-station-grid').classList.contains(`as-${mode}`)).toBe(true))
+    await waitFor(() => screen.getByTestId('radio-station-grid'))
+    expect(screen.queryByTestId('radio-station-table')).toBeNull()
   })
 
-  it('switches layout', async () => {
+  it('renders the table when the view mode is table', async () => {
+    preferences.temporary.radio_stations_view_mode = 'table'
+
+    await renderComponent()
+
+    await waitFor(() => screen.getByTestId('radio-station-table'))
+    expect(screen.queryByTestId('radio-station-grid')).toBeNull()
+  })
+
+  it('switches between grid and table via the view mode toggle', async () => {
+    preferences.temporary.radio_stations_view_mode = 'grid'
+
     await renderComponent()
     await h.tick()
 
-    await h.user.click(screen.getByRole('radio', { name: 'View as list' }))
-    await waitFor(() => expect(screen.getByTestId('radio-station-grid').classList.contains(`as-list`)).toBe(true))
+    screen.getByTestId('radio-station-grid')
+    expect(screen.queryByTestId('radio-station-table')).toBeNull()
+
+    await h.user.click(screen.getByRole('radio', { name: 'View as table' }))
+    await waitFor(() => {
+      screen.getByTestId('radio-station-table')
+      expect(screen.queryByTestId('radio-station-grid')).toBeNull()
+    })
 
     await h.user.click(screen.getByRole('radio', { name: 'View as grid' }))
-    await waitFor(() => expect(screen.getByTestId('radio-station-grid').classList.contains(`as-grid`)).toBe(true))
+    await waitFor(() => {
+      screen.getByTestId('radio-station-grid')
+      expect(screen.queryByTestId('radio-station-table')).toBeNull()
+    })
   })
 
   it('requests the Add Radio Station form', async () => {

--- a/resources/assets/js/components/screens/RadioStationListScreen.spec.ts
+++ b/resources/assets/js/components/screens/RadioStationListScreen.spec.ts
@@ -21,6 +21,7 @@ describe('radioStationListScreen.vue', () => {
     beforeEach: () => {
       openModalMock.mockClear()
       h.mock(radioStationStore, 'fetchAll')
+      preferences.temporary.radio_stations_view_mode = 'grid'
     },
   })
 
@@ -53,8 +54,6 @@ describe('radioStationListScreen.vue', () => {
   })
 
   it('renders the grid by default', async () => {
-    preferences.temporary.radio_stations_view_mode = 'grid'
-
     await renderComponent()
 
     await waitFor(() => screen.getByTestId('radio-station-grid'))
@@ -71,8 +70,6 @@ describe('radioStationListScreen.vue', () => {
   })
 
   it('switches between grid and table via the view mode toggle', async () => {
-    preferences.temporary.radio_stations_view_mode = 'grid'
-
     await renderComponent()
     await h.tick()
 

--- a/resources/assets/js/components/screens/RadioStationListScreen.vue
+++ b/resources/assets/js/components/screens/RadioStationListScreen.vue
@@ -22,6 +22,7 @@
             </Btn>
 
             <RadioStationListSorter
+              v-if="preferences.radio_stations_view_mode !== 'table'"
               :field="preferences.radio_stations_sort_field"
               :order="preferences.radio_stations_sort_order"
               @sort="sort"
@@ -41,7 +42,7 @@
               <span class="sr-only">Add a new station</span>
             </Btn>
 
-            <ViewModeSwitch v-model="preferences.radio_stations_view_mode" />
+            <ViewModeSwitch v-model="preferences.radio_stations_view_mode" secondary="table" />
           </div>
         </template>
       </ScreenHeader>
@@ -58,6 +59,19 @@
       </template>
     </ScreenEmptyState>
 
+    <div v-else-if="preferences.radio_stations_view_mode === 'table'" class="-m-6 flex-1 flex flex-col min-h-0">
+      <div v-if="showSkeletons" class="flex flex-col" role="status" aria-busy="true" aria-label="Loading">
+        <RadioStationTableRowSkeleton v-for="i in 12" :key="i" />
+      </div>
+      <RadioStationTable
+        v-else
+        :stations
+        :field="preferences.radio_stations_sort_field"
+        :order="preferences.radio_stations_sort_order"
+        @sort="sort"
+        @toggle-favorite="toggleFavorite"
+      />
+    </div>
     <div v-else ref="gridContainer" class="scroll-mask-y -m-6 flex-1 overflow-auto">
       <GridListView ref="grid" :view-mode="preferences.radio_stations_view_mode" data-testid="radio-station-grid">
         <div v-if="showSkeletons" role="status" aria-busy="true" aria-label="Loading" class="contents">
@@ -93,6 +107,8 @@ import ScreenBase from '@/components/screens/ScreenBase.vue'
 import Btn from '@/components/ui/form/Btn.vue'
 import ListFilter from '@/components/ui/ListFilter.vue'
 import RadioStationListSorter from '@/components/radio/RadioStationListSorter.vue'
+import RadioStationTable from '@/components/radio/RadioStationTable.vue'
+import RadioStationTableRowSkeleton from '@/components/radio/RadioStationTableRowSkeleton.vue'
 import ScreenEmptyState from '@/components/ui/ScreenEmptyState.vue'
 import RadioStationCard from '@/components/radio/RadioStationCard.vue'
 import GridListView from '@/components/ui/GridListView.vue'
@@ -140,6 +156,8 @@ const fetchStations = async () => {
     loading.value = false
   }
 }
+
+const toggleFavorite = (station: RadioStation) => radioStationStore.toggleFavorite(station)
 
 const toggleFavoritesOnly = () => {
   preferences.radio_stations_favorites_only = !preferences.radio_stations_favorites_only

--- a/resources/assets/js/config/tables.ts
+++ b/resources/assets/js/config/tables.ts
@@ -22,6 +22,18 @@ export const artistTableColumnConfig = {
   alwaysVisible: readonly ArtistTableColumnName[]
 }
 
+export const radioStationTableColumnConfig = {
+  storageKey: 'radio-station-table-columns',
+  validColumns: ['name', 'description', 'created_at', 'favorite'] as const,
+  defaultColumns: ['name', 'description', 'favorite'] as const,
+  alwaysVisible: ['name'] as const,
+} satisfies {
+  storageKey: string
+  validColumns: readonly RadioStationTableColumnName[]
+  defaultColumns: readonly RadioStationTableColumnName[]
+  alwaysVisible: readonly RadioStationTableColumnName[]
+}
+
 export const playableListColumnConfig = {
   storageKey: 'playable-list-columns',
   validColumns: [

--- a/resources/assets/js/types.d.ts
+++ b/resources/assets/js/types.d.ts
@@ -647,7 +647,9 @@ type AlbumListSortField = keyof Pick<
 type ArtistListSortField = keyof Pick<Artist, 'name' | 'created_at' | 'rating' | 'favorite'>
 type GenreListSortField = keyof Pick<Genre, 'name' | 'song_count'>
 type PodcastListSortField = keyof Pick<Podcast, 'title' | 'last_played_at' | 'subscribed_at' | 'author'>
-type RadioStationListSortField = keyof Pick<RadioStation, 'name' | 'created_at'>
+type RadioStationListSortField = keyof Pick<RadioStation, 'name' | 'created_at' | 'favorite'>
+
+type RadioStationTableColumnName = 'name' | 'description' | 'created_at' | 'favorite'
 type SortField =
   | PodcastListSortField
   | AlbumListSortField

--- a/tests/Integration/Casts/UserPreferencesCastTest.php
+++ b/tests/Integration/Casts/UserPreferencesCastTest.php
@@ -87,7 +87,7 @@ class UserPreferencesCastTest extends TestCase
         self::assertSame('NO_REPEAT', $prefs->repeatMode);
         self::assertSame('grid', $prefs->albumsViewMode);
         self::assertSame('grid', $prefs->artistsViewMode);
-        self::assertSame('thumbnails', $prefs->radioStationsViewMode);
+        self::assertSame('grid', $prefs->radioStationsViewMode);
         self::assertSame('name', $prefs->albumsSortField);
         self::assertSame('name', $prefs->artistsSortField);
         self::assertSame('name', $prefs->genresSortField);

--- a/tests/Unit/Values/User/Preferences/PreferenceBehaviorTest.php
+++ b/tests/Unit/Values/User/Preferences/PreferenceBehaviorTest.php
@@ -13,6 +13,7 @@ use App\Values\User\Preferences\CurrentEqualizerPresetPreference;
 use App\Values\User\Preferences\EqualizerPresetsPreference;
 use App\Values\User\Preferences\LastfmSessionKeyPreference;
 use App\Values\User\Preferences\MakeUploadsPublicPreference;
+use App\Values\User\Preferences\RadioStationsViewModePreference;
 use App\Values\User\Preferences\RepeatModePreference;
 use App\Values\User\Preferences\TranscodeQualityPreference;
 use App\Values\User\Preferences\VolumePreference;
@@ -58,6 +59,13 @@ class PreferenceBehaviorTest extends TestCase
     {
         self::assertSame('grid', AlbumsViewModePreference::make('thumbnails')->getValue());
         self::assertSame('table', AlbumsViewModePreference::make('list')->getValue());
+    }
+
+    #[Test]
+    public function radioStationsViewModeNormalizesLegacyValues(): void
+    {
+        self::assertSame('grid', RadioStationsViewModePreference::make('thumbnails')->getValue());
+        self::assertSame('table', RadioStationsViewModePreference::make('list')->getValue());
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

Brings the album/artist table-view treatment to the radio stations list screen.

**Frontend**
- New `RadioStationTable.vue` + `RadioStationRow.vue` + `RadioStationTableHeaderActionMenu.vue` + `RadioStationTableRowSkeleton.vue` under `resources/assets/js/components/radio/`.
- Columns:
  - **Name** — always visible, sortable.
  - **Description** — toggleable, gets twice the flex weight of name so it stretches naturally on wide screens.
  - **Date Added** — toggleable, sortable.
  - **Favorite** — toggleable, sortable.
- `RadioStationListSortField` widened to include `'favorite'`. New `RadioStationTableColumnName` type and `radioStationTableColumnConfig` entry in `config/tables.ts`.
- `RadioStationListScreen.vue`: `<ViewModeSwitch>` now uses `secondary="table"`; the standalone sort dropdown is hidden in table mode (sorting moves into the column headers); a new branch renders `<RadioStationTable>` with a row-skeleton loading state.

**Backend**
- `RadioStationsViewModePreference` accepts `['grid', 'table']` and defaults to `'grid'`. `cast()` normalizes legacy stored values: `'thumbnails'` → `'grid'`, `'list'` → `'table'`. Existing user rows load cleanly instead of throwing on the assertion.

**Tests**
- New `RadioStationTable.spec.ts` (3 tests) and `RadioStationRow.spec.ts` (4 tests).
- New `radioStationsViewModeNormalizesLegacyValues` test in `PreferenceBehaviorTest`, mirroring the album case.
- `UserPreferencesCastTest::defaultValues` now asserts `'grid'` for radio stations.

## Test plan

- [ ] Toggle the view mode switch on the Radio Stations screen — grid and table both render, the sort dropdown disappears in table mode, sort moves to the column headers.
- [ ] Column visibility checkboxes in the table's action menu toggle Description / Date Added / Favorite, but Name stays locked on.
- [ ] Double-click a row plays/stops the station; right-click opens the context menu.
- [ ] An existing user row with `radio_stations_view_mode = 'thumbnails'` or `'list'` loads without an assertion error (normalizes to `'grid'` / `'table'` respectively).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Table view for radio stations with sortable columns, per-column visibility toggles, and loading skeleton rows.
  * New station row UI with playback-on-double-click, favorite toggle, and context menu actions.
  * Default view mode switched to "grid" and legacy view-mode values are automatically normalized.

* **Tests**
  * Added unit and integration tests for the table, rows, header actions, and preference normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->