### PR TITLE
fix: shrink carousel overscroll mask on mobile

### DIFF
--- a/resources/assets/js/components/ui/Carousel.vue
+++ b/resources/assets/js/components/ui/Carousel.vue
@@ -83,6 +83,8 @@ const refresh = async () => {
 <style lang="postcss">
 .home-carousel {
   scrollbar-width: none;
+  --scroll-mask-fade-from-l: calc(100% - 40px);
+  --scroll-mask-fade-from-r: calc(100% - 40px);
 }
 
 .home-carousel::-webkit-scrollbar {

--- a/resources/assets/js/components/ui/Carousel.vue
+++ b/resources/assets/js/components/ui/Carousel.vue
@@ -40,7 +40,7 @@
 
     <div
       ref="scroller"
-      class="home-carousel scroll-mask-x-from-[calc(100%-1rem)] md:scroll-mask-x overflow-x-auto overflow-y-hidden w-full"
+      class="home-carousel scroll-mask-x-from-[calc(100%-2rem)] md:scroll-mask-x overflow-x-auto overflow-y-hidden w-full"
     >
       <div class="home-carousel-track flex gap-4">
         <slot />

--- a/resources/assets/js/components/ui/Carousel.vue
+++ b/resources/assets/js/components/ui/Carousel.vue
@@ -40,7 +40,7 @@
 
     <div
       ref="scroller"
-      class="home-carousel scroll-mask-x-from-[calc(100%-2rem)] overflow-x-auto overflow-y-hidden w-full"
+      class="home-carousel scroll-mask-x-from-[calc(100%-1rem)] md:scroll-mask-x overflow-x-auto overflow-y-hidden w-full"
     >
       <div class="home-carousel-track flex gap-4">
         <slot />

--- a/resources/assets/js/components/ui/Carousel.vue
+++ b/resources/assets/js/components/ui/Carousel.vue
@@ -38,7 +38,10 @@
       </nav>
     </header>
 
-    <div ref="scroller" class="home-carousel scroll-mask-x overflow-x-auto overflow-y-hidden w-full">
+    <div
+      ref="scroller"
+      class="home-carousel scroll-mask-x-from-[calc(100%-2rem)] overflow-x-auto overflow-y-hidden w-full"
+    >
       <div class="home-carousel-track flex gap-4">
         <slot />
       </div>
@@ -83,8 +86,6 @@ const refresh = async () => {
 <style lang="postcss">
 .home-carousel {
   scrollbar-width: none;
-  --scroll-mask-fade-from-l: calc(100% - 40px);
-  --scroll-mask-fade-from-r: calc(100% - 40px);
 }
 
 .home-carousel::-webkit-scrollbar {


### PR DESCRIPTION
## Summary

The carousel's overscroll mask uses `scroll-mask-x` (the percentage-based default — 20% of the scroller fades on each side when scrolled past the edge). On desktop the absolute fade region is comfortable; on a 375px phone, 20% is ~75px per side — way too much, eating most of the visible card.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved Carousel component styling to provide better horizontal scroll masking and overflow behavior, resulting in a cleaner visual edge and smoother scrolling across device sizes.
  * Minor template adjustments to support the updated presentation and responsiveness without altering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->