### PR TITLE
feat: rate podcasts

### DIFF
--- a/app/Builders/PodcastBuilder.php
+++ b/app/Builders/PodcastBuilder.php
@@ -4,7 +4,9 @@ namespace App\Builders;
 
 use App\Builders\Concerns\CanScopeByUser;
 use App\Models\Podcast;
+use App\Models\User;
 use Illuminate\Database\Query\JoinClause;
+use Illuminate\Support\Facades\DB;
 use LogicException;
 
 /**
@@ -21,5 +23,25 @@ class PodcastBuilder extends FavoriteableBuilder
         return $this->join('podcast_user', function (JoinClause $join): void {
             $join->on('podcasts.id', 'podcast_user.podcast_id')->where('podcast_user.user_id', $this->user->id);
         });
+    }
+
+    public function withUserContext(User $user, bool $favoritesOnly = false): self
+    {
+        $this->user = $user;
+
+        return $this->withFavoriteStatus(favoritesOnly: $favoritesOnly)->withRatingSubquery();
+    }
+
+    private function withRatingSubquery(): self
+    {
+        throw_unless($this->user, new LogicException('User must be set to query podcast ratings.'));
+
+        return $this->addSelect([
+            'rating' => DB::table('ratings')
+                ->where('rateable_type', 'podcast')
+                ->where('user_id', $this->user->id)
+                ->whereColumn('rateable_id', 'podcasts.id')
+                ->selectRaw('COALESCE(MAX(rating), 0)'),
+        ]);
     }
 }

--- a/app/Http/Controllers/API/RatePodcastController.php
+++ b/app/Http/Controllers/API/RatePodcastController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\API\RateRequest;
+use App\Http\Resources\PodcastResource;
+use App\Models\Podcast;
+use App\Models\User;
+use App\Repositories\PodcastRepository;
+use App\Services\RatingService;
+use Illuminate\Contracts\Auth\Authenticatable;
+
+class RatePodcastController extends Controller
+{
+    public function __construct(
+        private readonly RatingService $ratingService,
+        private readonly PodcastRepository $podcastRepository,
+    ) {}
+
+    /** @param User $user */
+    public function __invoke(RateRequest $request, Podcast $podcast, Authenticatable $user)
+    {
+        $this->authorize('access', $podcast);
+
+        $this->ratingService->setRating($podcast, $user, $request->rating);
+
+        return PodcastResource::make($this->podcastRepository->getOne($podcast->id, $user));
+    }
+}

--- a/app/Http/Resources/PodcastResource.php
+++ b/app/Http/Resources/PodcastResource.php
@@ -39,7 +39,7 @@ class PodcastResource extends JsonResource
     public function toArray(Request $request): array
     {
         $data = [
-            'type' => 'podcast',
+            'type' => 'podcasts',
             'id' => $this->podcast->id,
             'url' => $this->podcast->url,
             'title' => $this->podcast->title,

--- a/app/Http/Resources/PodcastResource.php
+++ b/app/Http/Resources/PodcastResource.php
@@ -19,6 +19,8 @@ class PodcastResource extends JsonResource
         'link',
         'description',
         'author',
+        'favorite',
+        'rating',
     ];
 
     public function __construct(
@@ -46,6 +48,7 @@ class PodcastResource extends JsonResource
             'description' => $this->podcast->description,
             'author' => $this->podcast->author,
             'favorite' => $this->podcast->favorite,
+            'rating' => (int) ($this->podcast->rating ?? 0),
         ];
 
         if ($this->withSubscriptionData) {

--- a/app/Models/Podcast.php
+++ b/app/Models/Podcast.php
@@ -6,7 +6,9 @@ use App\Builders\PodcastBuilder;
 use App\Casts\Podcast\CategoriesCast;
 use App\Casts\Podcast\PodcastMetadataCast;
 use App\Models\Concerns\MorphsToFavorites;
+use App\Models\Concerns\MorphsToRatings;
 use App\Models\Contracts\Favoriteable;
+use App\Models\Contracts\Rateable;
 use App\Models\Song as Episode;
 use Carbon\Carbon;
 use Database\Factories\PodcastFactory;
@@ -43,11 +45,12 @@ use PhanAn\Poddle\Values\ChannelMetadata;
 #[UseEloquentBuilder(PodcastBuilder::class)]
 #[Unguarded]
 #[Hidden(['created_at', 'updated_at'])]
-class Podcast extends Model implements Favoriteable
+class Podcast extends Model implements Favoriteable, Rateable
 {
     use HasFactory;
     use HasUuids;
     use MorphsToFavorites;
+    use MorphsToRatings;
     use Searchable;
 
     protected function casts(): array

--- a/app/Repositories/PodcastRepository.php
+++ b/app/Repositories/PodcastRepository.php
@@ -6,6 +6,7 @@ use App\Models\Podcast;
 use App\Models\User;
 use App\Repositories\Contracts\ScoutableRepository;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Relations\Relation;
 
 /**
  * @extends Repository<Podcast>
@@ -24,7 +25,7 @@ class PodcastRepository extends Repository implements ScoutableRepository
         $user ??= $this->auth->user();
 
         return Podcast::query()
-            ->with(['subscribers' => static fn ($query) => $query->where('users.id', $user->id)])
+            ->with(['subscribers' => static fn (Relation $query) => $query->where('users.id', $user->id)])
             ->setScopedUser($user)
             ->withUserContext($user)
             ->findOrFail($id);
@@ -36,7 +37,7 @@ class PodcastRepository extends Repository implements ScoutableRepository
         $user ??= $this->auth->user();
 
         return Podcast::query()
-            ->with(['subscribers' => static fn ($query) => $query->where('users.id', $user->id)])
+            ->with(['subscribers' => static fn (Relation $query) => $query->where('users.id', $user->id)])
             ->setScopedUser($user)
             ->withUserContext($user, favoritesOnly: $favoritesOnly)
             ->subscribed()
@@ -49,7 +50,7 @@ class PodcastRepository extends Repository implements ScoutableRepository
         $user ??= $this->auth->user();
 
         $podcasts = Podcast::query()
-            ->with(['subscribers' => static fn ($query) => $query->where('users.id', $user->id)])
+            ->with(['subscribers' => static fn (Relation $query) => $query->where('users.id', $user->id)])
             ->setScopedUser($user)
             ->withUserContext($user)
             ->subscribed()

--- a/app/Repositories/PodcastRepository.php
+++ b/app/Repositories/PodcastRepository.php
@@ -18,6 +18,18 @@ class PodcastRepository extends Repository implements ScoutableRepository
         return $this->findOneBy(['url' => $url]);
     }
 
+    /** @param string $id */
+    public function getOne($id, ?User $user = null): Podcast
+    {
+        $user ??= $this->auth->user();
+
+        return Podcast::query()
+            ->with(['subscribers' => static fn ($query) => $query->where('users.id', $user->id)])
+            ->setScopedUser($user)
+            ->withUserContext($user)
+            ->findOrFail($id);
+    }
+
     /** @return Collection<int, Podcast> */
     public function getAllSubscribedByUser(bool $favoritesOnly, ?User $user = null): Collection
     {
@@ -26,7 +38,7 @@ class PodcastRepository extends Repository implements ScoutableRepository
         return Podcast::query()
             ->with(['subscribers' => static fn ($query) => $query->where('users.id', $user->id)])
             ->setScopedUser($user)
-            ->withFavoriteStatus(favoritesOnly: $favoritesOnly)
+            ->withUserContext($user, favoritesOnly: $favoritesOnly)
             ->subscribed()
             ->get();
     }
@@ -39,6 +51,7 @@ class PodcastRepository extends Repository implements ScoutableRepository
         $podcasts = Podcast::query()
             ->with(['subscribers' => static fn ($query) => $query->where('users.id', $user->id)])
             ->setScopedUser($user)
+            ->withUserContext($user)
             ->subscribed()
             ->whereIn('podcasts.id', $ids)
             ->distinct()

--- a/resources/assets/js/__tests__/factory/podcastFactory.ts
+++ b/resources/assets/js/__tests__/factory/podcastFactory.ts
@@ -13,6 +13,7 @@ export default (): Podcast => {
     subscribed_at: faker.date.past().toISOString(),
     last_played_at: faker.date.past().toISOString(),
     favorite: faker.datatype.boolean(),
+    rating: faker.number.int({ min: 0, max: 5 }),
     state: {
       current_episode: null,
       progresses: {},

--- a/resources/assets/js/components/podcast/PodcastContextMenu.vue
+++ b/resources/assets/js/components/podcast/PodcastContextMenu.vue
@@ -5,6 +5,14 @@
     <Separator />
     <MenuItem @click="toggleFavorite">{{ podcast.favorite ? 'Undo Favorite' : 'Favorite' }}</MenuItem>
     <Separator />
+    <li
+      tabindex="-1"
+      class="px-4 py-2 focus:outline-hidden"
+      @mouseover="($event.currentTarget as HTMLLIElement).focus()"
+    >
+      <StarRating :rateable="podcast" />
+    </li>
+    <Separator />
     <MenuItem @click="visitWebsite">Visit Website</MenuItem>
     <Separator />
     <MenuItem @click="unsubscribe">Unsubscribe</MenuItem>
@@ -21,6 +29,8 @@ import { podcastStore } from '@/stores/podcastStore'
 import { playback } from '@/services/playbackManager'
 import { useDialogBox } from '@/composables/useDialogBox'
 import { useMessageToaster } from '@/composables/useMessageToaster'
+
+import StarRating from '@/components/ui/StarRating.vue'
 
 const props = defineProps<{ podcast: Podcast }>()
 const { podcast } = toRefs(props)

--- a/resources/assets/js/components/podcast/PodcastItem.vue
+++ b/resources/assets/js/components/podcast/PodcastItem.vue
@@ -26,8 +26,8 @@
             />
           </h3>
           <p class="mt-2 flex items-center gap-2 flex-wrap">
-            <span>{{ podcast.author }}</span>
             <StarRating :rateable="podcast" size="xs" />
+            <span>{{ podcast.author }}</span>
             <template v-if="lastPlayedAt">
               <span>•</span>
               <span class="text-k-fg-50">

--- a/resources/assets/js/components/podcast/PodcastItem.vue
+++ b/resources/assets/js/components/podcast/PodcastItem.vue
@@ -18,18 +18,15 @@
         <header>
           <h3 class="text-3xl font-bold">
             {{ podcast.title }}
-            <FavoriteButton
-              v-if="podcast.favorite"
-              :favorite="podcast.favorite"
-              class="ml-2"
-              @toggle="toggleFavorite"
-            />
+            <span class="inline-flex items-center gap-2 align-middle text-base font-normal ml-2">
+              <FavoriteButton v-if="podcast.favorite" :favorite="podcast.favorite" @toggle="toggleFavorite" />
+              <StarRating v-if="podcast.rating" :rateable="podcast" size="xs" />
+            </span>
           </h3>
-          <p class="mt-2 flex items-center gap-2 flex-wrap">
-            <StarRating :rateable="podcast" size="xs" />
-            <span>{{ podcast.author }}</span>
+          <p class="mt-2">
+            {{ podcast.author }}
             <template v-if="lastPlayedAt">
-              <span>•</span>
+              •
               <span class="text-k-fg-50">
                 Last played
                 <time :datetime="podcast.last_played_at" :title="podcast.last_played_at">{{ lastPlayedAt }}</time>

--- a/resources/assets/js/components/podcast/PodcastItem.vue
+++ b/resources/assets/js/components/podcast/PodcastItem.vue
@@ -25,10 +25,11 @@
               @toggle="toggleFavorite"
             />
           </h3>
-          <p class="mt-2">
-            {{ podcast.author }}
+          <p class="mt-2 flex items-center gap-2 flex-wrap">
+            <span>{{ podcast.author }}</span>
+            <StarRating :rateable="podcast" size="xs" />
             <template v-if="lastPlayedAt">
-              •
+              <span>•</span>
               <span class="text-k-fg-50">
                 Last played
                 <time :datetime="podcast.last_played_at" :title="podcast.last_played_at">{{ lastPlayedAt }}</time>
@@ -49,6 +50,7 @@ import { formatTimeAgo } from '@vueuse/core'
 import { textToHsl } from '@/utils/formatters'
 import { useRouter } from '@/composables/useRouter'
 import WithGradientBorder from '@/components/ui/WithGradientBorder.vue'
+import StarRating from '@/components/ui/StarRating.vue'
 import { podcastStore } from '@/stores/podcastStore'
 import { useContextMenu } from '@/composables/useContextMenu'
 import { defineAsyncComponent } from '@/utils/helpers'

--- a/resources/assets/js/components/screens/PodcastScreen.vue
+++ b/resources/assets/js/components/screens/PodcastScreen.vue
@@ -43,14 +43,10 @@
 
             <ListFilter v-if="episodes?.length" />
 
-            <FavoriteButton
-              v-if="podcast.favorite"
-              :favorite="podcast.favorite"
-              class="px-3.5 py-2"
-              @toggle="toggleFavorite"
-            />
-
-            <StarRating :rateable="podcast" />
+            <span class="inline-flex gap-3.5 px-2">
+              <FavoriteButton v-if="podcast.favorite" :favorite="podcast.favorite" @toggle="toggleFavorite" />
+              <StarRating :rateable="podcast" />
+            </span>
 
             <Btn variant="ghost" @click="requestContextMenu">
               <Icon :icon="faEllipsis" fixed-width />

--- a/resources/assets/js/components/screens/PodcastScreen.vue
+++ b/resources/assets/js/components/screens/PodcastScreen.vue
@@ -50,6 +50,8 @@
               @toggle="toggleFavorite"
             />
 
+            <StarRating :rateable="podcast" />
+
             <Btn variant="ghost" @click="requestContextMenu">
               <Icon :icon="faEllipsis" fixed-width />
               <span class="sr-only">More Actions</span>
@@ -101,6 +103,7 @@ import EpisodeItem from '@/components/podcast/EpisodeItem.vue'
 import VirtualScroller from '@/components/ui/VirtualScroller.vue'
 import Btn from '@/components/ui/form/Btn.vue'
 import ListFilter from '@/components/ui/ListFilter.vue'
+import StarRating from '@/components/ui/StarRating.vue'
 import BtnGroup from '@/components/ui/form/BtnGroup.vue'
 import EpisodeItemSkeleton from '@/components/podcast/EpisodeItemSkeleton.vue'
 

--- a/resources/assets/js/components/ui/StarRating.spec.ts
+++ b/resources/assets/js/components/ui/StarRating.spec.ts
@@ -4,6 +4,7 @@ import { createHarness } from '@/__tests__/TestHarness'
 import { albumStore } from '@/stores/albumStore'
 import { artistStore } from '@/stores/artistStore'
 import { playableStore } from '@/stores/playableStore'
+import { podcastStore } from '@/stores/podcastStore'
 import Component from './StarRating.vue'
 
 describe('starRating.vue', () => {
@@ -70,6 +71,16 @@ describe('starRating.vue', () => {
     await h.user.click(screen.getByRole('radio', { name: 'Rate 3 of 5' }))
 
     expect(spy).toHaveBeenCalledWith(song, 3)
+  })
+
+  it('dispatches to podcastStore.rate when given a podcast rateable', async () => {
+    const podcast = h.factory('podcast').make({ rating: 0 })
+    const spy = vi.spyOn(podcastStore, 'rate').mockResolvedValue()
+
+    h.render(Component, { props: { rateable: podcast } })
+    await h.user.click(screen.getByRole('radio', { name: 'Rate 4 of 5' }))
+
+    expect(spy).toHaveBeenCalledWith(podcast, 4)
   })
 
   it('labels stars with their numeric value when they do not match the current rating', () => {

--- a/resources/assets/js/components/ui/StarRating.vue
+++ b/resources/assets/js/components/ui/StarRating.vue
@@ -37,8 +37,9 @@ import { computed, ref, useId } from 'vue'
 import { albumStore } from '@/stores/albumStore'
 import { artistStore } from '@/stores/artistStore'
 import { playableStore } from '@/stores/playableStore'
+import { podcastStore } from '@/stores/podcastStore'
 
-type Rateable = Song | Album | Artist
+type Rateable = Song | Album | Artist | Podcast
 
 const props = withDefaults(
   defineProps<{
@@ -66,6 +67,10 @@ const persist = (entity: Rateable, value: number) => {
 
   if (entity.type === 'albums') {
     return albumStore.rate(entity as Reactive<Album>, value)
+  }
+
+  if (entity.type === 'podcasts') {
+    return podcastStore.rate(entity as Reactive<Podcast>, value)
   }
 
   return artistStore.rate(entity as Reactive<Artist>, value)

--- a/resources/assets/js/components/ui/StarRating.vue
+++ b/resources/assets/js/components/ui/StarRating.vue
@@ -1,5 +1,5 @@
 <template>
-  <div
+  <span
     role="radiogroup"
     :aria-label="`Rating: ${currentRating} of 5 stars`"
     class="inline-flex items-center gap-0.5"
@@ -26,7 +26,7 @@
       <Icon :icon="(hover || currentRating) >= star ? faStar : faEmptyStar" :size="size" />
       <span class="sr-only">Rate {{ star }} of 5</span>
     </label>
-  </div>
+  </span>
 </template>
 
 <script lang="ts" setup>

--- a/resources/assets/js/stores/podcastStore.ts
+++ b/resources/assets/js/stores/podcastStore.ts
@@ -53,4 +53,23 @@ export const podcastStore = {
 
     podcast.favorite = Boolean(favorite)
   },
+
+  async rate(podcast: Reactive<Podcast>, rating: number) {
+    const previous = podcast.rating
+    podcast.rating = rating
+
+    try {
+      const updated = await http.put<Podcast>(`podcasts/${podcast.id}/rating`, { rating })
+
+      if (podcast.rating === rating) {
+        podcast.rating = updated.rating
+      }
+    } catch (error) {
+      if (podcast.rating === rating) {
+        podcast.rating = previous
+      }
+
+      throw error
+    }
+  },
 }

--- a/resources/assets/js/types.d.ts
+++ b/resources/assets/js/types.d.ts
@@ -367,6 +367,7 @@ interface Podcast {
     progresses: Record<Playable['id'], number>
   }
   favorite: boolean
+  rating: number // 0-5, current user's rating; 0 = unrated
 }
 
 interface YouTubeVideo {

--- a/routes/api.base.php
+++ b/routes/api.base.php
@@ -61,6 +61,7 @@ use App\Http\Controllers\API\RadioStationController;
 use App\Http\Controllers\API\RadioStationNowPlayingController;
 use App\Http\Controllers\API\RateAlbumController;
 use App\Http\Controllers\API\RateArtistController;
+use App\Http\Controllers\API\RatePodcastController;
 use App\Http\Controllers\API\RateSongController;
 use App\Http\Controllers\API\RegisterPlayController;
 use App\Http\Controllers\API\ResetPasswordController;
@@ -194,6 +195,7 @@ Route::prefix('api')
             Route::put('songs/{song}/rating', RateSongController::class)->where(['song' => Uuid::REGEX]);
             Route::put('albums/{album}/rating', RateAlbumController::class);
             Route::put('artists/{artist}/rating', RateArtistController::class);
+            Route::put('podcasts/{podcast}/rating', RatePodcastController::class)->where(['podcast' => Uuid::REGEX]);
 
             Route::apiResource('playlist-folders', PlaylistFolderController::class);
             Route::apiResource('playlist-folders.playlists', PlaylistFolderPlaylistController::class)->except(

--- a/tests/Feature/RatePodcastTest.php
+++ b/tests/Feature/RatePodcastTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\Podcast;
 use App\Models\Rating;
+use App\Models\User;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -11,7 +12,7 @@ use function Tests\create_user;
 
 class RatePodcastTest extends TestCase
 {
-    private function subscribedPodcast(\App\Models\User $user): Podcast
+    private function makeSubscribedPodcast(User $user): Podcast
     {
         $podcast = Podcast::factory()->createOne();
         $user->podcasts()->attach($podcast);
@@ -23,7 +24,7 @@ class RatePodcastTest extends TestCase
     public function ratesAPodcast(): void
     {
         $user = create_user();
-        $podcast = $this->subscribedPodcast($user);
+        $podcast = $this->makeSubscribedPodcast($user);
 
         $this
             ->putAs("api/podcasts/$podcast->id/rating", ['rating' => 4], $user)
@@ -43,7 +44,7 @@ class RatePodcastTest extends TestCase
     public function updatesAnExistingRating(): void
     {
         $user = create_user();
-        $podcast = $this->subscribedPodcast($user);
+        $podcast = $this->makeSubscribedPodcast($user);
 
         $this->putAs("api/podcasts/$podcast->id/rating", ['rating' => 2], $user)->assertOk();
         $this
@@ -58,7 +59,7 @@ class RatePodcastTest extends TestCase
     public function ratingZeroClearsExistingRating(): void
     {
         $user = create_user();
-        $podcast = $this->subscribedPodcast($user);
+        $podcast = $this->makeSubscribedPodcast($user);
         $this->putAs("api/podcasts/$podcast->id/rating", ['rating' => 3], $user)->assertOk();
 
         $this
@@ -101,7 +102,7 @@ class RatePodcastTest extends TestCase
     public function rejectsOutOfRangeRating(): void
     {
         $user = create_user();
-        $podcast = $this->subscribedPodcast($user);
+        $podcast = $this->makeSubscribedPodcast($user);
 
         $this->putAs("api/podcasts/$podcast->id/rating", ['rating' => 6], $user)->assertUnprocessable();
         $this->putAs("api/podcasts/$podcast->id/rating", ['rating' => -1], $user)->assertUnprocessable();
@@ -111,7 +112,7 @@ class RatePodcastTest extends TestCase
     public function rejectsMissingRating(): void
     {
         $user = create_user();
-        $podcast = $this->subscribedPodcast($user);
+        $podcast = $this->makeSubscribedPodcast($user);
 
         $this->putAs("api/podcasts/$podcast->id/rating", [], $user)->assertUnprocessable();
     }

--- a/tests/Feature/RatePodcastTest.php
+++ b/tests/Feature/RatePodcastTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Podcast;
+use App\Models\Rating;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+use function Tests\create_user;
+
+class RatePodcastTest extends TestCase
+{
+    private function subscribedPodcast(\App\Models\User $user): Podcast
+    {
+        $podcast = Podcast::factory()->createOne();
+        $user->podcasts()->attach($podcast);
+
+        return $podcast;
+    }
+
+    #[Test]
+    public function ratesAPodcast(): void
+    {
+        $user = create_user();
+        $podcast = $this->subscribedPodcast($user);
+
+        $this
+            ->putAs("api/podcasts/$podcast->id/rating", ['rating' => 4], $user)
+            ->assertOk()
+            ->assertJsonPath('id', $podcast->id)
+            ->assertJsonPath('rating', 4);
+
+        $this->assertDatabaseHas(Rating::class, [
+            'user_id' => $user->id,
+            'rateable_id' => $podcast->id,
+            'rateable_type' => $podcast->getMorphClass(),
+            'rating' => 4,
+        ]);
+    }
+
+    #[Test]
+    public function updatesAnExistingRating(): void
+    {
+        $user = create_user();
+        $podcast = $this->subscribedPodcast($user);
+
+        $this->putAs("api/podcasts/$podcast->id/rating", ['rating' => 2], $user)->assertOk();
+        $this
+            ->putAs("api/podcasts/$podcast->id/rating", ['rating' => 5], $user)
+            ->assertOk()
+            ->assertJsonPath('rating', 5);
+
+        self::assertSame(1, Rating::query()->where('user_id', $user->id)->count());
+    }
+
+    #[Test]
+    public function ratingZeroClearsExistingRating(): void
+    {
+        $user = create_user();
+        $podcast = $this->subscribedPodcast($user);
+        $this->putAs("api/podcasts/$podcast->id/rating", ['rating' => 3], $user)->assertOk();
+
+        $this
+            ->putAs("api/podcasts/$podcast->id/rating", ['rating' => 0], $user)
+            ->assertOk()
+            ->assertJsonPath('rating', 0);
+
+        self::assertSame(0, Rating::query()->where('user_id', $user->id)->count());
+    }
+
+    #[Test]
+    public function ratingPersistsScopedToUser(): void
+    {
+        $alice = create_user();
+        $bob = create_user();
+        $podcast = Podcast::factory()->createOne();
+        $alice->podcasts()->attach($podcast);
+
+        Rating::factory()->for($bob)->for($podcast, 'rateable')->createOne(['rating' => 1]);
+
+        $this
+            ->putAs("api/podcasts/$podcast->id/rating", ['rating' => 5], $alice)
+            ->assertOk()
+            ->assertJsonPath('rating', 5);
+
+        self::assertSame(5, $podcast->fresh()->getRatingFor($alice));
+        self::assertSame(1, $podcast->fresh()->getRatingFor($bob));
+    }
+
+    #[Test]
+    public function rejectsRatingForPodcastUserIsNotSubscribedTo(): void
+    {
+        $user = create_user();
+        $podcast = Podcast::factory()->createOne();
+
+        $this->putAs("api/podcasts/$podcast->id/rating", ['rating' => 4], $user)->assertForbidden();
+    }
+
+    #[Test]
+    public function rejectsOutOfRangeRating(): void
+    {
+        $user = create_user();
+        $podcast = $this->subscribedPodcast($user);
+
+        $this->putAs("api/podcasts/$podcast->id/rating", ['rating' => 6], $user)->assertUnprocessable();
+        $this->putAs("api/podcasts/$podcast->id/rating", ['rating' => -1], $user)->assertUnprocessable();
+    }
+
+    #[Test]
+    public function rejectsMissingRating(): void
+    {
+        $user = create_user();
+        $podcast = $this->subscribedPodcast($user);
+
+        $this->putAs("api/podcasts/$podcast->id/rating", [], $user)->assertUnprocessable();
+    }
+}

--- a/tests/Feature/RatePodcastTest.php
+++ b/tests/Feature/RatePodcastTest.php
@@ -12,7 +12,7 @@ use function Tests\create_user;
 
 class RatePodcastTest extends TestCase
 {
-    private function makeSubscribedPodcast(User $user): Podcast
+    private static function makeSubscribedPodcast(User $user): Podcast
     {
         $podcast = Podcast::factory()->createOne();
         $user->podcasts()->attach($podcast);
@@ -24,7 +24,7 @@ class RatePodcastTest extends TestCase
     public function ratesAPodcast(): void
     {
         $user = create_user();
-        $podcast = $this->makeSubscribedPodcast($user);
+        $podcast = self::makeSubscribedPodcast($user);
 
         $this
             ->putAs("api/podcasts/$podcast->id/rating", ['rating' => 4], $user)
@@ -44,7 +44,7 @@ class RatePodcastTest extends TestCase
     public function updatesAnExistingRating(): void
     {
         $user = create_user();
-        $podcast = $this->makeSubscribedPodcast($user);
+        $podcast = self::makeSubscribedPodcast($user);
 
         $this->putAs("api/podcasts/$podcast->id/rating", ['rating' => 2], $user)->assertOk();
         $this
@@ -59,7 +59,7 @@ class RatePodcastTest extends TestCase
     public function ratingZeroClearsExistingRating(): void
     {
         $user = create_user();
-        $podcast = $this->makeSubscribedPodcast($user);
+        $podcast = self::makeSubscribedPodcast($user);
         $this->putAs("api/podcasts/$podcast->id/rating", ['rating' => 3], $user)->assertOk();
 
         $this
@@ -102,7 +102,7 @@ class RatePodcastTest extends TestCase
     public function rejectsOutOfRangeRating(): void
     {
         $user = create_user();
-        $podcast = $this->makeSubscribedPodcast($user);
+        $podcast = self::makeSubscribedPodcast($user);
 
         $this->putAs("api/podcasts/$podcast->id/rating", ['rating' => 6], $user)->assertUnprocessable();
         $this->putAs("api/podcasts/$podcast->id/rating", ['rating' => -1], $user)->assertUnprocessable();
@@ -112,7 +112,7 @@ class RatePodcastTest extends TestCase
     public function rejectsMissingRating(): void
     {
         $user = create_user();
-        $podcast = $this->makeSubscribedPodcast($user);
+        $podcast = self::makeSubscribedPodcast($user);
 
         $this->putAs("api/podcasts/$podcast->id/rating", [], $user)->assertUnprocessable();
     }


### PR DESCRIPTION
## Summary

Extends the rating system to podcasts. Songs, albums, and artists already support 0–5 star ratings (#2536, #2539); podcasts now mirror the same shape end-to-end.

## What changed

**Backend** — mirrors the album/artist pattern verbatim:

- `Podcast` model now implements `Rateable` and uses `MorphsToRatings`.
- `PodcastBuilder::withUserContext($user, $favoritesOnly = false)` selects a rating subquery joined on `ratings.rateable_type = 'podcast'`. `getAllSubscribedByUser`, `getMany`, and the new `getOne($id, $user)` all route through it.
- `PodcastResource` exposes `rating` in its JSON structure.
- `RatePodcastController` (mirrors `RateAlbumController`) + `PUT /api/podcasts/{podcast}/rating` route, gated by the existing `access` policy (must be subscribed).

**Frontend**:

- `Podcast` TS type gains `rating: number` (0–5; 0 = unrated). Factory updated.
- `podcastStore.rate(podcast, rating)` — same optimistic-update + rollback shape as `albumStore.rate` / `artistStore.rate`.
- `StarRating` component dispatches to `podcastStore.rate` when the rateable's type is `'podcasts'`.
- StarRating rendered in `PodcastContextMenu` (the canonical setter, matching album/artist context menus) and in the `PodcastScreen` header next to FavoriteButton (at-a-glance read + quick click).

## Tests

- `tests/Feature/RatePodcastTest.php` (7 tests): rates / updates / clears / per-user isolation / forbids unsubscribed / out-of-range / missing.
- `StarRating.spec.ts`: new dispatch case for the podcast branch.

`composer cs && composer lint && composer analyze` clean. Full PHP suite 1468/1468.

## Test plan

- [ ] Subscribe to a podcast. Open its page or right-click; verify a 5-star control appears.
- [ ] Click a star → row updates optimistically; reload page → rating persists.
- [ ] Click the currently-selected star → rating clears (returns to 0).
- [ ] Verify another user's rating is independent (per-user persistence).
- [ ] Unsubscribed podcast → `PUT /api/podcasts/{id}/rating` returns 403.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can rate podcasts via a star-rating UI in listings, rows, context menus, and detail screens.
  * Ratings are sent to the server (authenticated endpoint) and persisted per user.

* **Behavior Changes**
  * Podcast API responses now include numeric rating and favorite flags.
  * Rating 0 clears a user’s rating; ratings are scoped to the requesting user and require subscription to the podcast owner.

* **Tests**
  * Feature tests added for rating creation, updates, clearing, scoping, and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->