### PR TITLE
refactor: auto-hash user passwords via Eloquent cast

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -51,7 +51,7 @@ use Spatie\Permission\Traits\HasRoles;
  * @property string $email
  * @property string $name
  * @property string $organization_id
- * @property string $password
+ * @property ?string $password
  * @property string $public_id
  * @property-read ?string $sso_id
  * @property-read ?string $sso_provider
@@ -113,6 +113,7 @@ class User extends Authenticatable implements AuditableContract
     protected function casts(): array
     {
         return [
+            'password' => 'hashed',
             'preferences' => UserPreferencesCast::class,
             'subsonic_api_key' => 'encrypted',
             'two_factor_secret' => 'encrypted',

--- a/app/Repositories/UserRepository.php
+++ b/app/Repositories/UserRepository.php
@@ -8,7 +8,6 @@ use App\Enums\Acl\Role as RoleEnum;
 use App\Models\Organization;
 use App\Models\User;
 use App\Values\User\SsoUser;
-use Illuminate\Support\Facades\Hash;
 use SensitiveParameter;
 
 /**
@@ -29,7 +28,7 @@ class UserRepository extends Repository
                 $user = User::query()->create([
                     'email' => User::FIRST_ADMIN_EMAIL,
                     'name' => User::FIRST_ADMIN_NAME,
-                    'password' => Hash::make(User::FIRST_ADMIN_PASSWORD),
+                    'password' => User::FIRST_ADMIN_PASSWORD,
                     'organization_id' => $defaultOrganization->id,
                 ]);
 

--- a/app/Services/Auth/AuthenticationService.php
+++ b/app/Services/Auth/AuthenticationService.php
@@ -32,7 +32,7 @@ class AuthenticationService
         throw_unless($user && Hash::check($password, $user->password), InvalidCredentialsException::class);
 
         if (Hash::needsRehash($user->password)) {
-            $user->password = Hash::make($password);
+            $user->password = $password;
             $user->save();
         }
 
@@ -105,7 +105,7 @@ class AuthenticationService
             #[SensitiveParameter]
             string $password,
         ): void {
-            $user->password = Hash::make($password);
+            $user->password = $password;
             $user->save();
             event(new PasswordReset($user));
         });

--- a/app/Services/UserInvitationService.php
+++ b/app/Services/UserInvitationService.php
@@ -10,7 +10,6 @@ use App\Models\User;
 use App\Repositories\UserRepository;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Mail;
 use SensitiveParameter;
 
@@ -81,7 +80,7 @@ class UserInvitationService
 
         $user->update(attributes: [
             'name' => $name,
-            'password' => Hash::make($password),
+            'password' => $password,
             'invitation_token' => null,
             'invitation_accepted_at' => now(),
         ]);

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -68,7 +68,7 @@ class UserService
         $data = [
             'name' => $dto->name,
             'email' => $dto->email,
-            'password' => $dto->password ?: $user->password,
+            'password' => $dto->password ?? $user->password,
             'avatar' => $dto->avatar ? $this->maybeStoreAvatar($dto->avatar) : null,
         ];
 

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -12,7 +12,6 @@ use App\Values\User\SsoUser;
 use App\Values\User\UserCreateData;
 use App\Values\User\UserUpdateData;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 use SensitiveParameter;
 
@@ -57,7 +56,7 @@ class UserService
 
     public function changePassword(User $user, #[SensitiveParameter] string $newPassword): void
     {
-        $user->password = Hash::make($newPassword);
+        $user->password = $newPassword;
         $user->save();
     }
 

--- a/app/Values/User/UserCreateData.php
+++ b/app/Values/User/UserCreateData.php
@@ -4,12 +4,11 @@ namespace App\Values\User;
 
 use App\Enums\Acl\Role;
 use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Support\Facades\Hash;
 use SensitiveParameter;
 
 final readonly class UserCreateData implements Arrayable
 {
-    public string $password;
+    public ?string $password;
 
     public function __construct(
         public string $name,
@@ -25,7 +24,7 @@ final readonly class UserCreateData implements Arrayable
             SsoUser::assertValidProvider($ssoProvider);
         }
 
-        $this->password = $plainTextPassword ? Hash::make($plainTextPassword) : '';
+        $this->password = $plainTextPassword ?: null;
     }
 
     public static function fromSsoUser(SsoUser $ssoUser): self
@@ -33,7 +32,7 @@ final readonly class UserCreateData implements Arrayable
         return new self(
             name: $ssoUser->name,
             email: $ssoUser->email,
-            plainTextPassword: '',
+            plainTextPassword: null,
             role: Role::default(),
             avatar: $ssoUser->avatar,
             ssoId: $ssoUser->id,

--- a/app/Values/User/UserCreateData.php
+++ b/app/Values/User/UserCreateData.php
@@ -24,7 +24,7 @@ final readonly class UserCreateData implements Arrayable
             SsoUser::assertValidProvider($ssoProvider);
         }
 
-        $this->password = $plainTextPassword ?: null;
+        $this->password = $plainTextPassword === '' ? null : $plainTextPassword;
     }
 
     public static function fromSsoUser(SsoUser $ssoUser): self

--- a/app/Values/User/UserUpdateData.php
+++ b/app/Values/User/UserUpdateData.php
@@ -3,7 +3,6 @@
 namespace App\Values\User;
 
 use App\Enums\Acl\Role;
-use Illuminate\Support\Facades\Hash;
 use SensitiveParameter;
 
 final readonly class UserUpdateData
@@ -18,7 +17,7 @@ final readonly class UserUpdateData
         public ?Role $role,
         public ?string $avatar,
     ) {
-        $this->password = $plainTextPassword ? Hash::make($plainTextPassword) : null;
+        $this->password = $plainTextPassword ?: null;
     }
 
     public static function make(

--- a/app/Values/User/UserUpdateData.php
+++ b/app/Values/User/UserUpdateData.php
@@ -17,7 +17,7 @@ final readonly class UserUpdateData
         public ?Role $role,
         public ?string $avatar,
     ) {
-        $this->password = $plainTextPassword ?: null;
+        $this->password = $plainTextPassword === '' ? null : $plainTextPassword;
     }
 
     public static function make(

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -6,7 +6,6 @@ use App\Enums\Acl\Role;
 use App\Models\Organization;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
-use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 
 /** @extends Factory<User> */
@@ -18,7 +17,7 @@ class UserFactory extends Factory
         return [
             'name' => fake()->name,
             'email' => fake()->unique()->safeEmail,
-            'password' => Hash::make('secret'),
+            'password' => 'secret',
             'preferences' => [
                 'lastfm_session_key' => Str::random(),
             ],

--- a/database/migrations/2026_06_11_171617_make_users_password_nullable.php
+++ b/database/migrations/2026_06_11_171617_make_users_password_nullable.php
@@ -1,0 +1,14 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('users', static function (Blueprint $table): void {
+            $table->string('password', 60)->nullable()->change();
+        });
+    }
+};


### PR DESCRIPTION
## Summary

Adopts Laravel's built-in `'password' => 'hashed'` cast so user passwords are hashed automatically on assignment. Removes the seven manual `Hash::make()` call sites scattered across controllers, services, repositories, the factory, and value objects.

### Before

```php
$user->password = Hash::make($newPassword);
$user->save();
```

### After

```php
$user->password = $newPassword;
$user->save();
```

The cast detects already-hashed values via `Hash::isHashed()` and skips re-hashing, so existing tests that pass pre-hashed values (e.g. `create_user(['password' => Hash::make('secret')])`) continue to work without change.

## Why nullable

Empty-string passwords (used today for SSO users who have no local credential) would otherwise be silently hashed by the cast — and `Hash::check('', bcrypt(''))` returns **true**, which would let anyone log into an SSO account by submitting an empty password. To close that gap, the migration makes the `password` column nullable and the value objects now store `null` (not `''`) when no password is provided. The cast skips nulls cleanly.

## Files

- `app/Models/User.php` — add `'password' => 'hashed'` cast; doctag now `?string`
- `database/migrations/..._make_users_password_nullable.php` — change column to nullable
- `app/Values/User/UserCreateData.php`, `UserUpdateData.php` — drop `Hash::make`; store plain or null
- `app/Repositories/UserRepository.php` — drop `Hash::make` for first-admin seed
- `app/Services/UserInvitationService.php` — drop `Hash::make` on invitation accept
- `app/Services/Auth/AuthenticationService.php` — drop `Hash::make` on rehash + password-reset callback (`Hash::check`/`Hash::needsRehash` reads untouched)
- `app/Services/UserService.php` — drop `Hash::make` in `changePassword`
- `database/factories/UserFactory.php` — drop `Hash::make` from default

## Test plan

- [x] `composer cs`, `composer lint`, `composer analyze` — all clean
- [x] `php artisan test --compact` — 1508/1508 pass (6550 assertions)
- [ ] Manual sanity: register a user, log in, change password, accept an invitation, log in via SSO (which now writes `null` password). All should work; SSO accounts should remain unauthenticable via password.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Made user password optional to better support alternate sign-in methods.
  * Normalized how passwords are set/updated across login, reset, invitation, and user-update flows to ensure consistent handling of empty or absent values.
  * Adjusted default account creation behavior to reflect the new optional-password handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->