### PR TITLE
fix: make no-hover variant actually apply on touch devices

### DIFF
--- a/resources/assets/css/app.pcss
+++ b/resources/assets/css/app.pcss
@@ -12,7 +12,7 @@
 
 @config "../../../tailwind.config.js";
 
-@custom-variant no-hover (&:where(@media (hover: none) *));
+@custom-variant no-hover (@media (hover: none));
 
 /*
   The default border color has changed to `currentcolor` in Tailwind CSS v4,


### PR DESCRIPTION
## Summary

The `no-hover` custom variant in `app.pcss` was defined with invalid syntax — Tailwind v4 silently dropped it, so every `no-hover:` utility across the codebase was a no-op on touch/hoverless devices. Confirmed by grepping all of `public/build/assets/*.css` for `hover: none` and finding zero matches.

Fix: rewrite the variant to the canonical Tailwind v4 form: `@custom-variant no-hover (@media (hover: none));`.

## Impact

Activates all 17 existing `no-hover:` usages across 12 files — overlays, favorite buttons, ratings, play buttons on album/artist/podcast/playable thumbnails; tooltip hiding; sidebar trigger hiding; side sheet scrolling; audio player highlight; playable list column toggling. All were intentional, dormant UX.

## Test plan

- [ ] Build CSS and grep for `hover: none` — expect non-zero matches
- [ ] In Chrome DevTools → Rendering panel → set "Emulate CSS media feature hover" to `none`, refresh
- [ ] Album/artist cards show overlay + favorite + rating + play button without hovering
- [ ] Song row thumbnails show dark overlay + play button without hovering
- [ ] Tooltips are hidden on touch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated CSS custom variant handling to improve compatibility with touch-enabled devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->