### PR TITLE
fix: validate every redirect hop on outbound HTTP

### DIFF
--- a/app/Helpers/SafeHttp.php
+++ b/app/Helpers/SafeHttp.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Helpers;
+
+use App\Exceptions\UnsafeUrlException;
+use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\UriInterface;
+
+/**
+ * Defenses for SSRF on outbound HTTP. Every call site that follows redirects
+ * needs per-hop validation: an attacker-controlled URL can pass the initial
+ * SafeUrl check, then 302 to 127.0.0.1, 169.254.169.254, etc.
+ *
+ * Consumers using Laravel Http facade: `Http::withOptions(SafeHttp::redirectOptions())`.
+ * Consumers needing a PSR-18 client (e.g. Poddle): `SafeHttp::guzzleClient()`.
+ *
+ * Note: this addresses redirect-SSRF only. DNS rebinding via TOCTOU between
+ * the validator's DNS lookup and the HTTP client's connect-time lookup is a
+ * separate concern that requires IP pinning (e.g. curl's CURLOPT_RESOLVE) and
+ * is tracked separately.
+ */
+class SafeHttp
+{
+    public function __construct(
+        private readonly Network $network,
+    ) {}
+
+    /**
+     * Returns the `allow_redirects` options that re-validate every redirect
+     * target via Network::isSafeUrl, throwing UnsafeUrlException on a private
+     * or reserved target.
+     *
+     * @return array<string, mixed>
+     */
+    public function redirectOptions(int $max = 5): array
+    {
+        $network = $this->network;
+
+        return [
+            'allow_redirects' => [
+                'max' => $max,
+                'on_redirect' => static function (
+                    RequestInterface $request,
+                    ResponseInterface $response,
+                    UriInterface $uri,
+                ) use ($network): void {
+                    if (!$network->isSafeUrl((string) $uri)) {
+                        throw UnsafeUrlException::forUrl((string) $uri);
+                    }
+                },
+            ],
+        ];
+    }
+
+    /**
+     * Build a PSR-18 client that applies the same per-redirect-hop validation
+     * via Guzzle middleware. Use for libraries that take an injected client
+     * (e.g. PhanAn\Poddle\Poddle::fromUrl()).
+     */
+    public function guzzleClient(int $timeoutInSeconds = 30): Client
+    {
+        $network = $this->network;
+
+        $stack = HandlerStack::create();
+
+        $stack->push(Middleware::mapRequest(static function (RequestInterface $request) use ($network) {
+            if (!$network->isSafeUrl((string) $request->getUri())) {
+                throw UnsafeUrlException::forUrl((string) $request->getUri());
+            }
+
+            return $request;
+        }));
+
+        return new Client([
+            'handler' => $stack,
+            'timeout' => $timeoutInSeconds,
+            'allow_redirects' => [
+                'max' => 5,
+                'on_redirect' => static function (
+                    RequestInterface $request,
+                    ResponseInterface $response,
+                    UriInterface $uri,
+                ) use ($network): void {
+                    if (!$network->isSafeUrl((string) $uri)) {
+                        throw UnsafeUrlException::forUrl((string) $uri);
+                    }
+                },
+            ],
+        ]);
+    }
+}

--- a/app/Helpers/SafeHttp.php
+++ b/app/Helpers/SafeHttp.php
@@ -67,7 +67,9 @@ class SafeHttp
 
         $stack = HandlerStack::create();
 
-        $stack->push(Middleware::mapRequest(static function (RequestInterface $request) use ($network) {
+        $stack->push(Middleware::mapRequest(static function (RequestInterface $request) use (
+            $network,
+        ): RequestInterface {
             if (!$network->isSafeUrl((string) $request->getUri())) {
                 throw UnsafeUrlException::forUrl((string) $request->getUri());
             }
@@ -78,18 +80,7 @@ class SafeHttp
         return new Client([
             'handler' => $stack,
             'timeout' => $timeoutInSeconds,
-            'allow_redirects' => [
-                'max' => 5,
-                'on_redirect' => static function (
-                    RequestInterface $request,
-                    ResponseInterface $response,
-                    UriInterface $uri,
-                ) use ($network): void {
-                    if (!$network->isSafeUrl((string) $uri)) {
-                        throw UnsafeUrlException::forUrl((string) $uri);
-                    }
-                },
-            ],
+            ...$this->redirectOptions(),
         ]);
     }
 }

--- a/app/Helpers/SafeHttp.php
+++ b/app/Helpers/SafeHttp.php
@@ -38,17 +38,15 @@ class SafeHttp
      */
     public function redirectOptions(int $max = 5): array
     {
-        $network = $this->network;
-
         return [
             'allow_redirects' => [
                 'max' => $max,
-                'on_redirect' => static function (
+                'on_redirect' => function (
                     RequestInterface $request,
                     ResponseInterface $response,
                     UriInterface $uri,
-                ) use ($network): void {
-                    if (!$network->isSafeUrl((string) $uri)) {
+                ): void {
+                    if (!$this->network->isSafeUrl((string) $uri)) {
                         throw UnsafeUrlException::forUrl((string) $uri);
                     }
                 },
@@ -63,14 +61,10 @@ class SafeHttp
      */
     public function guzzleClient(int $timeoutInSeconds = 30): Client
     {
-        $network = $this->network;
-
         $stack = HandlerStack::create();
 
-        $stack->push(Middleware::mapRequest(static function (RequestInterface $request) use (
-            $network,
-        ): RequestInterface {
-            if (!$network->isSafeUrl((string) $request->getUri())) {
+        $stack->push(Middleware::mapRequest(function (RequestInterface $request): RequestInterface {
+            if (!$this->network->isSafeUrl((string) $request->getUri())) {
                 throw UnsafeUrlException::forUrl((string) $request->getUri());
             }
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use App\Enums\Acl\Role;
+use App\Helpers\SafeHttp;
 use App\Models\Album;
 use App\Models\Artist;
 use App\Models\Genre;
@@ -33,6 +34,7 @@ use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
+use Psr\Http\Client\ClientInterface;
 use SpotifyWebAPI\Session as SpotifySession;
 
 class AppServiceProvider extends ServiceProvider
@@ -74,6 +76,11 @@ class AppServiceProvider extends ServiceProvider
         });
 
         $this->app->bind(LicenseServiceInterface::class, LicenseService::class);
+
+        // PSR-18 client used by libraries that fetch external URLs (e.g. Poddle).
+        // Backed by SafeHttp so every redirect hop is re-validated against the
+        // SafeUrl rules — closes the redirect-SSRF leg of GHSA-6qvr-wjmv-v8mm.
+        $this->app->bind(ClientInterface::class, static fn (): ClientInterface => app(SafeHttp::class)->guzzleClient());
 
         $this->app->bind(ScannerCacheStrategyContract::class, static function () {
             // Use a no-cache strategy for unit tests to ensure consistent results

--- a/app/Rules/HasAudioContentType.php
+++ b/app/Rules/HasAudioContentType.php
@@ -2,6 +2,7 @@
 
 namespace App\Rules;
 
+use App\Helpers\SafeHttp;
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\Facades\Http;
@@ -40,9 +41,11 @@ class HasAudioContentType implements ValidationRule
      */
     private function resolveContentType(string $url): string
     {
+        $redirectOptions = app(SafeHttp::class)->redirectOptions();
+
         // Try HEAD first — fast and lightweight
         try {
-            $response = Http::head($url);
+            $response = Http::withOptions($redirectOptions)->head($url);
 
             if ($response->successful()) {
                 return $response->header('Content-Type');
@@ -51,7 +54,10 @@ class HasAudioContentType implements ValidationRule
         }
 
         // Fall back to GET with ICY headers — streaming servers often only respond to GET
-        $response = Http::withHeaders(['Icy-MetaData' => '1'])->withOptions(['stream' => true])->get($url);
+        $response = Http::withHeaders(['Icy-MetaData' => '1'])->withOptions([
+            ...$redirectOptions,
+            'stream' => true,
+        ])->get($url);
 
         return $response->header('Content-Type');
     }

--- a/app/Rules/SafeUrl.php
+++ b/app/Rules/SafeUrl.php
@@ -2,7 +2,9 @@
 
 namespace App\Rules;
 
+use App\Exceptions\UnsafeUrlException;
 use App\Helpers\Network;
+use App\Helpers\SafeHttp;
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\Facades\Http;
@@ -48,12 +50,22 @@ class SafeUrl implements ValidationRule
             return;
         }
 
+        $redirectOptions = app(SafeHttp::class)->redirectOptions();
+
         try {
-            $response = Http::head((string) $value);
+            $response = Http::withOptions($redirectOptions)->head((string) $value);
+        } catch (UnsafeUrlException) {
+            $fail('The :attribute must point to a public URL.');
+
+            return;
         } catch (Throwable) {
             // Some streaming servers don't support HEAD — try GET
             try {
-                $response = Http::withOptions(['stream' => true])->get((string) $value);
+                $response = Http::withOptions([...$redirectOptions, 'stream' => true])->get((string) $value);
+            } catch (UnsafeUrlException) {
+                $fail('The :attribute must point to a public URL.');
+
+                return;
             } catch (Throwable) {
                 $fail("The $attribute couldn't be reached.");
 

--- a/app/Services/Podcast/PodcastService.php
+++ b/app/Services/Podcast/PodcastService.php
@@ -7,6 +7,7 @@ use App\Exceptions\FailedToParsePodcastFeedException;
 use App\Exceptions\UnsafePodcastFeedUrlException;
 use App\Exceptions\UserAlreadySubscribedToPodcastException;
 use App\Helpers\Network;
+use App\Helpers\SafeHttp;
 use App\Helpers\Uuid;
 use App\Models\Podcast;
 use App\Models\PodcastUserPivot;
@@ -36,6 +37,7 @@ class PodcastService
         private readonly PodcastRepository $podcastRepository,
         private readonly SongRepository $songRepository,
         private readonly Network $network,
+        private readonly SafeHttp $safeHttp,
         private ?ClientInterface $client = null,
     ) {}
 
@@ -218,8 +220,14 @@ class PodcastService
             return false;
         }
 
+        if (!$this->network->isSafeUrl($podcast->url)) {
+            return true;
+        }
+
         try {
-            $lastModified = Http::head($podcast->url)->header('Last-Modified');
+            $lastModified = Http::withOptions($this->safeHttp->redirectOptions())
+                ->head($podcast->url)
+                ->header('Last-Modified');
 
             if (!$lastModified) {
                 return true;
@@ -246,7 +254,7 @@ class PodcastService
             return null;
         }
 
-        $client ??= new Client();
+        $client ??= $this->safeHttp->guzzleClient();
 
         try {
             $response = $client->request($method, $url, [
@@ -255,7 +263,10 @@ class PodcastService
                     'Origin' => '*',
                 ],
                 RequestOptions::HTTP_ERRORS => false,
-                RequestOptions::ALLOW_REDIRECTS => ['track_redirects' => true],
+                RequestOptions::ALLOW_REDIRECTS => [
+                    ...$this->safeHttp->redirectOptions()['allow_redirects'],
+                    'track_redirects' => true,
+                ],
             ]);
 
             $redirects = Arr::wrap($response->getHeader(RedirectMiddleware::HISTORY_HEADER));

--- a/app/Services/Radio/RadioStreamProxy.php
+++ b/app/Services/Radio/RadioStreamProxy.php
@@ -23,10 +23,23 @@ class RadioStreamProxy
             return false;
         }
 
+        // Disable redirect-following at the wrapper level. SafeUrl validates the
+        // initial URL, so the only way the stream socket could reach a private
+        // host is via a redirect at connect time — close that door entirely.
         $context = stream_context_create([
             'http' => [
                 'header' => "Icy-MetaData: 1\r\n",
                 'timeout' => 5,
+                'follow_location' => 0,
+                'max_redirects' => 0,
+            ],
+        ]);
+
+        $plainContext = stream_context_create([
+            'http' => [
+                'timeout' => 5,
+                'follow_location' => 0,
+                'max_redirects' => 0,
             ],
         ]);
 
@@ -39,7 +52,7 @@ class RadioStreamProxy
                 return $stream;
             }
 
-            return fopen($url, 'r');
+            return fopen($url, 'r', false, $plainContext);
         } finally {
             restore_error_handler();
         }

--- a/tests/Integration/Services/Podcast/PodcastServiceTest.php
+++ b/tests/Integration/Services/Podcast/PodcastServiceTest.php
@@ -189,6 +189,39 @@ class PodcastServiceTest extends TestCase
     }
 
     #[Test]
+    public function podcastObsoleteForcedWhenFeedUrlIsUnsafe(): void
+    {
+        // Even though the URL was somehow stored, isPodcastObsolete must refuse
+        // to probe it — returning true so the caller falls into refreshPodcast,
+        // which re-validates via createParser and throws UnsafePodcastFeedUrlException.
+        $podcast = Podcast::factory()->createOne([
+            'url' => 'http://127.0.0.1/feed.xml',
+            'last_synced_at' => now()->subDays(1),
+        ]);
+
+        self::assertTrue($this->service->isPodcastObsolete($podcast));
+    }
+
+    #[Test]
+    public function podcastObsoleteWhenFeedHeadRedirectsToPrivateHost(): void
+    {
+        // 302 to a private host on the HEAD probe — on_redirect throws, the
+        // method's catch block returns true (treat as obsolete) and refresh
+        // path will refuse to fetch from the private URL via createParser.
+        Http::fake([
+            'https://example.com/feed.xml' => Http::response('', 302, ['Location' => 'http://127.0.0.1/feed.xml']),
+            '*' => Http::response(),
+        ]);
+
+        $podcast = Podcast::factory()->createOne([
+            'url' => 'https://example.com/feed.xml',
+            'last_synced_at' => now()->subDays(1),
+        ]);
+
+        self::assertTrue($this->service->isPodcastObsolete($podcast));
+    }
+
+    #[Test]
     public function updateEpisodeProgress(): void
     {
         $episode = Song::factory()->asEpisode()->createOne();
@@ -288,6 +321,21 @@ class PodcastServiceTest extends TestCase
     public function getStreamableUrlRejectsUnsafeUrl(string $url): void
     {
         self::assertNull($this->service->getStreamableUrl($url));
+    }
+
+    #[Test]
+    public function getStreamableUrlRejectsRedirectToPrivateHost(): void
+    {
+        // Initial URL is public, but the server 302s to 127.0.0.1. The on_redirect
+        // validator must throw before the follow-up request is issued, and the
+        // method returns null instead of leaking the internal target.
+        $mock = new MockHandler([
+            new Response(302, ['Location' => 'http://127.0.0.1/episode.mp3']),
+        ]);
+
+        $client = new Client(['handler' => HandlerStack::create($mock)]);
+
+        self::assertNull($this->service->getStreamableUrl('https://example.com/episode.mp3', $client));
     }
 
     #[Test]

--- a/tests/Integration/Services/Podcast/PodcastServiceTest.php
+++ b/tests/Integration/Services/Podcast/PodcastServiceTest.php
@@ -13,6 +13,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
+use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -220,7 +221,7 @@ class PodcastServiceTest extends TestCase
 
         self::assertTrue($this->service->isPodcastObsolete($podcast));
 
-        Http::assertNotSent(static fn ($request): bool => str_contains($request->url(), '127.0.0.1'));
+        Http::assertNotSent(static fn (Request $request): bool => str_contains($request->url(), '127.0.0.1'));
     }
 
     #[Test]

--- a/tests/Integration/Services/Podcast/PodcastServiceTest.php
+++ b/tests/Integration/Services/Podcast/PodcastServiceTest.php
@@ -219,6 +219,8 @@ class PodcastServiceTest extends TestCase
         ]);
 
         self::assertTrue($this->service->isPodcastObsolete($podcast));
+
+        Http::assertNotSent(static fn ($request): bool => str_contains($request->url(), '127.0.0.1'));
     }
 
     #[Test]

--- a/tests/Unit/Helpers/SafeHttpTest.php
+++ b/tests/Unit/Helpers/SafeHttpTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Unit\Helpers;
+
+use App\Exceptions\UnsafeUrlException;
+use App\Helpers\SafeHttp;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SafeHttpTest extends TestCase
+{
+    private SafeHttp $safeHttp;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->safeHttp = app(SafeHttp::class);
+    }
+
+    #[Test]
+    public function guzzleClientRejectsPreflightUnsafeUrl(): void
+    {
+        $this->expectException(UnsafeUrlException::class);
+
+        $this->safeHttp->guzzleClient()->request('GET', 'http://127.0.0.1/admin');
+    }
+
+    #[Test]
+    public function redirectOptionsRejectRedirectToPrivateHost(): void
+    {
+        // Build a Guzzle client that emits a 302 to a private host, then would
+        // emit a 200 (which we must never reach). Apply only the redirect options
+        // — no pre-flight middleware — to isolate the on_redirect leg.
+        $mock = new MockHandler([
+            new Response(302, ['Location' => 'http://127.0.0.1/admin']),
+            new Response(200, [], 'should be unreachable'),
+        ]);
+
+        $client = new Client(['handler' => HandlerStack::create($mock)]);
+
+        $this->expectException(UnsafeUrlException::class);
+
+        try {
+            $client->request('GET', 'https://public.example.com/feed', $this->safeHttp->redirectOptions());
+        } catch (GuzzleException $e) {
+            // Guzzle wraps middleware exceptions; unwrap to surface the real cause.
+            if ($e->getPrevious() instanceof UnsafeUrlException) {
+                throw $e->getPrevious();
+            }
+
+            throw $e;
+        }
+    }
+
+    #[Test]
+    public function redirectOptionsAllowRedirectToPublicHost(): void
+    {
+        $mock = new MockHandler([
+            new Response(302, ['Location' => 'https://other.example.com/feed']),
+            new Response(200, [], 'ok'),
+        ]);
+
+        $client = new Client(['handler' => HandlerStack::create($mock)]);
+
+        $response = $client->request('GET', 'https://public.example.com/feed', $this->safeHttp->redirectOptions());
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('ok', (string) $response->getBody());
+    }
+}

--- a/tests/Unit/Rules/HasAudioContentTypeTest.php
+++ b/tests/Unit/Rules/HasAudioContentTypeTest.php
@@ -49,4 +49,23 @@ class HasAudioContentTypeTest extends TestCase
             fn () => $this->addToAssertionCount(1), // @phpstan-ignore-line
         );
     }
+
+    #[Test]
+    public function rejectsStreamRedirectingToPrivateHost(): void
+    {
+        // 302 from a public host to a private host: on_redirect must throw on the
+        // HEAD probe, the GET fallback must also redirect-throw, leaving the
+        // resolver with no content type — the rule fails with the "unreachable"
+        // message.
+        Http::fake([
+            'public.example.com/*' => Http::response('', 302, ['Location' => 'http://127.0.0.1/stream']),
+            '*' => Http::response('', 200),
+        ]);
+
+        (new HasAudioContentType())->validate(
+            'url',
+            'https://public.example.com/stream',
+            fn () => $this->addToAssertionCount(1), // @phpstan-ignore-line
+        );
+    }
 }

--- a/tests/Unit/Rules/HasAudioContentTypeTest.php
+++ b/tests/Unit/Rules/HasAudioContentTypeTest.php
@@ -67,5 +67,7 @@ class HasAudioContentTypeTest extends TestCase
             'https://public.example.com/stream',
             fn () => $this->addToAssertionCount(1), // @phpstan-ignore-line
         );
+
+        Http::assertNotSent(static fn ($request): bool => str_contains($request->url(), '127.0.0.1'));
     }
 }

--- a/tests/Unit/Rules/HasAudioContentTypeTest.php
+++ b/tests/Unit/Rules/HasAudioContentTypeTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Rules;
 
 use App\Rules\HasAudioContentType;
+use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -68,6 +69,6 @@ class HasAudioContentTypeTest extends TestCase
             fn () => $this->addToAssertionCount(1), // @phpstan-ignore-line
         );
 
-        Http::assertNotSent(static fn ($request): bool => str_contains($request->url(), '127.0.0.1'));
+        Http::assertNotSent(static fn (Request $request): bool => str_contains($request->url(), '127.0.0.1'));
     }
 }

--- a/tests/Unit/Rules/SafeUrlTest.php
+++ b/tests/Unit/Rules/SafeUrlTest.php
@@ -75,4 +75,17 @@ class SafeUrlTest extends TestCase
 
         self::assertFalse($this->passes('https://8.8.8.8/feed'));
     }
+
+    #[Test]
+    public function rejectsUrlsRedirectingToPrivateHost(): void
+    {
+        // The 302 to a private host must be caught by the on_redirect validator
+        // before Guzzle issues the follow-up request to 127.0.0.1.
+        Http::fake([
+            'public.example.com/*' => Http::response('', 302, ['Location' => 'http://127.0.0.1/admin']),
+            '*' => Http::response('', 200),
+        ]);
+
+        self::assertFalse($this->passes('https://public.example.com/feed'));
+    }
 }

--- a/tests/Unit/Rules/SafeUrlTest.php
+++ b/tests/Unit/Rules/SafeUrlTest.php
@@ -82,12 +82,16 @@ class SafeUrlTest extends TestCase
     {
         // The 302 to a private host must be caught by the on_redirect validator
         // before Guzzle issues the follow-up request to 127.0.0.1.
+        //
+        // Use 8.8.8.8 as the initial host so Network::isPublicHost short-circuits
+        // on the IP-literal path and never touches DNS — the test must not depend
+        // on whether 'public.example.com' resolves in the test environment.
         Http::fake([
-            'public.example.com/*' => Http::response('', 302, ['Location' => 'http://127.0.0.1/admin']),
+            '8.8.8.8/*' => Http::response('', 302, ['Location' => 'http://127.0.0.1/admin']),
             '*' => Http::response('', 200),
         ]);
 
-        self::assertFalse($this->passes('https://public.example.com/feed'));
+        self::assertFalse($this->passes('https://8.8.8.8/feed'));
 
         Http::assertNotSent(static fn (Request $request): bool => str_contains($request->url(), '127.0.0.1'));
     }

--- a/tests/Unit/Rules/SafeUrlTest.php
+++ b/tests/Unit/Rules/SafeUrlTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Rules;
 
 use App\Rules\SafeUrl;
+use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use PHPUnit\Framework\Attributes\Test;
 use RuntimeException;
@@ -88,6 +89,6 @@ class SafeUrlTest extends TestCase
 
         self::assertFalse($this->passes('https://public.example.com/feed'));
 
-        Http::assertNotSent(static fn ($request): bool => str_contains($request->url(), '127.0.0.1'));
+        Http::assertNotSent(static fn (Request $request): bool => str_contains($request->url(), '127.0.0.1'));
     }
 }

--- a/tests/Unit/Rules/SafeUrlTest.php
+++ b/tests/Unit/Rules/SafeUrlTest.php
@@ -87,5 +87,7 @@ class SafeUrlTest extends TestCase
         ]);
 
         self::assertFalse($this->passes('https://public.example.com/feed'));
+
+        Http::assertNotSent(static fn ($request): bool => str_contains($request->url(), '127.0.0.1'));
     }
 }


### PR DESCRIPTION
## Summary

Closes the redirect-SSRF leg of GHSA-6qvr-wjmv-v8mm. The recent SSRF round (#2545) plugged the **validator gap** between the web API and the Subsonic surface, but the validation itself is bypassable: an attacker-controlled URL passes the initial `SafeUrl` / `isSafeUrl` check, then 302s the HTTP client to `127.0.0.1`, `169.254.169.254`, or any other internal target.

This PR adds **per-redirect-hop validation** on every outbound HTTP path that follows redirects, centralized in a new helper.

> DNS rebinding (TOCTOU between validation and connect) is a separate, larger concern that needs IP pinning (`CURLOPT_RESOLVE`). Tracking that as a follow-up rather than rolling it into this PR.

## What changed

**New helper — `App\Helpers\SafeHttp`**

Two entry points:

- `redirectOptions(int $max = 5)` — returns the `allow_redirects` array with an `on_redirect` callback that re-runs `Network::isSafeUrl` and throws `UnsafeUrlException` for each hop. Pass it through `Http::withOptions(...)`.
- `guzzleClient(int $timeoutInSeconds = 30)` — returns a Guzzle `Client` with both pre-flight middleware (validates the initial URL) and the same redirect callback. For PSR-18 consumers.

**Container binding**

`Psr\Http\Client\ClientInterface` now resolves to `SafeHttp::guzzleClient()`, so `PhanAn\Poddle\Poddle::fromUrl(...)` picks up the safe client automatically — no per-call wiring needed.

**Consumers migrated**

- `App\Rules\SafeUrl` — its own HEAD probe (and GET fallback) now use `redirectOptions()`. A 302 from the submitted URL to a private host fails validation with `"must point to a public URL"` instead of being silently followed.
- `App\Rules\HasAudioContentType` — same migration for the HEAD/GET content-type probes.
- `App\Services\Podcast\PodcastService::isPodcastObsolete` — adds an `isSafeUrl` pre-check (defends against URLs that somehow bypassed validation at write time) and wraps the `Last-Modified` HEAD in `redirectOptions()`.
- `App\Services\Podcast\PodcastService::getStreamableUrl` — defaults to `SafeHttp::guzzleClient()` instead of a bare `new Client()` (so injected clients keep working, but the default is now safe) and merges `redirectOptions()['allow_redirects']` into the existing `track_redirects` option so the on_redirect callback fires on each hop.
- `App\Services\Radio\RadioStreamProxy::openStream` — disables redirect-following at the `fopen` HTTP wrapper level (`follow_location => 0`, `max_redirects => 0`). The URL already passed `isSafeUrl` at write time; a connect-time redirect is the only way the socket could reach a private host, and there's no legitimate reason a radio stream URL needs to redirect.

## Tests

- `tests/Unit/Helpers/SafeHttpTest.php` (new) — pre-flight rejection and on_redirect rejection/acceptance via `MockHandler`.
- `tests/Unit/Rules/SafeUrlTest.php::rejectsUrlsRedirectingToPrivateHost` — 302 to `127.0.0.1` makes the rule fail.
- `tests/Unit/Rules/HasAudioContentTypeTest.php::rejectsStreamRedirectingToPrivateHost` — 302 to `127.0.0.1` makes the content-type rule fail.
- `tests/Integration/Services/Podcast/PodcastServiceTest.php`:
  - `getStreamableUrlRejectsRedirectToPrivateHost` — public URL → 302 to `127.0.0.1` → returns `null`.
  - `podcastObsoleteForcedWhenFeedUrlIsUnsafe` — stored URL pointing at `127.0.0.1` short-circuits to `true`.
  - `podcastObsoleteWhenFeedHeadRedirectsToPrivateHost` — 302 on HEAD probe → `true` (refresh will then refuse to fetch).

Full backend suite: 1445/1445 passing locally. `composer cs && composer lint && composer analyze` all green.

## Test plan

- [ ] Reproduce the advisory PoCs against the patched build: a public URL that 302s to `http://127.0.0.1/...` should now fail at validation time on the web API (`SafeUrl` rule rejects it) and at fetch time everywhere else (`UnsafeUrlException`), instead of being followed.
- [ ] Verify Poddle picks up the bound client: subscribe to a benign public feed via the web API and confirm it still works end-to-end.
- [ ] Smoke-test radio playback in a Mac client (Feishin / Sonixd / Submariner) to confirm `RadioStreamProxy` still opens normal direct streams (no regression from disabling redirects).
- [ ] After merge: follow-up PR for DNS-rebinding (IP pinning via `CURLOPT_RESOLVE` on `SafeHttp::guzzleClient()` and a hand-rolled HTTPS connection for `RadioStreamProxy`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized outbound-HTTP safety helper and app-wide safe HTTP client binding to validate each redirect hop.

* **Security Improvements**
  * Prevent redirects to unsafe/private hosts across feed sync, URL validation, audio-content checks, stream retrieval, and stream opening (ICY mode disables redirect following); unsafe feeds treated as obsolete and internal targets not disclosed.

* **Tests**
  * Added unit and integration tests covering unsafe-redirect and blocked-redirect behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->