### PR TITLE
fix: hide carousel scroll buttons when the track fits

### DIFF
--- a/resources/assets/js/components/ui/Carousel.spec.ts
+++ b/resources/assets/js/components/ui/Carousel.spec.ts
@@ -1,12 +1,20 @@
 import { describe, expect, it, vi } from 'vite-plus/test'
 import { screen, waitFor } from '@testing-library/vue'
+import { nextTick } from 'vue'
 import { createHarness } from '@/__tests__/TestHarness'
 import Component from './Carousel.vue'
+
+const setOverflow = async (scroller: HTMLDivElement, clientWidth: number, scrollWidth: number) => {
+  Object.defineProperty(scroller, 'clientWidth', { value: clientWidth, configurable: true })
+  Object.defineProperty(scroller, 'scrollWidth', { value: scrollWidth, configurable: true })
+  window.dispatchEvent(new Event('resize'))
+  await nextTick()
+}
 
 describe('carousel.vue', () => {
   const h = createHarness()
 
-  it('renders the header slot and both scroll buttons', () => {
+  it('renders the header slot and renders content', () => {
     h.render(Component, {
       slots: {
         header: 'Most Played',
@@ -15,9 +23,28 @@ describe('carousel.vue', () => {
     })
 
     screen.getByText('Most Played')
+    screen.getByTestId('card')
+  })
+
+  it('hides the scroll buttons when the track fits within the scroller', () => {
+    h.render(Component, {
+      slots: { header: 'Top', default: '<div data-testid="card">Card</div>' },
+    })
+
+    expect(screen.queryByRole('button', { name: 'Scroll left' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Scroll right' })).toBeNull()
+  })
+
+  it('shows the scroll buttons when the track overflows the scroller', async () => {
+    const { container } = h.render(Component, {
+      slots: { header: 'Top', default: '<div>Card</div>' },
+    })
+
+    const scroller = container.querySelector('.home-carousel') as HTMLDivElement
+    await setOverflow(scroller, 800, 3200)
+
     screen.getByRole('button', { name: 'Scroll left' })
     screen.getByRole('button', { name: 'Scroll right' })
-    screen.getByTestId('card')
   })
 
   it('slides right by the scroller width when the right chevron is clicked', async () => {
@@ -28,9 +55,8 @@ describe('carousel.vue', () => {
     const scroller = container.querySelector('.home-carousel') as HTMLDivElement
     const spy = vi.fn()
     scroller.scrollTo = spy as unknown as typeof scroller.scrollTo
-    Object.defineProperty(scroller, 'clientWidth', { value: 800, configurable: true })
-    Object.defineProperty(scroller, 'scrollWidth', { value: 3200, configurable: true })
     Object.defineProperty(scroller, 'scrollLeft', { value: 0, configurable: true, writable: true })
+    await setOverflow(scroller, 800, 3200)
 
     await h.user.click(screen.getByRole('button', { name: 'Scroll right' }))
 
@@ -45,9 +71,8 @@ describe('carousel.vue', () => {
     const scroller = container.querySelector('.home-carousel') as HTMLDivElement
     const spy = vi.fn()
     scroller.scrollTo = spy as unknown as typeof scroller.scrollTo
-    Object.defineProperty(scroller, 'clientWidth', { value: 800, configurable: true })
-    Object.defineProperty(scroller, 'scrollWidth', { value: 3200, configurable: true })
     Object.defineProperty(scroller, 'scrollLeft', { value: 1600, configurable: true, writable: true })
+    await setOverflow(scroller, 800, 3200)
 
     await h.user.click(screen.getByRole('button', { name: 'Scroll left' }))
 

--- a/resources/assets/js/components/ui/Carousel.vue
+++ b/resources/assets/js/components/ui/Carousel.vue
@@ -50,7 +50,7 @@
 
 <script setup lang="ts">
 import { faChevronLeft, faChevronRight, faRotateRight } from '@fortawesome/free-solid-svg-icons'
-import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { onBeforeUnmount, onMounted, onUpdated, ref, watch } from 'vue'
 
 const props = defineProps<{ onRefresh?: () => Promise<unknown> | unknown }>()
 
@@ -62,7 +62,7 @@ let resizeObserver: ResizeObserver | undefined
 
 const updateOverflow = () => {
   const el = scroller.value
-  hasOverflow.value = !!el && el.scrollWidth > el.clientWidth
+  hasOverflow.value = !!el && el.scrollWidth > el.clientWidth + 1
 }
 
 const observeOverflow = (el: HTMLDivElement | undefined) => {
@@ -83,6 +83,8 @@ onMounted(() => {
   observeOverflow(scroller.value)
   window.addEventListener('resize', updateOverflow)
 })
+
+onUpdated(updateOverflow)
 
 onBeforeUnmount(() => {
   resizeObserver?.disconnect()

--- a/resources/assets/js/components/ui/Carousel.vue
+++ b/resources/assets/js/components/ui/Carousel.vue
@@ -62,7 +62,13 @@ let resizeObserver: ResizeObserver | undefined
 
 const updateOverflow = () => {
   const el = scroller.value
-  hasOverflow.value = Boolean(el) && el.scrollWidth > el.clientWidth + 1
+
+  if (!el) {
+    hasOverflow.value = false
+    return
+  }
+
+  hasOverflow.value = el.scrollWidth > el.clientWidth + 1
 }
 
 const observeOverflow = (el: HTMLDivElement | undefined) => {

--- a/resources/assets/js/components/ui/Carousel.vue
+++ b/resources/assets/js/components/ui/Carousel.vue
@@ -62,7 +62,7 @@ let resizeObserver: ResizeObserver | undefined
 
 const updateOverflow = () => {
   const el = scroller.value
-  hasOverflow.value = !!el && el.scrollWidth > el.clientWidth + 1
+  hasOverflow.value = Boolean(el) && el.scrollWidth > el.clientWidth + 1
 }
 
 const observeOverflow = (el: HTMLDivElement | undefined) => {

--- a/resources/assets/js/components/ui/Carousel.vue
+++ b/resources/assets/js/components/ui/Carousel.vue
@@ -17,24 +17,26 @@
           <Icon :icon="faRotateRight" />
           <span class="sr-only">Refresh</span>
         </button>
-        <button
-          type="button"
-          class="w-9 h-9 rounded-full flex items-center justify-center text-k-fg-70 hover:text-k-fg hover:bg-k-fg-5 transition"
-          title="Scroll left"
-          @click="slide(-1)"
-        >
-          <Icon :icon="faChevronLeft" />
-          <span class="sr-only">Scroll left</span>
-        </button>
-        <button
-          type="button"
-          class="w-9 h-9 rounded-full flex items-center justify-center text-k-fg-70 hover:text-k-fg hover:bg-k-fg-5 transition"
-          title="Scroll right"
-          @click="slide(1)"
-        >
-          <Icon :icon="faChevronRight" />
-          <span class="sr-only">Scroll right</span>
-        </button>
+        <template v-if="hasOverflow">
+          <button
+            type="button"
+            class="w-9 h-9 rounded-full flex items-center justify-center text-k-fg-70 hover:text-k-fg hover:bg-k-fg-5 transition"
+            title="Scroll left"
+            @click="slide(-1)"
+          >
+            <Icon :icon="faChevronLeft" />
+            <span class="sr-only">Scroll left</span>
+          </button>
+          <button
+            type="button"
+            class="w-9 h-9 rounded-full flex items-center justify-center text-k-fg-70 hover:text-k-fg hover:bg-k-fg-5 transition"
+            title="Scroll right"
+            @click="slide(1)"
+          >
+            <Icon :icon="faChevronRight" />
+            <span class="sr-only">Scroll right</span>
+          </button>
+        </template>
       </nav>
     </header>
 
@@ -48,12 +50,42 @@
 
 <script setup lang="ts">
 import { faChevronLeft, faChevronRight, faRotateRight } from '@fortawesome/free-solid-svg-icons'
-import { ref } from 'vue'
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
 
 const props = defineProps<{ onRefresh?: () => Promise<unknown> | unknown }>()
 
 const scroller = ref<HTMLDivElement>()
 const refreshing = ref(false)
+const hasOverflow = ref(false)
+
+let resizeObserver: ResizeObserver | undefined
+
+const updateOverflow = () => {
+  const el = scroller.value
+  hasOverflow.value = !!el && el.scrollWidth > el.clientWidth
+}
+
+const observeOverflow = (el: HTMLDivElement | undefined) => {
+  resizeObserver?.disconnect()
+  resizeObserver = undefined
+  if (!el) {
+    return
+  }
+  resizeObserver = new ResizeObserver(updateOverflow)
+  resizeObserver.observe(el)
+  resizeObserver.observe(el.firstElementChild ?? el)
+  updateOverflow()
+}
+
+onMounted(() => {
+  observeOverflow(scroller.value)
+  window.addEventListener('resize', updateOverflow)
+})
+onBeforeUnmount(() => {
+  resizeObserver?.disconnect()
+  window.removeEventListener('resize', updateOverflow)
+})
+watch(scroller, observeOverflow)
 
 const slide = (direction: 1 | -1) => {
   const el = scroller.value

--- a/resources/assets/js/components/ui/Carousel.vue
+++ b/resources/assets/js/components/ui/Carousel.vue
@@ -86,6 +86,7 @@ onBeforeUnmount(() => {
   resizeObserver?.disconnect()
   window.removeEventListener('resize', updateOverflow)
 })
+
 watch(scroller, observeOverflow)
 
 const slide = (direction: 1 | -1) => {

--- a/resources/assets/js/components/ui/Carousel.vue
+++ b/resources/assets/js/components/ui/Carousel.vue
@@ -68,9 +68,11 @@ const updateOverflow = () => {
 const observeOverflow = (el: HTMLDivElement | undefined) => {
   resizeObserver?.disconnect()
   resizeObserver = undefined
+
   if (!el) {
     return
   }
+
   resizeObserver = new ResizeObserver(updateOverflow)
   resizeObserver.observe(el)
   resizeObserver.observe(el.firstElementChild ?? el)

--- a/resources/assets/js/components/ui/Carousel.vue
+++ b/resources/assets/js/components/ui/Carousel.vue
@@ -81,6 +81,7 @@ onMounted(() => {
   observeOverflow(scroller.value)
   window.addEventListener('resize', updateOverflow)
 })
+
 onBeforeUnmount(() => {
   resizeObserver?.disconnect()
   window.removeEventListener('resize', updateOverflow)


### PR DESCRIPTION
## Summary

`Carousel.vue` always rendered its prev/next chevrons, even when the carousel track fit entirely within the visible scroller (nothing to scroll to). On home screens with one or two items, the buttons were pure visual noise. Hide them when there's no overflow.

## Implementation

- New `hasOverflow` ref, computed from `scroller.scrollWidth > scroller.clientWidth`.
- Recompute on:
  - mount and scroller-ref change (initial load),
  - `ResizeObserver` callbacks (scroller or track size changes — viewport rotate, slot updates),
  - window `resize` events (belt-and-suspenders, also gives the spec a way to trigger detection without a real layout engine).
- Prev/next chevrons live behind `v-if="hasOverflow"`. Refresh button is independent of overflow and unaffected.
- Cleanup is tied to `onBeforeUnmount`: `ResizeObserver.disconnect()` + `removeEventListener('resize', …)`.

## Test plan

- [x] `npx vp test run resources/assets/js/components/ui/Carousel.spec.ts` — 8 tests pass (new: `hides the scroll buttons when the track fits`, `shows the scroll buttons when the track overflows`)
- [x] Manual: home screen with one carousel item → no chevrons. Resize the window narrow → chevrons appear once the track no longer fits. Reload with a full carousel → chevrons present.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Carousel navigation chevrons now appear only when horizontal scrolling is needed, improving visual clarity.
  * Overflow detection and resize handling are more robust and stay synced with content and window changes, preventing stale controls.

* **Tests**
  * Improved test coverage for scroll-button visibility and left/right slide interactions; overflow scenarios are explicitly validated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->