### PR TITLE
fix: avoid playlist factory name collisions in flaky tests

### DIFF
--- a/resources/assets/js/__tests__/factory/playlistFactory.ts
+++ b/resources/assets/js/__tests__/factory/playlistFactory.ts
@@ -7,7 +7,7 @@ export default (): Playlist => ({
   id: faker.string.uuid(),
   description: faker.lorem.sentence(),
   folder_id: faker.string.uuid(),
-  name: faker.word.sample(),
+  name: faker.word.words(2),
   is_smart: false,
   rules: [],
   is_collaborative: false,


### PR DESCRIPTION
## Summary

Frontend Unit Tests on master are flaky: `PlayableContextMenu.spec.ts > lists and adds to existing playlist` fails intermittently with `TestingLibraryElementError: Found multiple elements with the text: finally` ([failing master run](https://github.com/koel/koel/actions/runs/27066500320)).

## Root cause

`playlistFactory` generates each playlist's name with `faker.word.sample()` — a single word from faker's ~3000-word pool. Tests call `.make(3)`, so the chance of two playlists rolling the same single word is non-trivial (~1/1000 per pair). When that happens, the test queries `screen.getByText(playlists[0].name)` and `getByText` throws because the duplicate name matches multiple list items.

## Fix

Switch to `faker.word.words(2)` — two-word names like "drone gradient". Vocabulary squared makes the collision space go from ~3000 to ~3000² ≈ 9M, dropping collision odds below noise.

Two-word names also match the format already used by `liveEventFactory` (`faker.word.words()`), so it's consistent with sibling factories.

## Test plan

- [x] `npx vp test run resources/assets/js/components/playable/PlayableContextMenu.spec.ts resources/assets/js/components/playable/AddToMenu.spec.ts` — 49 tests pass
- [ ] CI Frontend Unit Tests green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test data generation for playlists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->