### PR TITLE
fix: make ScreenHeaderSkeleton responsive on mobile

### DIFF
--- a/resources/assets/js/components/ui/ScreenHeaderSkeleton.vue
+++ b/resources/assets/js/components/ui/ScreenHeaderSkeleton.vue
@@ -1,11 +1,13 @@
 <template>
-  <header class="skeleton screen-header expanded flex items-end relative content-stretch p-8">
-    <aside class="w-[192px] aspect-square rounded-lg block mr-5 pulse" />
+  <header
+    class="skeleton screen-header expanded gap-4 min-h-0 md:min-h-full flex items-end shrink-0 relative content-stretch p-6 border-b border-b-k-fg-5"
+  >
+    <aside class="hidden md:block w-[192px] aspect-square rounded-lg pulse" />
 
-    <main class="flex flex-col items-start flex-1 gap-5">
-      <h1 class="h-16 w-4/5 pulse" />
+    <main class="flex flex-col items-start flex-1 gap-3 md:gap-5">
+      <h1 class="h-[clamp(1.8rem,3vw,4rem)] w-4/5 pulse" />
       <p class="meta h-[1.2rem] w-2/5 pulse" />
-      <p class="controls h-10 rounded-sm w-1/4 pulse" />
+      <p class="controls h-8 md:h-10 rounded-sm w-1/3 md:w-1/4 pulse" />
     </main>
   </header>
 </template>

--- a/resources/assets/js/components/ui/__snapshots__/ScreenHeaderSkeleton.spec.ts.snap
+++ b/resources/assets/js/components/ui/__snapshots__/ScreenHeaderSkeleton.spec.ts.snap
@@ -1,12 +1,12 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`ScreenHeaderSkeleton > renders correctly 1`] = `
-<header class="skeleton screen-header expanded flex items-end relative content-stretch p-8">
-  <aside class="w-[192px] aspect-square rounded-lg block mr-5 pulse"></aside>
-  <main class="flex flex-col items-start flex-1 gap-5">
-    <h1 class="h-16 w-4/5 pulse"></h1>
+<header class="skeleton screen-header expanded gap-4 min-h-0 md:min-h-full flex items-end shrink-0 relative content-stretch p-6 border-b border-b-k-fg-5">
+  <aside class="hidden md:block w-[192px] aspect-square rounded-lg pulse"></aside>
+  <main class="flex flex-col items-start flex-1 gap-3 md:gap-5">
+    <h1 class="h-[clamp(1.8rem,3vw,4rem)] w-4/5 pulse"></h1>
     <p class="meta h-[1.2rem] w-2/5 pulse"></p>
-    <p class="controls h-10 rounded-sm w-1/4 pulse"></p>
+    <p class="controls h-8 md:h-10 rounded-sm w-1/3 md:w-1/4 pulse"></p>
   </main>
 </header>
 `;


### PR DESCRIPTION
## Summary

`ScreenHeaderSkeleton.vue` rendered identically at every viewport — a fixed 192px thumbnail square, a 64px-tall title bar, and `p-8` padding — while the real `ScreenHeader.vue` it stands in for collapses substantially on mobile (thumbnail hidden, title font-size `clamp(1.8rem, 3vw, 4rem)`, `p-6`). The skeleton therefore looked out of place on phones during loading: oversized thumbnail block and an oversized title placeholder that didn't match what the real header was about to settle into.

## Changes

Mirror `ScreenHeader.vue`'s responsive shape on `ScreenHeaderSkeleton.vue`:

- **Root**: `gap-4 min-h-0 md:min-h-full p-6 border-b border-b-k-fg-5 shrink-0` (was `p-8`, no responsive min-height, no bottom border).
- **Thumbnail aside**: `hidden md:block` so the 192px square doesn't appear on mobile, matching the real header's `hidden md:flex`. Dropped the manual `mr-5` since the root's `gap-4` handles spacing.
- **Title placeholder**: `h-[clamp(1.8rem,3vw,4rem)]` instead of the hardcoded `h-16`. Same clamp curve the real header uses for its font-size.
- **Main gap**: `gap-3 md:gap-5` so the spacing doesn't feel airy when the title shrinks.
- **Controls placeholder**: `h-8 md:h-10 w-1/3 md:w-1/4` so the controls box scales down with everything else.

## Test plan

- [x] `npx vp test run resources/assets/js/components/ui/ScreenHeaderSkeleton.spec.ts` — snapshot refreshed, 1 passing
- [x] `npx vp check resources/assets/js/components/ui/ScreenHeaderSkeleton.vue` — format + lint clean
- [ ] Manual: load any screen with a `ScreenHeader` (Album, Artist, Playlist) on a narrow viewport during the loading state. Skeleton should match the actual header's compact mobile form, not the desktop form.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved skeleton loading screen layout and responsiveness for better visual consistency across devices. Enhanced spacing and sizing adjustments for a more polished loading experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->