### PR TITLE
fix: prevent frontend test runs from breaking the dev server

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -57,26 +57,27 @@ export default defineConfig({
   plugins: [
     vue(),
     tailwindcss(),
-    laravel({
-      input: [
-        'resources/assets/js/app.ts',
-        'resources/assets/js/remote/app.ts'
-      ],
-      refresh: true
-    }),
-    visualizer({
-      filename: 'stats.html'
-    })
+    ...(process.env.VITEST
+      ? []
+      : [
+          laravel({
+            input: ['resources/assets/js/app.ts', 'resources/assets/js/remote/app.ts'],
+            refresh: true,
+          }),
+          visualizer({
+            filename: 'stats.html',
+          }),
+        ]),
   ],
   build: {
-    cssMinify: 'esbuild'
+    cssMinify: 'esbuild',
   },
   resolve: {
     alias: {
       '@': resolve(__dirname, './resources/assets/js'),
       '@modules': resolve(__dirname, './node_modules'),
-      'lodash': 'lodash-es'
-    }
+      lodash: 'lodash-es',
+    },
   },
   test: {
     environment: 'jsdom',
@@ -86,5 +87,5 @@ export default defineConfig({
         cacheDir: resolve(__dirname, 'node_modules/.vitest'),
       },
     },
-  }
+  },
 })


### PR DESCRIPTION
## Summary

Running `vp test` while `composer run dev` was active would silently revert the dev preview at `http://localhost:8000/` to the last production build — confusing because nothing in the test run *should* touch the dev server.

Root cause: `vite.config.ts` includes `laravel-vite-plugin` and `rollup-plugin-visualizer` in its `plugins` array. Vitest loads the same config when running tests, so those plugins instantiate alongside the test runner. `laravel-vite-plugin` writes / tears down `public/hot` as part of its dev-server lifecycle hooks; when the test process exits, `public/hot` is gone. Laravel's `@vite` directive then falls back to `public/build/manifest.json`, serving the last production build instead of the running dev server's modules.

Fix: scope both plugins behind `process.env.VITEST` so they only register outside of test mode. Vitest sets `VITEST=true` automatically on startup.

## Test plan

- [ ] Start `composer run dev`, confirm `http://localhost:8000/` serves fresh edits
- [ ] Run `npx vp test run` against any spec
- [ ] After test run, refresh `http://localhost:8000/` — still serves fresh edits (no revert)
- [ ] `public/hot` still exists after tests complete
- [ ] `pnpm run build` still produces a working production bundle (plugins still active for build mode)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to optimize plugin loading during testing and improve dependency resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->