### PR TITLE
fix: hide header action button on mobile when list isn't sortable

### DIFF
--- a/resources/assets/js/components/playable/playable-list/PlayableListHeader.spec.ts
+++ b/resources/assets/js/components/playable/playable-list/PlayableListHeader.spec.ts
@@ -1,4 +1,5 @@
 import { screen } from '@testing-library/vue'
+import isMobile from 'ismobilejs'
 import { ref } from 'vue'
 import { describe, expect, it } from 'vite-plus/test'
 import { createHarness } from '@/__tests__/TestHarness'
@@ -111,5 +112,22 @@ describe('playableListHeader.vue', () => {
 
     await h.user.click(screen.getByTestId('header-track-number'))
     expect(emitted().sort).toBeUndefined()
+  })
+
+  it.each<[boolean, boolean, boolean]>([
+    [false, true, true], // desktop + sortable → show
+    [false, false, true], // desktop + unsortable → show (column-toggle still useful)
+    [true, true, true], // mobile + sortable → show (sort still works)
+    [true, false, false], // mobile + unsortable (queue) → hide
+  ])('action menu visibility — mobile=%s sortable=%s → visible=%s', async (mobile, sortable, expected) => {
+    isMobile.any = mobile
+
+    try {
+      const { html } = await renderComponent({ sortable, reorderable: true })
+
+      expect(html().includes('class="extra"')).toBe(expected)
+    } finally {
+      isMobile.any = false
+    }
   })
 })

--- a/resources/assets/js/components/playable/playable-list/PlayableListHeader.spec.ts
+++ b/resources/assets/js/components/playable/playable-list/PlayableListHeader.spec.ts
@@ -114,16 +114,23 @@ describe('playableListHeader.vue', () => {
     expect(emitted().sort).toBeUndefined()
   })
 
-  it.each<[boolean, boolean, boolean]>([
-    [false, true, true], // desktop + sortable → show
-    [false, false, true], // desktop + unsortable → show (column-toggle still useful)
-    [true, true, true], // mobile + sortable → show (sort still works)
-    [true, false, false], // mobile + unsortable (queue) → hide
-  ])('action menu visibility — mobile=%s sortable=%s → visible=%s', async (mobile, sortable, expected) => {
+  it.each<[boolean, boolean]>([
+    [false, true], // desktop + sortable
+    [false, false], // desktop + unsortable: column-toggle is still useful
+    [true, true], // mobile + sortable: sort still works
+  ])('shows action menu — mobile=%s sortable=%s', async (mobile, sortable) => {
     isMobile.any = mobile
 
     await renderComponent({ sortable, reorderable: true })
 
-    expect(screen.queryByTestId('header-extra') !== null).toBe(expected)
+    screen.getByTestId('header-extra')
+  })
+
+  it('hides action menu on mobile when not sortable', async () => {
+    isMobile.any = true
+
+    await renderComponent({ sortable: false, reorderable: true })
+
+    expect(screen.queryByTestId('header-extra')).toBeNull()
   })
 })

--- a/resources/assets/js/components/playable/playable-list/PlayableListHeader.spec.ts
+++ b/resources/assets/js/components/playable/playable-list/PlayableListHeader.spec.ts
@@ -122,12 +122,8 @@ describe('playableListHeader.vue', () => {
   ])('action menu visibility — mobile=%s sortable=%s → visible=%s', async (mobile, sortable, expected) => {
     isMobile.any = mobile
 
-    try {
-      const { html } = await renderComponent({ sortable, reorderable: true })
+    await renderComponent({ sortable, reorderable: true })
 
-      expect(html().includes('class="extra"')).toBe(expected)
-    } finally {
-      isMobile.any = false
-    }
+    expect(screen.queryByTestId('header-extra') !== null).toBe(expected)
   })
 })

--- a/resources/assets/js/components/playable/playable-list/PlayableListHeader.vue
+++ b/resources/assets/js/components/playable/playable-list/PlayableListHeader.vue
@@ -166,7 +166,7 @@
         />
       </template>
     </span>
-    <span class="extra">
+    <span v-if="shouldShowActionMenu" class="extra">
       <PlayableListHeaderActionMenu
         :sortable="config.sortable"
         :field="sortField"
@@ -181,6 +181,7 @@
 </template>
 
 <script setup lang="ts">
+import isMobile from 'ismobilejs'
 import type { Ref } from 'vue'
 import { computed } from 'vue'
 import { faCaretDown, faCaretUp, faHeart } from '@fortawesome/free-solid-svg-icons'
@@ -228,4 +229,9 @@ const sortingByAlbumOrPodcast = computed(() => {
   const sortFields = arrayify(sortField.value)
   return sortFields[0] === 'album_name' || sortFields[0] === 'podcast_title'
 })
+
+// On mobile, the table columns collapse — sorting is the only thing the action
+// menu can do. If the list isn't sortable (e.g. the queue), the button would
+// just open an inert menu, so drop it entirely.
+const shouldShowActionMenu = computed(() => !isMobile.any || config.sortable)
 </script>

--- a/resources/assets/js/components/playable/playable-list/PlayableListHeader.vue
+++ b/resources/assets/js/components/playable/playable-list/PlayableListHeader.vue
@@ -166,7 +166,7 @@
         />
       </template>
     </span>
-    <span v-if="shouldShowActionMenu" class="extra">
+    <span v-if="shouldShowActionMenu" class="extra" data-testid="header-extra">
       <PlayableListHeaderActionMenu
         :sortable="config.sortable"
         :field="sortField"


### PR DESCRIPTION
## Summary

On mobile, the playable-list table header collapses every column except the title (CSS in `PlayableList.vue:444` hides `track`, `album`, `time`, `year`, `genre`, etc.), but the trailing `.extra` column — which renders the action button (`PlayableListHeaderActionMenu`) — has no responsive rule, so it stays on screen.

On the Queue screen (`config.sortable === false`), that button opens a menu whose items are inert: every click is dropped by `sort()` since the list isn't sortable, and the column-visibility checkboxes don't show either (nothing to toggle on mobile). The user just sees a menu where nothing happens.

This PR hides the `.extra` column when `isMobile.any && !config.sortable`. Sortable mobile lists keep the button (sorting still works); desktop is untouched (`config.sortable === false` there still lets users access the column-visibility menu).

`isMobile.any` from `ismobilejs` is koel's established mobile primitive — already used in `PlayableList.vue:23`, the sidebars, side sheet, search form, and more. The test harness already toggles it via the same flag.

## Test plan

- [ ] On Queue / mobile: action button no longer appears in the header.
- [ ] On Queue / desktop: action button still appears (menu shows column-toggle checkboxes).
- [ ] On any sortable list / mobile (e.g. Songs, an Album): action button still appears (sort menu works).
- [ ] Existing PlayableListHeader specs are green; new `it.each` covers all four (mobile × sortable) combinations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Action menu visibility on mobile improved: the extra action section is now hidden unless sorting is enabled, preventing non-functional menu items on small screens.

* **Tests**
  * Added parameterized tests to validate action menu visibility across mobile/desktop and sortable/non-sortable scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->