### PR TITLE
fix: close SSRF gaps in Subsonic podcast and internet radio endpoints

### DIFF
--- a/app/Exceptions/UnsafePodcastFeedUrlException.php
+++ b/app/Exceptions/UnsafePodcastFeedUrlException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Exceptions;
+
+use RuntimeException;
+
+final class UnsafePodcastFeedUrlException extends RuntimeException
+{
+    public static function create(string $url): self
+    {
+        return new self("The podcast feed URL $url is not safe to fetch.");
+    }
+}

--- a/app/Http/Requests/Subsonic/CreateInternetRadioStationRequest.php
+++ b/app/Http/Requests/Subsonic/CreateInternetRadioStationRequest.php
@@ -3,6 +3,8 @@
 namespace App\Http\Requests\Subsonic;
 
 use App\Http\Requests\Request;
+use App\Rules\HasAudioContentType;
+use App\Rules\SafeUrl;
 
 /**
  * @property string $streamUrl
@@ -15,7 +17,7 @@ class CreateInternetRadioStationRequest extends Request
     public function rules(): array
     {
         return [
-            'streamUrl' => ['required', 'string'],
+            'streamUrl' => ['required', 'url', new SafeUrl(), new HasAudioContentType()],
             'name' => ['required', 'string'],
             'homepageUrl' => ['nullable', 'string'],
         ];

--- a/app/Http/Requests/Subsonic/CreatePodcastChannelRequest.php
+++ b/app/Http/Requests/Subsonic/CreatePodcastChannelRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Subsonic;
 
 use App\Http\Requests\Request;
+use App\Rules\SafeUrl;
 
 /**
  * @property string $url
@@ -13,7 +14,7 @@ class CreatePodcastChannelRequest extends Request
     public function rules(): array
     {
         return [
-            'url' => ['required', 'string', 'url'],
+            'url' => ['required', 'string', 'url', new SafeUrl()],
         ];
     }
 }

--- a/app/Http/Requests/Subsonic/UpdateInternetRadioStationRequest.php
+++ b/app/Http/Requests/Subsonic/UpdateInternetRadioStationRequest.php
@@ -3,6 +3,8 @@
 namespace App\Http\Requests\Subsonic;
 
 use App\Http\Requests\Request;
+use App\Rules\HasAudioContentType;
+use App\Rules\SafeUrl;
 
 /**
  * @property string $id
@@ -17,7 +19,7 @@ class UpdateInternetRadioStationRequest extends Request
     {
         return [
             'id' => ['required', 'string'],
-            'streamUrl' => ['required', 'string'],
+            'streamUrl' => ['required', 'url', new SafeUrl(), new HasAudioContentType()],
             'name' => ['required', 'string'],
             'homepageUrl' => ['nullable', 'string'],
         ];

--- a/app/Services/Podcast/PodcastService.php
+++ b/app/Services/Podcast/PodcastService.php
@@ -83,7 +83,7 @@ class PodcastService
 
                 return $podcast;
             });
-        } catch (UserAlreadySubscribedToPodcastException $exception) {
+        } catch (UserAlreadySubscribedToPodcastException|UnsafePodcastFeedUrlException $exception) {
             throw $exception;
         } catch (Throwable $exception) {
             Log::error($exception);

--- a/app/Services/Podcast/PodcastService.php
+++ b/app/Services/Podcast/PodcastService.php
@@ -4,6 +4,7 @@ namespace App\Services\Podcast;
 
 use App\Events\UserUnsubscribedFromPodcast;
 use App\Exceptions\FailedToParsePodcastFeedException;
+use App\Exceptions\UnsafePodcastFeedUrlException;
 use App\Exceptions\UserAlreadySubscribedToPodcastException;
 use App\Helpers\Network;
 use App\Helpers\Uuid;
@@ -291,6 +292,10 @@ class PodcastService
 
     private function createParser(string $url): Poddle
     {
+        if (!$this->network->isSafeUrl($url)) {
+            throw UnsafePodcastFeedUrlException::create($url);
+        }
+
         return Poddle::fromUrl($url, 5 * 60, $this->client);
     }
 }

--- a/app/Services/Radio/RadioStreamProxy.php
+++ b/app/Services/Radio/RadioStreamProxy.php
@@ -2,10 +2,15 @@
 
 namespace App\Services\Radio;
 
+use App\Helpers\Network;
 use App\Models\RadioStation;
 
 class RadioStreamProxy
 {
+    public function __construct(
+        private readonly Network $network,
+    ) {}
+
     /**
      * Open a stream to the radio station URL, requesting ICY metadata.
      * Falls back to a plain connection if ICY request fails.
@@ -14,6 +19,10 @@ class RadioStreamProxy
      */
     public function openStream(string $url)
     {
+        if (!$this->network->isSafeUrl($url)) {
+            return false;
+        }
+
         $context = stream_context_create([
             'http' => [
                 'header' => "Icy-MetaData: 1\r\n",

--- a/tests/Feature/Subsonic/CreateInternetRadioStationTest.php
+++ b/tests/Feature/Subsonic/CreateInternetRadioStationTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Subsonic;
 
 use App\Models\RadioStation;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Http;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -11,6 +12,13 @@ use function Tests\create_user;
 
 class CreateInternetRadioStationTest extends TestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Http::fake(['*' => Http::response('', 200, ['Content-Type' => 'audio/mpeg'])]);
+    }
+
     #[Test]
     public function createsAStation(): void
     {
@@ -71,6 +79,26 @@ class CreateInternetRadioStationTest extends TestCase
                         'apiKey' => $user->subsonic_api_key,
                         'f' => 'json',
                         'name' => 'Missing',
+                    ]),
+            )
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.status', 'failed')
+            ->assertJsonPath('subsonic-response.error.code', 10);
+    }
+
+    #[Test]
+    public function unsafeStreamUrlReturnsCode10(): void
+    {
+        $user = create_user();
+
+        $this
+            ->getJson(
+                '/rest/createInternetRadioStation.view?'
+                    . Arr::query([
+                        'apiKey' => $user->subsonic_api_key,
+                        'f' => 'json',
+                        'name' => 'Internal',
+                        'streamUrl' => 'http://127.0.0.1/stream',
                     ]),
             )
             ->assertOk()

--- a/tests/Feature/Subsonic/CreatePodcastChannelTest.php
+++ b/tests/Feature/Subsonic/CreatePodcastChannelTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Subsonic;
 use App\Models\Podcast;
 use App\Models\User;
 use App\Services\Podcast\PodcastService;
+use Illuminate\Support\Facades\Http;
 use Mockery;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -12,6 +13,13 @@ use function Tests\create_user;
 
 class CreatePodcastChannelTest extends SubsonicTestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Http::fake(['*' => Http::response('', 200, ['Content-Type' => 'application/rss+xml'])]);
+    }
+
     #[Test]
     public function subscribesUserToFeed(): void
     {
@@ -46,5 +54,15 @@ class CreatePodcastChannelTest extends SubsonicTestCase
         $user = create_user();
 
         $this->getSubsonic('createPodcastChannel.view', $user)->assertSubsonicErrorCode(10);
+    }
+
+    #[Test]
+    public function unsafeUrlReturnsCode10(): void
+    {
+        $user = create_user();
+
+        $this->getSubsonic('createPodcastChannel.view', $user, [
+            'url' => 'http://127.0.0.1/internal/feed.rss',
+        ])->assertSubsonicErrorCode(10);
     }
 }

--- a/tests/Feature/Subsonic/UpdateInternetRadioStationTest.php
+++ b/tests/Feature/Subsonic/UpdateInternetRadioStationTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Subsonic;
 
 use App\Models\RadioStation;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Http;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -11,6 +12,13 @@ use function Tests\create_user;
 
 class UpdateInternetRadioStationTest extends TestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Http::fake(['*' => Http::response('', 200, ['Content-Type' => 'audio/mpeg'])]);
+    }
+
     #[Test]
     public function updatesAnOwnedStation(): void
     {
@@ -89,5 +97,27 @@ class UpdateInternetRadioStationTest extends TestCase
             ->assertOk()
             ->assertJsonPath('subsonic-response.status', 'failed')
             ->assertJsonPath('subsonic-response.error.code', 70);
+    }
+
+    #[Test]
+    public function unsafeStreamUrlReturnsCode10(): void
+    {
+        $user = create_user();
+        $station = RadioStation::factory()->createOne(['user_id' => $user->id]);
+
+        $this
+            ->getJson(
+                '/rest/updateInternetRadioStation.view?'
+                    . Arr::query([
+                        'apiKey' => $user->subsonic_api_key,
+                        'f' => 'json',
+                        'id' => $station->id,
+                        'name' => 'Internal',
+                        'streamUrl' => 'http://127.0.0.1/stream',
+                    ]),
+            )
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.status', 'failed')
+            ->assertJsonPath('subsonic-response.error.code', 10);
     }
 }

--- a/tests/Integration/Services/Podcast/PodcastServiceTest.php
+++ b/tests/Integration/Services/Podcast/PodcastServiceTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Integration\Services\Podcast;
 
 use App\Events\UserUnsubscribedFromPodcast;
+use App\Exceptions\UnsafePodcastFeedUrlException;
 use App\Exceptions\UserAlreadySubscribedToPodcastException;
 use App\Models\Podcast;
 use App\Models\PodcastUserPivot;
@@ -38,6 +39,14 @@ class PodcastServiceTest extends TestCase
         $this->instance(ClientInterface::class, new Client(['handler' => $handlerStack]));
 
         $this->service = app(PodcastService::class);
+    }
+
+    #[Test]
+    public function addPodcastWithUnsafeUrlThrowsDistinctException(): void
+    {
+        $this->expectException(UnsafePodcastFeedUrlException::class);
+
+        $this->service->addPodcast('http://127.0.0.1/feed.xml', create_user());
     }
 
     #[Test]

--- a/tests/Unit/Services/Radio/RadioStreamProxyTest.php
+++ b/tests/Unit/Services/Radio/RadioStreamProxyTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Unit\Services\Radio;
+
+use App\Helpers\Network;
+use App\Services\Radio\RadioStreamProxy;
+use Mockery;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class RadioStreamProxyTest extends TestCase
+{
+    #[Test]
+    public function openStreamRefusesUnsafeUrl(): void
+    {
+        $network = Mockery::mock(Network::class);
+        $network->expects('isSafeUrl')->with('http://127.0.0.1/stream')->andReturnFalse();
+
+        $proxy = new RadioStreamProxy($network);
+
+        self::assertFalse($proxy->openStream('http://127.0.0.1/stream'));
+    }
+}


### PR DESCRIPTION
## Summary

Closes the two private SSRF advisories: GHSA-w79m-f3jx-779v (blind SSRF via Subsonic podcast channel creation) and GHSA-6p96-cfg5-4vhp (full-read SSRF via Subsonic internet radio stations).

Both have the same shape: the regular web API enforces `SafeUrl` (and `HasAudioContentType` for radio), but the Subsonic-compatible counterparts don't, so the validation gap reintroduces an SSRF primitive the main API explicitly blocks.

**Validator gaps closed (the actual fix)**

- `CreatePodcastChannelRequest` — `url` field now also has `new SafeUrl()`.
- `CreateInternetRadioStationRequest` / `UpdateInternetRadioStationRequest` — `streamUrl` becomes `['required', 'url', new SafeUrl(), new HasAudioContentType()]`, matching the web API.

**Defense-in-depth at the service layer** (so a future route or test that skips validation can't reintroduce the SSRF)

- `RadioStreamProxy::openStream()` injects `Network` and returns `false` early when the target isn't `isSafeUrl()`.
- `PodcastService::createParser()` re-checks `isSafeUrl()` before handing the URL to `Poddle::fromUrl(...)`. Throws a new dedicated `UnsafePodcastFeedUrlException` rather than overloading `FailedToParsePodcastFeedException` (whose `create()` requires a `$previous` Throwable, and per koel's "named class per failure mode" convention the unsafe-URL case is semantically distinct from a parse failure).

**Tests**

- Subsonic Create/Update tests for both podcast and radio gain an `Http::fake` setUp so `SafeUrl`'s HEAD probe (and `HasAudioContentType`'s content-type check) don't try real network on the happy path, plus a new "unsafe URL → code 10" case in each file.
- New `RadioStreamProxyTest` covering the proxy refusing to open a stream when `Network::isSafeUrl()` returns `false`.

## Test plan

- [ ] `php artisan test tests/Feature/Subsonic/CreatePodcastChannelTest.php tests/Feature/Subsonic/CreateInternetRadioStationTest.php tests/Feature/Subsonic/UpdateInternetRadioStationTest.php tests/Unit/Services/Radio/RadioStreamProxyTest.php` is green (13/41 locally).
- [ ] Reproduce the original PoCs from the advisories against the patched build: `rest/createPodcastChannel.view?url=http://127.0.0.1/...` and `rest/createInternetRadioStation.view?streamUrl=http://127.0.0.1/...` should now return Subsonic error code 10 instead of `status: ok`.
- [ ] After the PR ships, follow the koel release pipeline (koel/koel → franken → docker → publish advisory) so users on Subsonic clients can upgrade.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced URL safety checks: podcast feed and internet radio URLs from unsafe/internal addresses are rejected early to prevent fetching them.

* **Bug Fixes**
  * Service now fails safely when an unsafe feed/stream URL is provided, avoiding downstream errors.

* **Tests**
  * Added tests to confirm unsafe URLs are rejected and surfaced as proper error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->