### PR TITLE
fix: make album/artist card body fill the grid cell

### DIFF
--- a/resources/assets/js/components/ui/album-artist/AlbumOrArtistCard.vue
+++ b/resources/assets/js/components/ui/album-artist/AlbumOrArtistCard.vue
@@ -8,7 +8,7 @@
   >
     <article
       :class="layout"
-      class="relative group flex p-5 rounded-[inherit] flex-col gap-5"
+      class="relative group flex h-full p-5 rounded-[inherit] flex-col gap-5"
       data-testid="artist-album-card"
       :draggable="!isMobile.any"
       tabindex="0"


### PR DESCRIPTION
## Summary

When album/artist/radio cards sit in a grid row where one sibling has a longer description than the others, the grid stretches every cell to match the tallest. The `<article>` inside `WithGradientBorder` was previously content-sized, so the shorter cards ended with empty space at the bottom showing through — the `bg-k-fg-5` fill on the article didn't reach the bottom of the wrapper.

Adding `h-full` to the article so it stretches with its wrapper and the gray fill covers the whole card regardless of which sibling has the longer text.

Most visible on the radio stations grid, where descriptions vary widely in length.

## Test plan

- [ ] Open the radio stations screen in grid mode with two cards whose descriptions differ a lot (e.g. Wacken Radio vs WCPE). The shorter card's gray fill should reach the bottom rounded corners.
- [ ] Same on the album and artist grids — no visible regression on cards with content of equal length.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Album and artist cards now utilize the full available height when displayed in the default view layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->