### PR TITLE
feat: add EMBED_ENABLED toggle to disable embedding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -236,6 +236,10 @@ BACKUP_ON_DELETE=true
 MEDIA_BROWSER_ENABLED=false
 
 
+# Whether to allow embedding songs, albums, artists, and playlists on external sites.
+EMBED_ENABLED=true
+
+
 # If using SSO, set the providers details here. Koel will automatically enable SSO if these values are set.
 # Create an OAuth client and get these values from https://console.developers.google.com/apis/credentials
 SSO_GOOGLE_CLIENT_ID=

--- a/app/Http/Controllers/API/FetchInitialDataController.php
+++ b/app/Http/Controllers/API/FetchInitialDataController.php
@@ -65,6 +65,7 @@ class FetchInitialDataController extends Controller
             'download_limit' => (int) config('koel.download.limit'),
             'uses_media_browser' => MediaBrowser::used(),
             'uses_ai' => License::isPlus() && config('koel.ai.enabled'),
+            'allows_embedding' => (bool) config('koel.embed.enabled'),
             'supports_batch_downloading' => extension_loaded('zip'),
             'media_path_set' => (bool) Setting::get('media_path'),
             'supports_transcoding' =>

--- a/app/Http/Middleware/EnsureEmbedsEnabled.php
+++ b/app/Http/Middleware/EnsureEmbedsEnabled.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Container\Attributes\Config;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class EnsureEmbedsEnabled
+{
+    public function __construct(
+        #[Config('koel.embed.enabled')]
+        private readonly bool $enabled,
+    ) {}
+
+    /** @param Closure(Request): Response $next */
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (!$this->enabled) {
+            throw new NotFoundHttpException();
+        }
+
+        return $next($request);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -2,6 +2,7 @@
 
 use App\Exceptions\SubsonicAwareErrorRenderer;
 use App\Http\Middleware\AuthenticateAudioRequests;
+use App\Http\Middleware\EnsureEmbedsEnabled;
 use App\Http\Middleware\ForceHttps;
 use App\Http\Middleware\HandleDemoMode;
 use App\Http\Middleware\ObjectStorageAuthenticate;
@@ -46,6 +47,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->alias([
             'audio.auth' => AuthenticateAudioRequests::class,
             'os.auth' => ObjectStorageAuthenticate::class,
+            'embeds.enabled' => EnsureEmbedsEnabled::class,
         ]);
 
         // Koel is an SPA without a `login` route, so the Authenticate middleware would otherwise

--- a/config/koel.php
+++ b/config/koel.php
@@ -178,6 +178,10 @@ return [
         'enabled' => env('MEDIA_BROWSER_ENABLED', false),
     ],
 
+    'embed' => [
+        'enabled' => env('EMBED_ENABLED', true),
+    ],
+
     /*
      |--------------------------------------------------------------------------
      | Ignore Dot Files

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -177,3 +177,4 @@ Additional providers (Gemini, Ollama, etc.) can be configured in `config/ai.php`
 | `BACKUP_ON_DELETE` | Whether to create a backup of a song when deleting it from the filesystem. | `true` |
 | `CDN_URL` | A CDN URL mapped to Koel's home URL, used to serve media files. No trailing slash. | _(empty)_ |
 | `MEDIA_BROWSER_ENABLED` | Whether to enable the media browser (experimental Koel Plus feature). | `false` |
+| `EMBED_ENABLED` | Whether to allow embedding songs, albums, artists, and playlists on external sites. Set to `false` to hide the "Embed…" menu entries and disable both creation and rendering of embed widgets. | `true` |

--- a/resources/assets/js/__tests__/TestHarness.ts
+++ b/resources/assets/js/__tests__/TestHarness.ts
@@ -38,6 +38,7 @@ class TestHarness {
 
       commonStore.state.song_length = 10
       commonStore.state.allows_download = true
+      commonStore.state.allows_embedding = true
       commonStore.state.uses_i_tunes = true
       commonStore.state.supports_batch_downloading = true
       commonStore.state.supports_transcoding = true

--- a/resources/assets/js/components/album/AlbumContextMenu.spec.ts
+++ b/resources/assets/js/components/album/AlbumContextMenu.spec.ts
@@ -118,4 +118,11 @@ describe('albumContextMenu.vue', () => {
 
     await assertOpenModal(openModalMock, CreateEmbedForm, { embeddable: album })
   })
+
+  it('does not have an option to embed when embedding is disabled', async () => {
+    commonStore.state.allows_embedding = false
+    await renderComponent()
+
+    expect(screen.queryByText('Embed…')).toBeNull()
+  })
 })

--- a/resources/assets/js/components/album/AlbumContextMenu.vue
+++ b/resources/assets/js/components/album/AlbumContextMenu.vue
@@ -24,8 +24,10 @@
       <Separator />
       <MenuItem @click="toggleOffline">{{ allCached ? 'Remove Offline Versions' : 'Make Available Offline' }}</MenuItem>
     </template>
-    <Separator />
-    <MenuItem @click="showEmbedModal">Embed…</MenuItem>
+    <template v-if="allowEmbedding">
+      <Separator />
+      <MenuItem @click="showEmbedModal">Embed…</MenuItem>
+    </template>
   </ul>
 </template>
 
@@ -59,6 +61,7 @@ const { openModal } = useModal()
 const { currentUserCan } = usePolicies()
 
 const allowDownload = toRef(commonStore.state, 'allows_download')
+const allowEmbedding = toRef(commonStore.state, 'allows_embedding')
 const allowEdit = computed(() => currentUserCan.editAlbum(album.value))
 
 const isStandardAlbum = computed(() => !albumStore.isUnknown(album.value))

--- a/resources/assets/js/components/artist/ArtistContextMenu.spec.ts
+++ b/resources/assets/js/components/artist/ArtistContextMenu.spec.ts
@@ -108,4 +108,11 @@ describe('artistContextMenu.vue', () => {
 
     await assertOpenModal(openModalMock, CreateEmbedForm, { embeddable: artist })
   })
+
+  it('does not have an option to embed when embedding is disabled', async () => {
+    commonStore.state.allows_embedding = false
+    await renderComponent()
+
+    expect(screen.queryByText('Embed…')).toBeNull()
+  })
 })

--- a/resources/assets/js/components/artist/ArtistContextMenu.vue
+++ b/resources/assets/js/components/artist/ArtistContextMenu.vue
@@ -18,8 +18,10 @@
       <Separator />
       <MenuItem @click="download">Download</MenuItem>
     </template>
-    <Separator />
-    <MenuItem @click="showEmbedModal">Embed…</MenuItem>
+    <template v-if="allowEmbedding">
+      <Separator />
+      <MenuItem @click="showEmbedModal">Embed…</MenuItem>
+    </template>
   </ul>
 </template>
 
@@ -50,6 +52,7 @@ const { openModal } = useModal()
 const { currentUserCan } = usePolicies()
 
 const allowDownload = toRef(commonStore.state, 'allows_download')
+const allowEmbedding = toRef(commonStore.state, 'allows_embedding')
 const allowEdit = computed(() => currentUserCan.editArtist(artist.value))
 
 const isStandardArtist = computed(() => !artistStore.isUnknown(artist.value) && !artistStore.isVarious(artist.value))

--- a/resources/assets/js/components/playable/PlayableContextMenu.spec.ts
+++ b/resources/assets/js/components/playable/PlayableContextMenu.spec.ts
@@ -8,6 +8,7 @@ import { eventBus } from '@/utils/eventBus'
 import { screen, waitFor } from '@testing-library/vue'
 import { downloadService } from '@/services/downloadService'
 import { playbackService } from '@/services/QueuePlaybackService'
+import { commonStore } from '@/stores/commonStore'
 import { playlistStore } from '@/stores/playlistStore'
 import { queueStore } from '@/stores/queueStore'
 import { playableStore } from '@/stores/playableStore'
@@ -487,6 +488,13 @@ describe('playableContextMenu.vue', () => {
     await h.user.click(screen.getByText('Embed…'))
 
     await assertOpenModal(openModalMock, CreateEmbedForm, { embeddable: playables[0] })
+  })
+
+  it('does not have an option to embed when embedding is disabled', async () => {
+    commonStore.state.allows_embedding = false
+    await renderComponent(h.factory('song').make())
+
+    expect(screen.queryByText('Embed…')).toBeNull()
   })
 
   it('makes songs available offline', async () => {

--- a/resources/assets/js/components/playable/PlayableContextMenu.vue
+++ b/resources/assets/js/components/playable/PlayableContextMenu.vue
@@ -102,7 +102,7 @@
       </MenuItem>
     </template>
 
-    <MenuItem v-if="onlyOneSelected">
+    <MenuItem v-if="canShare">
       Share
       <template #subMenuItems>
         <MenuItem v-if="canBeShared" @click="copyUrl">
@@ -111,7 +111,7 @@
           </template>
           Copy URL
         </MenuItem>
-        <MenuItem @click="showEmbedModal">
+        <MenuItem v-if="allowEmbedding" @click="showEmbedModal">
           <template #icon>
             <Icon :icon="faCode" fixed-width />
           </template>
@@ -222,6 +222,8 @@ const firstSongPlaying = computed(() =>
 )
 const normalPlaylists = computed(() => playlists.value.filter(({ is_smart }) => !is_smart))
 const canBeShared = computed(() => !isPlus.value || (isSong(playables.value[0]) && playables.value[0].is_public))
+const allowEmbedding = computed(() => commonStore.state.allows_embedding)
+const canShare = computed(() => onlyOneSelected.value && (canBeShared.value || allowEmbedding.value))
 
 const makePublic = () =>
   trigger(async () => {

--- a/resources/assets/js/components/playable/PlayableContextMenu.vue
+++ b/resources/assets/js/components/playable/PlayableContextMenu.vue
@@ -222,7 +222,7 @@ const firstSongPlaying = computed(() =>
 )
 const normalPlaylists = computed(() => playlists.value.filter(({ is_smart }) => !is_smart))
 const canBeShared = computed(() => !isPlus.value || (isSong(playables.value[0]) && playables.value[0].is_public))
-const allowEmbedding = computed(() => commonStore.state.allows_embedding)
+const allowEmbedding = toRef(commonStore.state, 'allows_embedding')
 const canShare = computed(() => onlyOneSelected.value && (canBeShared.value || allowEmbedding.value))
 
 const makePublic = () =>

--- a/resources/assets/js/components/playlist/PlaylistContextMenu.spec.ts
+++ b/resources/assets/js/components/playlist/PlaylistContextMenu.spec.ts
@@ -4,6 +4,7 @@ import { assertOpenModal } from '@/__tests__/assertions'
 import factory from '@/__tests__/factory'
 import { MessageToasterStub } from '@/__tests__/stubs'
 import { screen, waitFor } from '@testing-library/vue'
+import { commonStore } from '@/stores/commonStore'
 import { queueStore } from '@/stores/queueStore'
 import { playableStore } from '@/stores/playableStore'
 import { userStore } from '@/stores/userStore'
@@ -220,5 +221,12 @@ describe('playlistContextMenu.vue', () => {
     await h.user.click(screen.getByText('Embed…'))
 
     await assertOpenModal(openModalMock, CreateEmbedForm, { embeddable: playlist })
+  })
+
+  it('does not have an option to embed when embedding is disabled', async () => {
+    commonStore.state.allows_embedding = false
+    await renderComponent(h.factory('playlist').make())
+
+    expect(screen.queryByText('Embed…')).toBeNull()
   })
 })

--- a/resources/assets/js/components/playlist/PlaylistContextMenu.vue
+++ b/resources/assets/js/components/playlist/PlaylistContextMenu.vue
@@ -3,10 +3,10 @@
     <MenuItem @click="play">Play</MenuItem>
     <MenuItem @click="shuffle">Shuffle</MenuItem>
     <MenuItem @click="addToQueue">Add to Queue</MenuItem>
-    <MenuItem>
+    <MenuItem v-if="canShare">
       Share
       <template #subMenuItems>
-        <MenuItem @click="showEmbedModal">Embed…</MenuItem>
+        <MenuItem v-if="allowEmbedding" @click="showEmbedModal">Embed…</MenuItem>
         <MenuItem v-if="canShowCollaboration" @click="showCollaborationModal">Collaborate…</MenuItem>
       </template>
     </MenuItem>
@@ -67,10 +67,12 @@ const { currentUserCan } = usePolicies()
 const { showConfirmDialog } = useDialogBox()
 
 const allowDownload = toRef(commonStore.state, 'allows_download')
+const allowEmbedding = toRef(commonStore.state, 'allows_embedding')
 
 const canEditPlaylist = computed(() => currentUserCan.editPlaylist(playlist.value))
 const canDeletePlaylist = computed(() => currentUserCan.deletePlaylist(playlist.value))
 const canShowCollaboration = computed(() => isPlus.value && !playlist.value?.is_smart)
+const canShare = computed(() => allowEmbedding.value || canShowCollaboration.value)
 
 const edit = () =>
   trigger(() => {

--- a/resources/assets/js/stores/commonStore.ts
+++ b/resources/assets/js/stores/commonStore.ts
@@ -11,6 +11,7 @@ import { userStore } from '@/stores/userStore'
 
 const initialState = {
   allows_download: false,
+  allows_embedding: true,
   assignable_roles: [] as Array<{ id: Role; label: string; description: string }>,
   download_limit: 0,
   cdn_url: '',

--- a/routes/api.base.php
+++ b/routes/api.base.php
@@ -106,8 +106,10 @@ Route::prefix('api')
             Route::get('invitations', [UserInvitationController::class, 'get']);
             Route::post('invitations/accept', [UserInvitationController::class, 'accept']);
 
-            Route::get('embeds/{embed}/{options}', [EmbedController::class, 'getPayload'])->name('embeds.payload');
-            Route::post('embed-options', [EmbedOptionsController::class, 'encrypt']);
+            Route::middleware('embeds.enabled')->group(static function (): void {
+                Route::get('embeds/{embed}/{options}', [EmbedController::class, 'getPayload'])->name('embeds.payload');
+                Route::post('embed-options', [EmbedOptionsController::class, 'encrypt']);
+            });
         });
 
         Route::middleware('auth')->group(static function (): void {
@@ -287,7 +289,9 @@ Route::prefix('api')
             Route::apiResource('themes', ThemeController::class)->except('show', 'update');
 
             // Embed routes
-            Route::post('embeds/resolve', [EmbedController::class, 'resolveForEmbeddable']);
+            Route::middleware('embeds.enabled')->group(static function (): void {
+                Route::post('embeds/resolve', [EmbedController::class, 'resolveForEmbeddable']);
+            });
         });
 
         // Object-storage (S3) routes

--- a/routes/web.base.php
+++ b/routes/web.base.php
@@ -65,7 +65,7 @@ Route::middleware('web')->group(static function (): void {
 
     Route::get('embeds/{embed}/stream/{song}/{options}', StreamEmbedController::class)->name(
         'embeds.stream',
-    )->middleware('signed', 'throttle:10,1');
+    )->middleware('embeds.enabled', 'signed', 'throttle:10,1');
 });
 
 Route::middleware('web')

--- a/tests/Feature/EmbedOptionsTest.php
+++ b/tests/Feature/EmbedOptionsTest.php
@@ -19,4 +19,16 @@ class EmbedOptionsTest extends TestCase
             ->assertSuccessful()
             ->assertJsonStructure(['encrypted']);
     }
+
+    #[Test]
+    public function encryptReturnsNotFoundWhenEmbeddingDisabled(): void
+    {
+        config(['koel.embed.enabled' => false]);
+
+        $this->post('api/embed-options', [
+            'theme' => 'cat',
+            'layout' => 'compact',
+            'preview' => true,
+        ])->assertNotFound();
+    }
 }

--- a/tests/Feature/EmbedTest.php
+++ b/tests/Feature/EmbedTest.php
@@ -66,4 +66,28 @@ class EmbedTest extends TestCase
 
         $this->getJson("api/embeds/{$embed->id}/$options")->assertNotFound();
     }
+
+    #[Test]
+    public function resolveReturnsNotFoundWhenEmbeddingDisabled(): void
+    {
+        config(['koel.embed.enabled' => false]);
+
+        $song = Song::factory()->createOne();
+
+        $this->postAs('api/embeds/resolve', [
+            'embeddable_id' => $song->id,
+            'embeddable_type' => 'playable',
+        ])->assertNotFound();
+    }
+
+    #[Test]
+    public function getPayloadReturnsNotFoundWhenEmbeddingDisabled(): void
+    {
+        config(['koel.embed.enabled' => false]);
+
+        $embed = Embed::factory()->createOne();
+        $options = EmbedOptions::make();
+
+        $this->getJson("api/embeds/{$embed->id}/$options")->assertNotFound();
+    }
 }

--- a/tests/Feature/InitialDataTest.php
+++ b/tests/Feature/InitialDataTest.php
@@ -21,6 +21,7 @@ class InitialDataTest extends TestCase
             'uses_media_browser',
             'uses_ticketmaster',
             'allows_download',
+            'allows_embedding',
             'supports_transcoding',
             'cdn_url',
             'current_version',


### PR DESCRIPTION
## Summary

Adds a plain boolean `EMBED_ENABLED` env var (default `true`, preserving current behavior) that lets admins disable the entire embed feature in one switch. Useful for installations where the operator does not want users sharing or embedding copyrighted content on external sites.

The toggle is **edition-agnostic** — both Community and Plus installations can use it.

## What changes when set to `false`

**Server**

A new `EnsureEmbedsEnabled` middleware, aliased as `embeds.enabled`, is attached to all four embed routes and returns `404` when disabled:

| Method | Route | Controller |
|---|---|---|
| `GET` | `/api/embeds/{embed}/{options}` | `EmbedController@getPayload` |
| `POST` | `/api/embed-options` | `EmbedOptionsController@encrypt` |
| `POST` | `/api/embeds/resolve` | `EmbedController@resolveForEmbeddable` |
| `GET` | `/embeds/{embed}/stream/{song}/{options}` | `StreamEmbedController` |

404 (not 403) is deliberate: existing embed URLs stop working too, not just new-embed creation. That's the right shape for a copyright kill switch — the feature looks genuinely absent.

**Client**

`FetchInitialDataController` ships an `allows_embedding` boolean on the boot payload. `commonStore` exposes it. The four context menus gate their "Embed…" entries:

- `PlayableContextMenu.vue` (song) — Share submenu collapses if both Copy URL and Embed are unavailable.
- `AlbumContextMenu.vue`, `ArtistContextMenu.vue` — the trailing separator + Embed item drop together.
- `PlaylistContextMenu.vue` — Share submenu collapses if both Embed and Collaborate (Plus) are unavailable.

## Tests

- `EmbedTest::resolveReturnsNotFoundWhenEmbeddingDisabled` and `getPayloadReturnsNotFoundWhenEmbeddingDisabled`.
- `EmbedOptionsTest::encryptReturnsNotFoundWhenEmbeddingDisabled`.
- `InitialDataTest` — new `allows_embedding` field in the asserted JSON structure.
- `Album/Artist/Playable/PlaylistContextMenu.spec.ts` each grow a `does not have an option to embed when embedding is disabled` case.
- `TestHarness.beforeEach` defaults `allows_embedding = true` next to the existing `allows_download = true` (mirroring the established pattern).

`composer cs`, `composer lint`, `composer analyze`, `vp check` all green locally. Full PHP suite 1448/1448.

## Docs

- `.env.example` — new `EMBED_ENABLED=true` block, documented inline.
- `docs/environment-variables.md` — table entry under Miscellaneous.

## Test plan

- [ ] With `EMBED_ENABLED=true` (default): all existing embed flows continue to work, no UI difference.
- [ ] With `EMBED_ENABLED=false`: "Embed…" entry disappears from song / album / artist / playlist context menus; the Share submenus collapse cleanly when they have nothing left to show; direct API hits to the four routes return 404; an existing embed URL (created when the flag was on) also returns 404 after the flag is flipped off.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to enable/disable embedding of songs, albums, artists, and playlists on external sites.
  * Initial app data now exposes whether embedding is allowed.

* **Bug Fixes / Behavior**
  * Embed-related endpoints and streaming routes are blocked when embedding is disabled.

* **Documentation**
  * Added docs explaining the new embedding control and its effects.

* **Tests**
  * Added tests verifying UI visibility and API responses when embedding is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->