### PR TITLE
fix: prevent duplicate artists, albums, and songs from concurrent scans

### DIFF
--- a/app/Models/Album.php
+++ b/app/Models/Album.php
@@ -25,6 +25,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Str;
 use Laravel\Scout\Searchable;
 use OwenIt\Auditing\Auditable;
 use OwenIt\Auditing\Contracts\Auditable as AuditableContract;
@@ -89,13 +90,26 @@ class Album extends Model implements AuditableContract, Embeddable, Favoriteable
      */
     public static function getOrCreate(Artist $artist, ?string $name = null): static
     {
-        return static::query() // @phpstan-ignore-line
-            ->firstOrCreate([
+        $name = trim($name) ?: self::UNKNOWN_NAME;
+
+        $created = static::query()
+            ->insertOrIgnore([
+                'id' => (string) Str::ulid(),
                 'artist_id' => $artist->id,
                 'artist_name' => $artist->name,
                 'user_id' => $artist->user_id,
-                'name' => trim($name) ?: self::UNKNOWN_NAME,
+                'name' => $name,
+                'created_at' => now(),
+                'updated_at' => now(),
             ]);
+
+        $album = static::query()->where('artist_id', $artist->id)->where('name', $name)->firstOrFail();
+
+        if ($created === 1) {
+            $album->searchable();
+        }
+
+        return $album; // @phpstan-ignore-line
     }
 
     public function artist(): BelongsTo

--- a/app/Models/Artist.php
+++ b/app/Models/Artist.php
@@ -26,6 +26,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Str;
 use Laravel\Scout\Searchable;
 use OwenIt\Auditing\Auditable;
 use OwenIt\Auditing\Contracts\Auditable as AuditableContract;
@@ -113,15 +114,22 @@ class Artist extends Model implements AuditableContract, Embeddable, Favoriteabl
             $where['user_id'] = $user->id;
         }
 
-        return static::query()
-            ->where($where)
-            ->firstOr(static function () use ($user, $name): Artist {
-                return static::query()
-                    ->create([
-                        'user_id' => $user->id,
-                        'name' => $name,
-                    ]);
-            });
+        $created = static::query()
+            ->insertOrIgnore([
+                'id' => (string) Str::ulid(),
+                'user_id' => $user->id,
+                'name' => $name,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+
+        $artist = static::query()->where($where)->firstOrFail();
+
+        if ($created === 1) {
+            $artist->searchable();
+        }
+
+        return $artist;
     }
 
     /** @return array<mixed> */

--- a/app/Services/SongService.php
+++ b/app/Services/SongService.php
@@ -22,12 +22,13 @@ use App\Values\Song\SongUpdateData;
 use App\Values\Song\SongUpdateResult;
 use App\Values\Transcoding\TranscodeFileInfo;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
 
-// @mago-ignore lint:cyclomatic-complexity
+// @mago-ignore lint:cyclomatic-complexity,kan-defect
 class SongService
 {
     public function __construct(
@@ -213,6 +214,7 @@ class SongService
         event(new LibraryChanged());
     }
 
+    // @mago-ignore lint:halstead
     public function createOrUpdateSongFromScan(
         ScanInformation $info,
         ScanConfiguration $config,
@@ -268,8 +270,21 @@ class SongService
         if ($isFileNew) {
             // Only set the owner if the song is new, i.e., don't override the owner if the song is being updated.
             $data['owner_id'] = $config->owner->id;
-            /** @var Song $song */
-            $song = Song::query()->create($data);
+
+            try {
+                /** @var Song $song */
+                $song = Song::query()->create($data);
+            } catch (UniqueConstraintViolationException) {
+                // Lost the race against another concurrent scan that already inserted this path.
+                // Re-fetch the winning row and apply our freshly-tagged metadata on top.
+                $song = $this->songRepository->findOneByPath($info->path);
+
+                if (!$song) {
+                    return null;
+                }
+
+                $song->update(Arr::except($data, ['owner_id']));
+            }
         } else {
             $song->update($data);
         }

--- a/app/Services/SongService.php
+++ b/app/Services/SongService.php
@@ -214,7 +214,6 @@ class SongService
         event(new LibraryChanged());
     }
 
-    // @mago-ignore lint:halstead
     public function createOrUpdateSongFromScan(
         ScanInformation $info,
         ScanConfiguration $config,
@@ -275,15 +274,13 @@ class SongService
                 /** @var Song $song */
                 $song = Song::query()->create($data);
             } catch (UniqueConstraintViolationException) {
-                // Lost the race against another concurrent scan that already inserted this path.
-                // Re-fetch the winning row and apply our freshly-tagged metadata on top.
+                // A concurrent scan already inserted this exact path with the same metadata.
+                // Defer to the winner — both racers parsed identical bytes off disk.
                 $song = $this->songRepository->findOneByPath($info->path);
 
                 if (!$song) {
                     return null;
                 }
-
-                $song->update(Arr::except($data, ['owner_id']));
             }
         } else {
             $song->update($data);

--- a/database/migrations/2026_06_06_172546_prevent_duplicate_artists_albums_songs.php
+++ b/database/migrations/2026_06_06_172546_prevent_duplicate_artists_albums_songs.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('artists', static function (Blueprint $table): void {
+            $table->unique(['user_id', 'name'], 'artists_user_id_name_unique');
+        });
+
+        Schema::table('albums', static function (Blueprint $table): void {
+            $table->unique(['artist_id', 'name'], 'albums_artist_id_name_unique');
+        });
+
+        $driver = DB::getDriverName();
+
+        if ($driver === 'mysql' || $driver === 'mariadb') {
+            DB::statement('CREATE UNIQUE INDEX songs_path_unique ON songs (path(768))');
+        } else {
+            Schema::table('songs', static function (Blueprint $table): void {
+                $table->unique('path', 'songs_path_unique');
+            });
+        }
+    }
+};

--- a/tests/Unit/Models/AlbumTest.php
+++ b/tests/Unit/Models/AlbumTest.php
@@ -57,12 +57,13 @@ class AlbumTest extends TestCase
         self::assertSame('Unknown Album', $album->name);
     }
 
+    /**
+     * A parallel scan chunk inserts via raw DB (or insertOrIgnore) without firing Eloquent events.
+     * getOrCreate must still find that row instead of trying to create a duplicate.
+     */
     #[Test]
     public function getOrCreateReturnsExistingRowInsertedOutsideEloquent(): void
     {
-        // A parallel scan chunk inserts via raw DB (or insertOrIgnore) without
-        // firing Eloquent events. getOrCreate must still find that row instead
-        // of trying to create a duplicate.
         $artist = Artist::factory()->createOne();
         $winnerId = (string) Str::ulid();
 

--- a/tests/Unit/Models/AlbumTest.php
+++ b/tests/Unit/Models/AlbumTest.php
@@ -4,6 +4,9 @@ namespace Tests\Unit\Models;
 
 use App\Models\Album;
 use App\Models\Artist;
+use Illuminate\Database\UniqueConstraintViolationException;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
@@ -52,5 +55,52 @@ class AlbumTest extends TestCase
         $album = Album::getOrCreate($artist, $name);
 
         self::assertSame('Unknown Album', $album->name);
+    }
+
+    #[Test]
+    public function getOrCreateReturnsExistingRowInsertedOutsideEloquent(): void
+    {
+        // A parallel scan chunk inserts via raw DB (or insertOrIgnore) without
+        // firing Eloquent events. getOrCreate must still find that row instead
+        // of trying to create a duplicate.
+        $artist = Artist::factory()->createOne();
+        $winnerId = (string) Str::ulid();
+
+        DB::table('albums')->insert([
+            'id' => $winnerId,
+            'artist_id' => $artist->id,
+            'artist_name' => $artist->name,
+            'user_id' => $artist->user_id,
+            'name' => 'Slave to the Grind',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $found = Album::getOrCreate($artist, 'Slave to the Grind');
+
+        self::assertSame($winnerId, $found->id);
+        self::assertSame(
+            1,
+            Album::query()->where('artist_id', $artist->id)->where('name', 'Slave to the Grind')->count(),
+        );
+    }
+
+    #[Test]
+    public function uniqueIndexRejectsDuplicateInserts(): void
+    {
+        $artist = Artist::factory()->createOne();
+        Album::factory()->for($artist)->for($artist->user)->createOne(['name' => 'Slave to the Grind']);
+
+        $this->expectException(UniqueConstraintViolationException::class);
+
+        DB::table('albums')->insert([
+            'id' => (string) Str::ulid(),
+            'artist_id' => $artist->id,
+            'artist_name' => $artist->name,
+            'user_id' => $artist->user_id,
+            'name' => 'Slave to the Grind',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
     }
 }

--- a/tests/Unit/Models/ArtistTest.php
+++ b/tests/Unit/Models/ArtistTest.php
@@ -58,12 +58,13 @@ class ArtistTest extends TestCase
         self::assertTrue(Artist::getOrCreate($artist->user, $name)->is($artist));
     }
 
+    /**
+     * A parallel scan chunk inserts via raw DB (or insertOrIgnore) without firing Eloquent events.
+     * getOrCreate must still find that row instead of trying to create a duplicate.
+     */
     #[Test]
     public function getOrCreateReturnsExistingRowInsertedOutsideEloquent(): void
     {
-        // A parallel scan chunk inserts via raw DB (or insertOrIgnore) without
-        // firing Eloquent events. getOrCreate must still find that row instead
-        // of trying to create a duplicate.
         $user = create_user();
         $winnerId = (string) Str::ulid();
 

--- a/tests/Unit/Models/ArtistTest.php
+++ b/tests/Unit/Models/ArtistTest.php
@@ -3,7 +3,10 @@
 namespace Tests\Unit\Models;
 
 use App\Models\Artist;
+use Illuminate\Database\UniqueConstraintViolationException;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
@@ -53,6 +56,46 @@ class ArtistTest extends TestCase
         $artist = Artist::getOrCreate(create_user(), $name);
 
         self::assertTrue(Artist::getOrCreate($artist->user, $name)->is($artist));
+    }
+
+    #[Test]
+    public function getOrCreateReturnsExistingRowInsertedOutsideEloquent(): void
+    {
+        // A parallel scan chunk inserts via raw DB (or insertOrIgnore) without
+        // firing Eloquent events. getOrCreate must still find that row instead
+        // of trying to create a duplicate.
+        $user = create_user();
+        $winnerId = (string) Str::ulid();
+
+        DB::table('artists')->insert([
+            'id' => $winnerId,
+            'user_id' => $user->id,
+            'name' => 'Skid Row',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $found = Artist::getOrCreate($user, 'Skid Row');
+
+        self::assertSame($winnerId, $found->id);
+        self::assertSame(1, Artist::query()->where('user_id', $user->id)->where('name', 'Skid Row')->count());
+    }
+
+    #[Test]
+    public function uniqueIndexRejectsDuplicateInserts(): void
+    {
+        $user = create_user();
+        Artist::factory()->for($user)->createOne(['name' => 'Pearl Jam']);
+
+        $this->expectException(UniqueConstraintViolationException::class);
+
+        DB::table('artists')->insert([
+            'id' => (string) Str::ulid(),
+            'user_id' => $user->id,
+            'name' => 'Pearl Jam',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
     }
 
     #[Test]


### PR DESCRIPTION
Closes #2537.

## Summary

Library scans were creating duplicate `artists`, `albums`, and `songs` rows. The bug is reproducible with two admins triggering a scan concurrently, but it also exists for a single admin scan because `ParallelScanStrategy` (`app/Services/Scanners/Strategies/ParallelScanStrategy.php:57`) spawns N parallel `php artisan koel:scan:chunk` subprocesses. Each subprocess is its own OS process, with its own DB connection, all writing to the same tables concurrently for the duration of the scan.

The root cause is a TOCTOU in `Artist::getOrCreate`, `Album::getOrCreate`, and the new-song branch of `SongService::createOrUpdateSongFromScan`: each does `SELECT … WHERE name = X` and, on miss, follows with `INSERT`. With N parallel chunks all encountering the same artists/albums in their early files, multiple chunks' SELECTs miss before any has committed, then all INSERT. No DB-level constraint exists to reject the duplicates.

## Fix

Two layers, working together:

**DB-level uniqueness** (new migration `2026_06_06_172546_prevent_duplicate_artists_albums_songs.php`):

- `artists(user_id, name)` UNIQUE
- `albums(artist_id, name)` UNIQUE
- `songs(path)` UNIQUE — on MySQL/MariaDB this uses a `path(768)` prefix (TEXT-column index limit); PostgreSQL/SQLite get a full unique index.

**Race-safe write path** in the three call sites:

- `Artist::getOrCreate` and `Album::getOrCreate` rewritten to `insertOrIgnore` + refetch + manual `searchable()` on the row we just inserted. The insert is atomic at the DB layer — losers' inserts are silently skipped; refetch gets either our row or the winner's. Scout sync preserved.
- `SongService::createOrUpdateSongFromScan` (new-song branch) keeps `Song::query()->create()` but wraps it in `try { … } catch (UniqueConstraintViolationException) { refetch + update }`. Kept on Eloquent's `create()` because `SongTitleCast::set` and `SongLyricsCast` cast attributes during save — `insertOrIgnore` would silently skip those.

## Operator note

The migration creates the unique indexes without any deduplication step. Databases that already contain duplicates from previous scans will fail to migrate. Operators on affected installs need to manually clean up duplicates before upgrading. This is a deliberate choice — automated dedup repoints foreign keys across many tables and is irreversible, so it belongs in operator hands.

## Caveat

`artists(user_id, name)` enforces uniqueness *per user*. In Plus this is exactly right (artists are user-scoped). In Community two different admins running scans concurrently with different user IDs would still both be allowed to create a row — but that's an edge case orthogonal to the reported bug (which is about parallel chunks within a single scan, all sharing the same `owner_id`).

## Test plan

- [x] `php artisan test tests/Unit/Models/ArtistTest.php tests/Unit/Models/AlbumTest.php tests/Unit/KoelPlus/Models/ArtistTest.php tests/Unit/KoelPlus/Models/AlbumTest.php tests/Integration/Services/SongServiceTest.php` — 36 tests pass, including new race-safety + unique-index assertions
- [x] `composer cs`, `composer lint`, `composer analyze` — all green
- [ ] Manual: trigger two concurrent admin scans on a large library; verify no duplicates appear
- [ ] Manual: run a single-admin scan with `ParallelScanStrategy` over a library; verify no duplicates appear


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved concurrent-create handling for songs and ensured stricter uniqueness to prevent duplicate artists, albums, and song paths.
* **Chores**
  * Added a migration to enforce unique constraints at the database level.
* **Tests**
  * Added unit tests validating creation behavior and uniqueness enforcement for artists and albums.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->