### PR TITLE
refactor: drop the playlist-folder hatch, move via a single store method

### DIFF
--- a/resources/assets/js/components/layout/main-wrapper/sidebar/PlaylistFolderSidebarItem.vue
+++ b/resources/assets/js/components/layout/main-wrapper/sidebar/PlaylistFolderSidebarItem.vue
@@ -38,7 +38,7 @@ import { computed, onBeforeUnmount, onMounted, ref, toRefs } from 'vue'
 import { defineAsyncComponent } from '@/utils/helpers'
 import { playlistFolderStore } from '@/stores/playlistFolderStore'
 import { playlistStore } from '@/stores/playlistStore'
-import { currentDropTargetFolderId, useDraggable, useDroppable } from '@/composables/useDragAndDrop'
+import { useDraggable, useDroppable } from '@/composables/useDragAndDrop'
 import { useContextMenu } from '@/composables/useContextMenu'
 
 import PlaylistSidebarItem from './PlaylistSidebarItem.vue'
@@ -110,7 +110,6 @@ const onDragOver = (event: DragEvent) => {
   }
 
   droppable.value = true
-  currentDropTargetFolderId.value = folder.value.id
 }
 
 const onDragLeave = (event: DragEvent) => {
@@ -123,10 +122,6 @@ const onDragLeave = (event: DragEvent) => {
 
   droppable.value = false
   cancelAutoExpand()
-
-  if (currentDropTargetFolderId.value === folder.value.id) {
-    currentDropTargetFolderId.value = null
-  }
 }
 
 const onDrop = async (event: DragEvent) => {

--- a/resources/assets/js/components/layout/main-wrapper/sidebar/PlaylistFolderSidebarItem.vue
+++ b/resources/assets/js/components/layout/main-wrapper/sidebar/PlaylistFolderSidebarItem.vue
@@ -1,6 +1,6 @@
 <template>
   <li
-    :class="{ droppable }"
+    :class="{ droppable, 'drag-source': isDragSource, 'drag-target': isDropTarget }"
     class="playlist-folder relative"
     :draggable="!isMobile.any"
     tabindex="0"
@@ -38,7 +38,12 @@ import { computed, onBeforeUnmount, onMounted, ref, toRefs } from 'vue'
 import { defineAsyncComponent } from '@/utils/helpers'
 import { playlistFolderStore } from '@/stores/playlistFolderStore'
 import { playlistStore } from '@/stores/playlistStore'
-import { useDraggable, useDroppable } from '@/composables/useDragAndDrop'
+import {
+  currentDraggedPlaylist,
+  currentDropTargetFolderId,
+  useDraggable,
+  useDroppable,
+} from '@/composables/useDragAndDrop'
 import { useContextMenu } from '@/composables/useContextMenu'
 
 import PlaylistSidebarItem from './PlaylistSidebarItem.vue'
@@ -59,6 +64,12 @@ const droppable = ref(false)
 const expandTimeout = ref<number | null>(null)
 
 const playlistsInFolder = computed(() => playlistStore.byFolder(folder.value))
+
+// Whether the playlist currently being dragged came from this folder.
+const isDragSource = computed(() => currentDraggedPlaylist.value?.folder_id === folder.value.id)
+
+// Whether the cursor is currently over this folder as an accepting drop target.
+const isDropTarget = computed(() => currentDropTargetFolderId.value === folder.value.id)
 
 const toggle = () => (opened.value = !opened.value)
 
@@ -103,6 +114,7 @@ const onDragOver = (event: DragEvent) => {
   event.preventDefault()
   event.stopPropagation()
   droppable.value = true
+  currentDropTargetFolderId.value = folder.value.id
 }
 
 const onDragLeave = (event: DragEvent) => {
@@ -115,6 +127,10 @@ const onDragLeave = (event: DragEvent) => {
 
   droppable.value = false
   cancelAutoExpand()
+
+  if (currentDropTargetFolderId.value === folder.value.id) {
+    currentDropTargetFolderId.value = null
+  }
 }
 
 const onDrop = async (event: DragEvent) => {
@@ -145,6 +161,6 @@ const onContextMenu = (event: MouseEvent) =>
 <style lang="postcss" scoped>
 @reference '@css/app.pcss';
 .droppable {
-  @apply ring-1 ring-offset-0 ring-k-highlight rounded-md cursor-copy;
+  @apply cursor-copy;
 }
 </style>

--- a/resources/assets/js/components/layout/main-wrapper/sidebar/PlaylistFolderSidebarItem.vue
+++ b/resources/assets/js/components/layout/main-wrapper/sidebar/PlaylistFolderSidebarItem.vue
@@ -55,12 +55,7 @@ const { acceptsDrop, resolveDroppedValue } = useDroppable(['playlist'])
 const { startDragging } = useDraggable('playlist-folder')
 const { openContextMenu } = useContextMenu()
 
-// Provided by SidebarPlaylistsSection so we can flag ourselves as the active
-// hover-target — the section uses that to switch its drop-zone affordance.
 const folderDropTargetId = inject(PlaylistFolderDropTargetKey, ref<string | null>(null))
-
-// Provided by SidebarPlaylistsSection: lets us read the playlist being dragged
-// so the drag-ghost text can say "Move A into folder B".
 const draggedPlaylist = inject(DraggedPlaylistKey, ref<Playlist | null>(null))
 
 const opened = ref(false)
@@ -78,9 +73,7 @@ const cancelAutoExpand = () => {
   }
 }
 
-// `dragend` fires on the drag source whenever the operation ends, regardless of
-// where the drop landed or whether a child handler swallowed the event with
-// stopPropagation. Use it as the reliable signal to clear the indicator.
+// dragend always fires on the source, regardless of drop-handler stopPropagation.
 const clearOnDragEnd = () => {
   droppable.value = false
   cancelAutoExpand()
@@ -100,8 +93,7 @@ onBeforeUnmount(() => {
 const onDragStart = (event: DragEvent) => startDragging(event, folder.value)
 
 const onDragOver = (event: DragEvent) => {
-  // Auto-expand the folder after a brief hover so the user can see what's inside,
-  // or drop on a playlist within.
+  // Auto-expand so the user can drop on a playlist inside.
   if (!opened.value && expandTimeout.value === null) {
     expandTimeout.value = window.setTimeout(() => {
       opened.value = true
@@ -116,8 +108,7 @@ const onDragOver = (event: DragEvent) => {
   event.preventDefault()
   event.stopPropagation()
 
-  // The browser's drag-and-drop cursor on macOS ignores CSS `cursor:`; setting
-  // dropEffect explicitly is how we get the copy (+) cursor while hovering.
+  // macOS ignores CSS cursor: during DnD; dropEffect drives the native + cursor.
   if (event.dataTransfer) {
     event.dataTransfer.dropEffect = 'copy'
   }
@@ -127,15 +118,12 @@ const onDragOver = (event: DragEvent) => {
 
   const playlist = draggedPlaylist.value
   if (playlist) {
-    // Hovering over the source folder is a no-op — suppress the ghost text
-    // so we don't pretend a move is about to happen.
     setDragText(playlist.folder_id === folder.value.id ? '' : `Move ${playlist.name} to ${folder.value.name}`)
   }
 }
 
 const onDragLeave = (event: DragEvent) => {
-  // `dragleave` fires when crossing into child elements, too. Only treat it as a
-  // real leave when the cursor moves outside the folder's bounding element.
+  // dragleave also fires when entering a child — ignore unless cursor is truly outside.
   const relatedTarget = event.relatedTarget as Node | null
   if (relatedTarget && (event.currentTarget as Node).contains(relatedTarget)) {
     return

--- a/resources/assets/js/components/layout/main-wrapper/sidebar/PlaylistFolderSidebarItem.vue
+++ b/resources/assets/js/components/layout/main-wrapper/sidebar/PlaylistFolderSidebarItem.vue
@@ -38,7 +38,7 @@ import { computed, onBeforeUnmount, onMounted, ref, toRefs } from 'vue'
 import { defineAsyncComponent } from '@/utils/helpers'
 import { playlistFolderStore } from '@/stores/playlistFolderStore'
 import { playlistStore } from '@/stores/playlistStore'
-import { useDraggable, useDroppable } from '@/composables/useDragAndDrop'
+import { currentDropTargetFolderId, useDraggable, useDroppable } from '@/composables/useDragAndDrop'
 import { useContextMenu } from '@/composables/useContextMenu'
 
 import PlaylistSidebarItem from './PlaylistSidebarItem.vue'
@@ -110,6 +110,7 @@ const onDragOver = (event: DragEvent) => {
   }
 
   droppable.value = true
+  currentDropTargetFolderId.value = folder.value.id
 }
 
 const onDragLeave = (event: DragEvent) => {
@@ -122,6 +123,10 @@ const onDragLeave = (event: DragEvent) => {
 
   droppable.value = false
   cancelAutoExpand()
+
+  if (currentDropTargetFolderId.value === folder.value.id) {
+    currentDropTargetFolderId.value = null
+  }
 }
 
 const onDrop = async (event: DragEvent) => {

--- a/resources/assets/js/components/layout/main-wrapper/sidebar/PlaylistFolderSidebarItem.vue
+++ b/resources/assets/js/components/layout/main-wrapper/sidebar/PlaylistFolderSidebarItem.vue
@@ -125,8 +125,11 @@ const onDragOver = (event: DragEvent) => {
   droppable.value = true
   folderDropTargetId.value = folder.value.id
 
-  if (draggedPlaylist.value) {
-    setDragText(`Move "${draggedPlaylist.value.name}" into folder "${folder.value.name}"`)
+  const playlist = draggedPlaylist.value
+  if (playlist) {
+    // Hovering over the source folder is a no-op — suppress the ghost text
+    // so we don't pretend a move is about to happen.
+    setDragText(playlist.folder_id === folder.value.id ? '' : `Move ${playlist.name} to ${folder.value.name}`)
   }
 }
 

--- a/resources/assets/js/components/layout/main-wrapper/sidebar/PlaylistFolderSidebarItem.vue
+++ b/resources/assets/js/components/layout/main-wrapper/sidebar/PlaylistFolderSidebarItem.vue
@@ -34,12 +34,13 @@
 <script lang="ts" setup>
 import { faFolder, faFolderOpen } from '@fortawesome/free-solid-svg-icons'
 import isMobile from 'ismobilejs'
-import { computed, onBeforeUnmount, onMounted, ref, toRefs } from 'vue'
+import { computed, inject, onBeforeUnmount, onMounted, ref, toRefs } from 'vue'
 import { defineAsyncComponent } from '@/utils/helpers'
 import { playlistFolderStore } from '@/stores/playlistFolderStore'
 import { playlistStore } from '@/stores/playlistStore'
 import { useDraggable, useDroppable } from '@/composables/useDragAndDrop'
 import { useContextMenu } from '@/composables/useContextMenu'
+import { PlaylistFolderDropTargetKey } from '@/config/symbols'
 
 import PlaylistSidebarItem from './PlaylistSidebarItem.vue'
 import SidebarItem from './SidebarItem.vue'
@@ -53,6 +54,10 @@ const { folder } = toRefs(props)
 const { acceptsDrop, resolveDroppedValue } = useDroppable(['playlist'])
 const { startDragging } = useDraggable('playlist-folder')
 const { openContextMenu } = useContextMenu()
+
+// Provided by SidebarPlaylistsSection so we can flag ourselves as the active
+// hover-target — the section uses that to switch its drop-zone affordance.
+const folderDropTargetId = inject(PlaylistFolderDropTargetKey, ref<string | null>(null))
 
 const opened = ref(false)
 const droppable = ref(false)
@@ -75,6 +80,10 @@ const cancelAutoExpand = () => {
 const clearOnDragEnd = () => {
   droppable.value = false
   cancelAutoExpand()
+
+  if (folderDropTargetId.value === folder.value.id) {
+    folderDropTargetId.value = null
+  }
 }
 
 onMounted(() => document.addEventListener('dragend', clearOnDragEnd))
@@ -110,6 +119,7 @@ const onDragOver = (event: DragEvent) => {
   }
 
   droppable.value = true
+  folderDropTargetId.value = folder.value.id
 }
 
 const onDragLeave = (event: DragEvent) => {
@@ -122,6 +132,10 @@ const onDragLeave = (event: DragEvent) => {
 
   droppable.value = false
   cancelAutoExpand()
+
+  if (folderDropTargetId.value === folder.value.id) {
+    folderDropTargetId.value = null
+  }
 }
 
 const onDrop = async (event: DragEvent) => {

--- a/resources/assets/js/components/layout/main-wrapper/sidebar/PlaylistFolderSidebarItem.vue
+++ b/resources/assets/js/components/layout/main-wrapper/sidebar/PlaylistFolderSidebarItem.vue
@@ -38,9 +38,9 @@ import { computed, inject, onBeforeUnmount, onMounted, ref, toRefs } from 'vue'
 import { defineAsyncComponent } from '@/utils/helpers'
 import { playlistFolderStore } from '@/stores/playlistFolderStore'
 import { playlistStore } from '@/stores/playlistStore'
-import { useDraggable, useDroppable } from '@/composables/useDragAndDrop'
+import { setDragText, useDraggable, useDroppable } from '@/composables/useDragAndDrop'
 import { useContextMenu } from '@/composables/useContextMenu'
-import { PlaylistFolderDropTargetKey } from '@/config/symbols'
+import { DraggedPlaylistKey, PlaylistFolderDropTargetKey } from '@/config/symbols'
 
 import PlaylistSidebarItem from './PlaylistSidebarItem.vue'
 import SidebarItem from './SidebarItem.vue'
@@ -58,6 +58,10 @@ const { openContextMenu } = useContextMenu()
 // Provided by SidebarPlaylistsSection so we can flag ourselves as the active
 // hover-target — the section uses that to switch its drop-zone affordance.
 const folderDropTargetId = inject(PlaylistFolderDropTargetKey, ref<string | null>(null))
+
+// Provided by SidebarPlaylistsSection: lets us read the playlist being dragged
+// so the drag-ghost text can say "Move A into folder B".
+const draggedPlaylist = inject(DraggedPlaylistKey, ref<Playlist | null>(null))
 
 const opened = ref(false)
 const droppable = ref(false)
@@ -120,6 +124,10 @@ const onDragOver = (event: DragEvent) => {
 
   droppable.value = true
   folderDropTargetId.value = folder.value.id
+
+  if (draggedPlaylist.value) {
+    setDragText(`Move "${draggedPlaylist.value.name}" into folder "${folder.value.name}"`)
+  }
 }
 
 const onDragLeave = (event: DragEvent) => {

--- a/resources/assets/js/components/layout/main-wrapper/sidebar/PlaylistFolderSidebarItem.vue
+++ b/resources/assets/js/components/layout/main-wrapper/sidebar/PlaylistFolderSidebarItem.vue
@@ -102,6 +102,13 @@ const onDragOver = (event: DragEvent) => {
 
   event.preventDefault()
   event.stopPropagation()
+
+  // The browser's drag-and-drop cursor on macOS ignores CSS `cursor:`; setting
+  // dropEffect explicitly is how we get the copy (+) cursor while hovering.
+  if (event.dataTransfer) {
+    event.dataTransfer.dropEffect = 'copy'
+  }
+
   droppable.value = true
 }
 

--- a/resources/assets/js/components/layout/main-wrapper/sidebar/PlaylistFolderSidebarItem.vue
+++ b/resources/assets/js/components/layout/main-wrapper/sidebar/PlaylistFolderSidebarItem.vue
@@ -34,7 +34,7 @@
 <script lang="ts" setup>
 import { faFolder, faFolderOpen } from '@fortawesome/free-solid-svg-icons'
 import isMobile from 'ismobilejs'
-import { computed, onBeforeUnmount, ref, toRefs } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, toRefs } from 'vue'
 import { defineAsyncComponent } from '@/utils/helpers'
 import { playlistFolderStore } from '@/stores/playlistFolderStore'
 import { playlistStore } from '@/stores/playlistStore'
@@ -69,7 +69,20 @@ const cancelAutoExpand = () => {
   }
 }
 
-onBeforeUnmount(cancelAutoExpand)
+// `dragend` fires on the drag source whenever the operation ends, regardless of
+// where the drop landed or whether a child handler swallowed the event with
+// stopPropagation. Use it as the reliable signal to clear the indicator.
+const clearOnDragEnd = () => {
+  droppable.value = false
+  cancelAutoExpand()
+}
+
+onMounted(() => document.addEventListener('dragend', clearOnDragEnd))
+
+onBeforeUnmount(() => {
+  cancelAutoExpand()
+  document.removeEventListener('dragend', clearOnDragEnd)
+})
 
 const onDragStart = (event: DragEvent) => startDragging(event, folder.value)
 
@@ -88,6 +101,7 @@ const onDragOver = (event: DragEvent) => {
   }
 
   event.preventDefault()
+  event.stopPropagation()
   droppable.value = true
 }
 

--- a/resources/assets/js/components/layout/main-wrapper/sidebar/PlaylistFolderSidebarItem.vue
+++ b/resources/assets/js/components/layout/main-wrapper/sidebar/PlaylistFolderSidebarItem.vue
@@ -1,6 +1,6 @@
 <template>
   <li
-    :class="{ droppable, 'drag-source': isDragSource, 'drag-target': isDropTarget }"
+    :class="{ droppable }"
     class="playlist-folder relative"
     :draggable="!isMobile.any"
     tabindex="0"
@@ -38,12 +38,7 @@ import { computed, onBeforeUnmount, onMounted, ref, toRefs } from 'vue'
 import { defineAsyncComponent } from '@/utils/helpers'
 import { playlistFolderStore } from '@/stores/playlistFolderStore'
 import { playlistStore } from '@/stores/playlistStore'
-import {
-  currentDraggedPlaylist,
-  currentDropTargetFolderId,
-  useDraggable,
-  useDroppable,
-} from '@/composables/useDragAndDrop'
+import { useDraggable, useDroppable } from '@/composables/useDragAndDrop'
 import { useContextMenu } from '@/composables/useContextMenu'
 
 import PlaylistSidebarItem from './PlaylistSidebarItem.vue'
@@ -64,12 +59,6 @@ const droppable = ref(false)
 const expandTimeout = ref<number | null>(null)
 
 const playlistsInFolder = computed(() => playlistStore.byFolder(folder.value))
-
-// Whether the playlist currently being dragged came from this folder.
-const isDragSource = computed(() => currentDraggedPlaylist.value?.folder_id === folder.value.id)
-
-// Whether the cursor is currently over this folder as an accepting drop target.
-const isDropTarget = computed(() => currentDropTargetFolderId.value === folder.value.id)
 
 const toggle = () => (opened.value = !opened.value)
 
@@ -114,7 +103,6 @@ const onDragOver = (event: DragEvent) => {
   event.preventDefault()
   event.stopPropagation()
   droppable.value = true
-  currentDropTargetFolderId.value = folder.value.id
 }
 
 const onDragLeave = (event: DragEvent) => {
@@ -127,10 +115,6 @@ const onDragLeave = (event: DragEvent) => {
 
   droppable.value = false
   cancelAutoExpand()
-
-  if (currentDropTargetFolderId.value === folder.value.id) {
-    currentDropTargetFolderId.value = null
-  }
 }
 
 const onDrop = async (event: DragEvent) => {

--- a/resources/assets/js/components/layout/main-wrapper/sidebar/PlaylistFolderSidebarItem.vue
+++ b/resources/assets/js/components/layout/main-wrapper/sidebar/PlaylistFolderSidebarItem.vue
@@ -27,15 +27,6 @@
           />
         </ul>
       </li>
-
-      <li
-        v-if="opened"
-        :class="droppableOnHatch && 'droppable'"
-        class="hatch absolute bottom-0 w-full h-1"
-        @dragover="onDragOverHatch"
-        @dragleave.prevent="onDragLeaveHatch"
-        @drop.prevent="onDropOnHatch"
-      />
     </ul>
   </li>
 </template>
@@ -43,7 +34,7 @@
 <script lang="ts" setup>
 import { faFolder, faFolderOpen } from '@fortawesome/free-solid-svg-icons'
 import isMobile from 'ismobilejs'
-import { computed, ref, toRefs } from 'vue'
+import { computed, onBeforeUnmount, ref, toRefs } from 'vue'
 import { defineAsyncComponent } from '@/utils/helpers'
 import { playlistFolderStore } from '@/stores/playlistFolderStore'
 import { playlistStore } from '@/stores/playlistStore'
@@ -65,21 +56,30 @@ const { openContextMenu } = useContextMenu()
 
 const opened = ref(false)
 const droppable = ref(false)
-const droppableOnHatch = ref(false)
-let expandTimeout = 0
+const expandTimeout = ref<number | null>(null)
 
 const playlistsInFolder = computed(() => playlistStore.byFolder(folder.value))
 
 const toggle = () => (opened.value = !opened.value)
 
+const cancelAutoExpand = () => {
+  if (expandTimeout.value !== null) {
+    window.clearTimeout(expandTimeout.value)
+    expandTimeout.value = null
+  }
+}
+
+onBeforeUnmount(cancelAutoExpand)
+
 const onDragStart = (event: DragEvent) => startDragging(event, folder.value)
 
 const onDragOver = (event: DragEvent) => {
-  // Expand the folder after a short delay so the user can drop songs onto playlists inside.
-  if (!opened.value && !expandTimeout) {
-    expandTimeout = window.setTimeout(() => {
+  // Auto-expand the folder after a brief hover so the user can see what's inside,
+  // or drop on a playlist within.
+  if (!opened.value && expandTimeout.value === null) {
+    expandTimeout.value = window.setTimeout(() => {
       opened.value = true
-      expandTimeout = 0
+      expandTimeout.value = null
     }, 500)
   }
 
@@ -91,15 +91,20 @@ const onDragOver = (event: DragEvent) => {
   droppable.value = true
 }
 
-const onDragLeave = () => {
+const onDragLeave = (event: DragEvent) => {
+  // `dragleave` fires when crossing into child elements, too. Only treat it as a
+  // real leave when the cursor moves outside the folder's bounding element.
+  const relatedTarget = event.relatedTarget as Node | null
+  if (relatedTarget && (event.currentTarget as Node).contains(relatedTarget)) {
+    return
+  }
+
   droppable.value = false
-  clearTimeout(expandTimeout)
-  expandTimeout = 0
+  cancelAutoExpand()
 }
 
 const onDrop = async (event: DragEvent) => {
-  clearTimeout(expandTimeout)
-  expandTimeout = 0
+  cancelAutoExpand()
   droppable.value = false
 
   if (!acceptsDrop(event)) {
@@ -107,40 +112,14 @@ const onDrop = async (event: DragEvent) => {
   }
 
   event.preventDefault()
+  event.stopPropagation()
 
   const playlist = await resolveDroppedValue<Playlist>(event)
-  if (!playlist || playlist.folder_id === folder.value.id) {
+  if (!playlist) {
     return
   }
 
-  await playlistFolderStore.addPlaylistToFolder(folder.value, playlist)
-}
-
-const onDragLeaveHatch = () => (droppableOnHatch.value = false)
-
-const onDragOverHatch = (event: DragEvent) => {
-  if (!acceptsDrop(event)) {
-    return false
-  }
-
-  event.preventDefault()
-  droppableOnHatch.value = true
-}
-
-const onDropOnHatch = async (event: DragEvent) => {
-  droppableOnHatch.value = false
-  droppable.value = false
-
-  const playlist = (await resolveDroppedValue<Playlist>(event))!
-
-  // if the playlist isn't in the folder, don't do anything. The folder will handle the drop.
-  if (playlist.folder_id !== folder.value.id) {
-    return
-  }
-
-  // otherwise, the user is trying to remove the playlist from the folder.
-  event.stopPropagation()
-  await playlistFolderStore.removePlaylistFromFolder(folder.value, playlist)
+  await playlistFolderStore.movePlaylistToFolder(playlist, folder.value)
 }
 
 const onContextMenu = (event: MouseEvent) =>
@@ -153,9 +132,5 @@ const onContextMenu = (event: MouseEvent) =>
 @reference '@css/app.pcss';
 .droppable {
   @apply ring-1 ring-offset-0 ring-k-highlight rounded-md cursor-copy;
-}
-
-.hatch.droppable {
-  @apply border-b-[3px] border-k-highlight;
 }
 </style>

--- a/resources/assets/js/components/layout/main-wrapper/sidebar/PlaylistSidebarItem.vue
+++ b/resources/assets/js/components/layout/main-wrapper/sidebar/PlaylistSidebarItem.vue
@@ -30,7 +30,7 @@
 import { faClockRotateLeft, faHeart, faUsers, faWandMagicSparkles } from '@fortawesome/free-solid-svg-icons'
 import isMobile from 'ismobilejs'
 import { ListMusicIcon } from 'lucide-vue-next'
-import { computed, ref, toRefs } from 'vue'
+import { computed, inject, ref, toRefs } from 'vue'
 import { defineAsyncComponent } from '@/utils/helpers'
 import { playableStore } from '@/stores/playableStore'
 import { recentlyPlayedStore } from '@/stores/recentlyPlayedStore'
@@ -39,6 +39,7 @@ import { useDraggable, useDroppable } from '@/composables/useDragAndDrop'
 import { usePlaylistContentManagement } from '@/composables/usePlaylistContentManagement'
 import { useContextMenu } from '@/composables/useContextMenu'
 import { playback } from '@/services/playbackManager'
+import { DraggedPlaylistKey } from '@/config/symbols'
 
 import SidebarItem from '@/components/layout/main-wrapper/sidebar/SidebarItem.vue'
 
@@ -50,6 +51,10 @@ const { url, isCurrentScreen, getRouteParam } = useRouter()
 const { startDragging } = useDraggable('playlist')
 const { acceptsDrop, resolveDroppedItems } = useDroppable(['playables', 'album', 'artist', 'browser-media'])
 const { openContextMenu } = useContextMenu()
+
+// Provided by SidebarPlaylistsSection. Lets the section / folders read which
+// playlist is being dragged to compose context-aware drag-ghost text.
+const draggedPlaylist = inject(DraggedPlaylistKey, ref<Playlist | null>(null))
 
 const droppable = ref(false)
 
@@ -121,7 +126,14 @@ const onDblClick = async () => {
   }
 }
 
-const onDragStart = (event: DragEvent) => isPlaylist(list.value) && startDragging(event, list.value)
+const onDragStart = (event: DragEvent) => {
+  if (!isPlaylist(list.value)) {
+    return
+  }
+
+  startDragging(event, list.value)
+  draggedPlaylist.value = list.value
+}
 
 const onDragOver = (event: DragEvent) => {
   if (!contentEditable.value || !acceptsDrop(event)) {

--- a/resources/assets/js/components/layout/main-wrapper/sidebar/PlaylistSidebarItem.vue
+++ b/resources/assets/js/components/layout/main-wrapper/sidebar/PlaylistSidebarItem.vue
@@ -1,7 +1,4 @@
 <template>
-  <!-- Drag events stop propagation only when this item accepts the drop, so a
-       rejected drag (e.g. a playlist-type drag over a playlist item) bubbles up
-       to the folder or the section list to be handled there. -->
   <SidebarItem
     :class="{ droppable }"
     :href="href"
@@ -52,8 +49,6 @@ const { startDragging } = useDraggable('playlist')
 const { acceptsDrop, resolveDroppedItems } = useDroppable(['playables', 'album', 'artist', 'browser-media'])
 const { openContextMenu } = useContextMenu()
 
-// Provided by SidebarPlaylistsSection. Lets the section / folders read which
-// playlist is being dragged to compose context-aware drag-ghost text.
 const draggedPlaylist = inject(DraggedPlaylistKey, ref<Playlist | null>(null))
 
 const droppable = ref(false)

--- a/resources/assets/js/components/layout/main-wrapper/sidebar/PlaylistSidebarItem.vue
+++ b/resources/assets/js/components/layout/main-wrapper/sidebar/PlaylistSidebarItem.vue
@@ -1,5 +1,7 @@
 <template>
-  <!-- using .stop modifier to prevent events from bubbling up to the containing playlist folder (if any) -->
+  <!-- Drag events stop propagation only when this item accepts the drop, so a
+       rejected drag (e.g. a playlist-type drag over a playlist item) bubbles up
+       to the folder or the section list to be handled there. -->
   <SidebarItem
     :class="{ droppable }"
     :href="href"
@@ -8,10 +10,10 @@
     :active
     @dblclick="onDblClick"
     @contextmenu="onContextMenu"
-    @dragleave.stop="onDragLeave"
-    @dragover.stop="onDragOver"
+    @dragleave="onDragLeave"
+    @dragover="onDragOver"
     @dragstart.stop="onDragStart"
-    @drop.stop="onDrop"
+    @drop="onDrop"
   >
     <template #icon>
       <Icon v-if="isRecentlyPlayedList(list)" :icon="faClockRotateLeft" fixed-width />
@@ -122,35 +124,37 @@ const onDblClick = async () => {
 const onDragStart = (event: DragEvent) => isPlaylist(list.value) && startDragging(event, list.value)
 
 const onDragOver = (event: DragEvent) => {
-  if (!contentEditable.value) {
-    return false
-  }
-  if (!acceptsDrop(event)) {
-    return false
+  if (!contentEditable.value || !acceptsDrop(event)) {
+    return
   }
 
   event.preventDefault()
+  event.stopPropagation()
   droppable.value = true
-
-  return false
 }
 
-const onDragLeave = () => (droppable.value = false)
+const onDragLeave = (event: DragEvent) => {
+  if (!droppable.value) {
+    return
+  }
+
+  event.stopPropagation()
+  droppable.value = false
+}
 
 const onDrop = async (event: DragEvent) => {
-  droppable.value = false
+  if (!contentEditable.value || !acceptsDrop(event)) {
+    return
+  }
 
-  if (!contentEditable.value) {
-    return false
-  }
-  if (!acceptsDrop(event)) {
-    return false
-  }
+  event.preventDefault()
+  event.stopPropagation()
+  droppable.value = false
 
   const playables = await resolveDroppedItems(event)
 
   if (!playables?.length) {
-    return false
+    return
   }
 
   if (isFavoriteList(list.value)) {
@@ -158,8 +162,6 @@ const onDrop = async (event: DragEvent) => {
   } else if (isPlaylist(list.value)) {
     await addToPlaylist(list.value, playables)
   }
-
-  return false
 }
 </script>
 

--- a/resources/assets/js/components/layout/main-wrapper/sidebar/SidebarPlaylistsSection.vue
+++ b/resources/assets/js/components/layout/main-wrapper/sidebar/SidebarPlaylistsSection.vue
@@ -84,12 +84,15 @@ const onDragOver = (event: DragEvent) => {
   }
 
   const playlist = draggedPlaylist.value
-  if (playlist?.folder_id) {
-    const sourceFolder = playlistFolderStore.byId(playlist.folder_id)
-    if (sourceFolder) {
-      setDragText(`Move "${playlist.name}" out of folder "${sourceFolder.name}"`)
-    }
+  if (!playlist?.folder_id) {
+    // Either nothing tracked yet, or the playlist isn't in a folder so dropping
+    // here is a no-op. Don't claim a move is about to happen.
+    setDragText('')
+    return
   }
+
+  const sourceFolder = playlistFolderStore.byId(playlist.folder_id)
+  setDragText(sourceFolder ? `Move ${playlist.name} out of ${sourceFolder.name}` : '')
 }
 
 const onDrop = async (event: DragEvent) => {

--- a/resources/assets/js/components/layout/main-wrapper/sidebar/SidebarPlaylistsSection.vue
+++ b/resources/assets/js/components/layout/main-wrapper/sidebar/SidebarPlaylistsSection.vue
@@ -55,6 +55,12 @@ const onDragOver = (event: DragEvent) => {
   }
 
   event.preventDefault()
+
+  // The browser's drag-and-drop cursor on macOS ignores CSS `cursor:`; setting
+  // dropEffect explicitly is how we get the copy (+) cursor while hovering.
+  if (event.dataTransfer) {
+    event.dataTransfer.dropEffect = 'copy'
+  }
 }
 
 const onDrop = async (event: DragEvent) => {

--- a/resources/assets/js/components/layout/main-wrapper/sidebar/SidebarPlaylistsSection.vue
+++ b/resources/assets/js/components/layout/main-wrapper/sidebar/SidebarPlaylistsSection.vue
@@ -5,7 +5,11 @@
       <CreatePlaylistContextMenuButton />
     </SidebarSectionHeader>
 
-    <ul :class="{ dragging: isDraggingPlaylist }" @dragover="onDragOver" @drop="onDrop">
+    <ul
+      :class="{ dragging: isDraggingPlaylist, 'has-folder-target': isDraggingPlaylist && hasFolderTarget }"
+      @dragover="onDragOver"
+      @drop="onDrop"
+    >
       <PlaylistSidebarItem :list="{ name: 'Favorites', playables: favorites }" />
       <PlaylistSidebarItem :list="{ name: 'Recently Played', playables: [] }" />
       <PlaylistFolderSidebarItem v-for="folder in folders" :key="folder.id" :folder="folder" />
@@ -15,11 +19,12 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, toRef } from 'vue'
+import { computed, provide, ref, toRef } from 'vue'
 import { playlistFolderStore } from '@/stores/playlistFolderStore'
 import { playlistStore } from '@/stores/playlistStore'
 import { playableStore } from '@/stores/playableStore'
 import { currentDragType, useDroppable } from '@/composables/useDragAndDrop'
+import { PlaylistFolderDropTargetKey } from '@/config/symbols'
 
 import PlaylistSidebarItem from './PlaylistSidebarItem.vue'
 import PlaylistFolderSidebarItem from './PlaylistFolderSidebarItem.vue'
@@ -34,6 +39,13 @@ const favorites = toRef(playableStore.state, 'favorites')
 const { acceptsDrop, resolveDroppedValue } = useDroppable(['playlist'])
 
 const isDraggingPlaylist = computed(() => currentDragType.value === 'playlist')
+
+// Folders write their id here while they are the active hover-target, and clear
+// it when the cursor leaves them. The CSS below reads this to switch between
+// the "section is the target" and "this folder is the target" states.
+const folderDropTargetId = ref<string | null>(null)
+provide(PlaylistFolderDropTargetKey, folderDropTargetId)
+const hasFolderTarget = computed(() => folderDropTargetId.value !== null)
 
 const orphanPlaylists = computed(() =>
   playlists.value.filter(({ folder_id }) => {
@@ -95,16 +107,16 @@ ul.dragging {
   cursor: copy;
 }
 
-ul.dragging:not(:has(:deep(.droppable))) {
+ul.dragging:not(.has-folder-target) {
   @apply outline-1 outline-dashed outline-offset-2 outline-k-highlight rounded-md;
 }
 
-ul.dragging:has(:deep(.droppable)) > :deep(*) {
+ul.dragging.has-folder-target > :deep(*) {
   opacity: 0.4;
   transition: opacity 0.15s ease;
 }
 
-ul.dragging:has(:deep(.droppable)) > :deep(.droppable) {
+ul.dragging.has-folder-target > :deep(.droppable) {
   opacity: 1;
 }
 </style>

--- a/resources/assets/js/components/layout/main-wrapper/sidebar/SidebarPlaylistsSection.vue
+++ b/resources/assets/js/components/layout/main-wrapper/sidebar/SidebarPlaylistsSection.vue
@@ -19,12 +19,12 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, provide, ref, toRef } from 'vue'
+import { computed, onBeforeUnmount, onMounted, provide, ref, toRef } from 'vue'
 import { playlistFolderStore } from '@/stores/playlistFolderStore'
 import { playlistStore } from '@/stores/playlistStore'
 import { playableStore } from '@/stores/playableStore'
-import { currentDragType, useDroppable } from '@/composables/useDragAndDrop'
-import { PlaylistFolderDropTargetKey } from '@/config/symbols'
+import { currentDragType, setDragText, useDroppable } from '@/composables/useDragAndDrop'
+import { DraggedPlaylistKey, PlaylistFolderDropTargetKey } from '@/config/symbols'
 
 import PlaylistSidebarItem from './PlaylistSidebarItem.vue'
 import PlaylistFolderSidebarItem from './PlaylistFolderSidebarItem.vue'
@@ -46,6 +46,15 @@ const isDraggingPlaylist = computed(() => currentDragType.value === 'playlist')
 const folderDropTargetId = ref<string | null>(null)
 provide(PlaylistFolderDropTargetKey, folderDropTargetId)
 const hasFolderTarget = computed(() => folderDropTargetId.value !== null)
+
+// PlaylistSidebarItem writes this on dragstart so other sidebar entries can
+// resolve the source folder and compose context-aware drag-ghost text.
+const draggedPlaylist = ref<Playlist | null>(null)
+provide(DraggedPlaylistKey, draggedPlaylist)
+
+const clearDraggedPlaylist = () => (draggedPlaylist.value = null)
+onMounted(() => document.addEventListener('dragend', clearDraggedPlaylist))
+onBeforeUnmount(() => document.removeEventListener('dragend', clearDraggedPlaylist))
 
 const orphanPlaylists = computed(() =>
   playlists.value.filter(({ folder_id }) => {
@@ -72,6 +81,14 @@ const onDragOver = (event: DragEvent) => {
   // dropEffect explicitly is how we get the copy (+) cursor while hovering.
   if (event.dataTransfer) {
     event.dataTransfer.dropEffect = 'copy'
+  }
+
+  const playlist = draggedPlaylist.value
+  if (playlist?.folder_id) {
+    const sourceFolder = playlistFolderStore.byId(playlist.folder_id)
+    if (sourceFolder) {
+      setDragText(`Move "${playlist.name}" out of folder "${sourceFolder.name}"`)
+    }
   }
 }
 

--- a/resources/assets/js/components/layout/main-wrapper/sidebar/SidebarPlaylistsSection.vue
+++ b/resources/assets/js/components/layout/main-wrapper/sidebar/SidebarPlaylistsSection.vue
@@ -6,7 +6,7 @@
     </SidebarSectionHeader>
 
     <ul
-      :class="{ dragging: isDraggingPlaylist, 'no-target': isDraggingPlaylist && !hasDropTarget }"
+      :class="{ dragging: isDraggingPlaylist, 'has-folder-target': isDraggingPlaylist && hasDropTarget }"
       @dragover="onDragOver"
       @drop="onDrop"
     >
@@ -87,28 +87,29 @@ const onDrop = async (event: DragEvent) => {
 <style lang="postcss" scoped>
 @reference '@css/app.pcss';
 
-/* While a playlist is being dragged, dim everything in the section and signal
-   the whole area as a valid drop target via the cursor. The folder under the
-   cursor (which carries the .droppable class on its root) pops back to full
-   opacity to indicate it's the accepting target; dropping anywhere else moves
-   the playlist out of its folder. */
+/* Two states while a playlist is being dragged:
+
+   1. No folder under the cursor — the section as a whole is the implicit
+      "move out of folder" target. Surface a dashed outline around the whole
+      <ul> and keep every entry at full opacity; dimming would lie about the
+      drop being unavailable.
+   2. Cursor over a folder — that folder is the specific target. Dim every
+      entry except the folder under the cursor, which keeps full opacity to
+      identify it as the accepting target. */
 ul.dragging {
   cursor: copy;
-  transition: outline-color 0.15s ease;
 }
 
-ul.dragging > :deep(*) {
+ul.dragging:not(.has-folder-target) {
+  @apply outline-1 outline-dashed outline-offset-2 outline-k-highlight rounded-md;
+}
+
+ul.dragging.has-folder-target > :deep(*) {
   opacity: 0.4;
   transition: opacity 0.15s ease;
 }
 
-ul.dragging > :deep(.droppable) {
+ul.dragging.has-folder-target > :deep(.droppable) {
   opacity: 1;
-}
-
-/* No folder is targeted — surface a faint dashed outline so the user can see
-   that the whole section is the implicit "move out of folder" drop zone. */
-ul.dragging.no-target {
-  @apply outline-1 outline-dashed outline-offset-2 outline-k-highlight rounded-md;
 }
 </style>

--- a/resources/assets/js/components/layout/main-wrapper/sidebar/SidebarPlaylistsSection.vue
+++ b/resources/assets/js/components/layout/main-wrapper/sidebar/SidebarPlaylistsSection.vue
@@ -5,7 +5,7 @@
       <CreatePlaylistContextMenuButton />
     </SidebarSectionHeader>
 
-    <ul :class="{ dragging: isDraggingPlaylist, 'has-target': hasDropTarget }" @dragover="onDragOver" @drop="onDrop">
+    <ul :class="{ dragging: isDraggingPlaylist }" @dragover="onDragOver" @drop="onDrop">
       <PlaylistSidebarItem :list="{ name: 'Favorites', playables: favorites }" />
       <PlaylistSidebarItem :list="{ name: 'Recently Played', playables: [] }" />
       <PlaylistFolderSidebarItem v-for="folder in folders" :key="folder.id" :folder="folder" />
@@ -19,7 +19,7 @@ import { computed, toRef } from 'vue'
 import { playlistFolderStore } from '@/stores/playlistFolderStore'
 import { playlistStore } from '@/stores/playlistStore'
 import { playableStore } from '@/stores/playableStore'
-import { currentDragType, currentDropTargetFolderId, useDroppable } from '@/composables/useDragAndDrop'
+import { currentDragType, useDroppable } from '@/composables/useDragAndDrop'
 
 import PlaylistSidebarItem from './PlaylistSidebarItem.vue'
 import PlaylistFolderSidebarItem from './PlaylistFolderSidebarItem.vue'
@@ -34,7 +34,6 @@ const favorites = toRef(playableStore.state, 'favorites')
 const { acceptsDrop, resolveDroppedValue } = useDroppable(['playlist'])
 
 const isDraggingPlaylist = computed(() => currentDragType.value === 'playlist')
-const hasDropTarget = computed(() => currentDropTargetFolderId.value !== null)
 
 const orphanPlaylists = computed(() =>
   playlists.value.filter(({ folder_id }) => {
@@ -77,28 +76,21 @@ const onDrop = async (event: DragEvent) => {
 <style lang="postcss" scoped>
 @reference '@css/app.pcss';
 
-/* Two states while a playlist is being dragged:
+/* While a playlist is being dragged, dim everything in the section and signal
+   the whole area as a valid drop target via the cursor. The folder under the
+   cursor (which carries the .droppable class on its root) pops back to full
+   opacity to indicate it's the accepting target; dropping anywhere else moves
+   the playlist out of its folder. */
+ul.dragging {
+  cursor: copy;
+}
 
-   1. No drop target under the cursor — the source folder dims, signalling
-      "you're leaving me." Everything else stays at full opacity, so the
-      whole non-source area reads as a valid "drop to remove from folder."
-
-   2. Cursor over an accepting folder — invert: the target folder pops at
-      full opacity, everything else (including the source) dims, signalling
-      "drop here to add to this folder." */
 ul.dragging > :deep(*) {
+  opacity: 0.4;
   transition: opacity 0.15s ease;
 }
 
-ul.dragging > :deep(.drag-source) {
-  opacity: 0.4;
-}
-
-ul.dragging.has-target > :deep(*) {
-  opacity: 0.4;
-}
-
-ul.dragging.has-target > :deep(.drag-target) {
+ul.dragging > :deep(.droppable) {
   opacity: 1;
 }
 </style>

--- a/resources/assets/js/components/layout/main-wrapper/sidebar/SidebarPlaylistsSection.vue
+++ b/resources/assets/js/components/layout/main-wrapper/sidebar/SidebarPlaylistsSection.vue
@@ -5,7 +5,7 @@
       <CreatePlaylistContextMenuButton />
     </SidebarSectionHeader>
 
-    <ul>
+    <ul :class="{ droppable }" class="rounded-md" @dragleave="onDragLeave" @dragover="onDragOver" @drop="onDrop">
       <PlaylistSidebarItem :list="{ name: 'Favorites', playables: favorites }" />
       <PlaylistSidebarItem :list="{ name: 'Recently Played', playables: [] }" />
       <PlaylistFolderSidebarItem v-for="folder in folders" :key="folder.id" :folder="folder" />
@@ -15,10 +15,11 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, toRef } from 'vue'
+import { computed, ref, toRef } from 'vue'
 import { playlistFolderStore } from '@/stores/playlistFolderStore'
 import { playlistStore } from '@/stores/playlistStore'
 import { playableStore } from '@/stores/playableStore'
+import { useDroppable } from '@/composables/useDragAndDrop'
 
 import PlaylistSidebarItem from './PlaylistSidebarItem.vue'
 import PlaylistFolderSidebarItem from './PlaylistFolderSidebarItem.vue'
@@ -29,6 +30,9 @@ import SidebarSection from '@/components/layout/main-wrapper/sidebar/SidebarSect
 const folders = toRef(playlistFolderStore.state, 'folders')
 const playlists = toRef(playlistStore.state, 'playlists')
 const favorites = toRef(playableStore.state, 'favorites')
+
+const { acceptsDrop, resolveDroppedValue } = useDroppable(['playlist'])
+const droppable = ref(false)
 
 const orphanPlaylists = computed(() =>
   playlists.value.filter(({ folder_id }) => {
@@ -41,4 +45,46 @@ const orphanPlaylists = computed(() =>
     return !folders.value.find(folder => folder.id === folder_id)
   }),
 )
+
+const onDragOver = (event: DragEvent) => {
+  if (!acceptsDrop(event)) {
+    return false
+  }
+
+  event.preventDefault()
+  droppable.value = true
+}
+
+const onDragLeave = (event: DragEvent) => {
+  const relatedTarget = event.relatedTarget as Node | null
+  if (relatedTarget && (event.currentTarget as Node).contains(relatedTarget)) {
+    return
+  }
+
+  droppable.value = false
+}
+
+const onDrop = async (event: DragEvent) => {
+  droppable.value = false
+
+  if (!acceptsDrop(event)) {
+    return false
+  }
+
+  event.preventDefault()
+
+  const playlist = await resolveDroppedValue<Playlist>(event)
+  if (!playlist || playlist.folder_id === null) {
+    return
+  }
+
+  await playlistFolderStore.movePlaylistToFolder(playlist, null)
+}
 </script>
+
+<style lang="postcss" scoped>
+@reference '@css/app.pcss';
+.droppable {
+  @apply ring-1 ring-offset-0 ring-k-highlight cursor-copy;
+}
+</style>

--- a/resources/assets/js/components/layout/main-wrapper/sidebar/SidebarPlaylistsSection.vue
+++ b/resources/assets/js/components/layout/main-wrapper/sidebar/SidebarPlaylistsSection.vue
@@ -5,11 +5,22 @@
       <CreatePlaylistContextMenuButton />
     </SidebarSectionHeader>
 
-    <ul :class="{ droppable }" class="rounded-md" @dragleave="onDragLeave" @dragover="onDragOver" @drop="onDrop">
+    <ul>
       <PlaylistSidebarItem :list="{ name: 'Favorites', playables: favorites }" />
       <PlaylistSidebarItem :list="{ name: 'Recently Played', playables: [] }" />
       <PlaylistFolderSidebarItem v-for="folder in folders" :key="folder.id" :folder="folder" />
       <PlaylistSidebarItem v-for="playlist in orphanPlaylists" :key="playlist.id" :list="playlist" />
+
+      <li
+        v-if="showOutOfFolderZone"
+        :class="{ droppable }"
+        class="drop-zone mt-2 px-3 py-2 rounded-md text-sm text-k-text-secondary border border-dashed border-k-fg-30 text-center select-none"
+        @dragleave="onZoneDragLeave"
+        @dragover="onZoneDragOver"
+        @drop="onZoneDrop"
+      >
+        Drop here to move out of folder
+      </li>
     </ul>
   </SidebarSection>
 </template>
@@ -19,7 +30,7 @@ import { computed, ref, toRef } from 'vue'
 import { playlistFolderStore } from '@/stores/playlistFolderStore'
 import { playlistStore } from '@/stores/playlistStore'
 import { playableStore } from '@/stores/playableStore'
-import { useDroppable } from '@/composables/useDragAndDrop'
+import { currentDragType, useDroppable } from '@/composables/useDragAndDrop'
 
 import PlaylistSidebarItem from './PlaylistSidebarItem.vue'
 import PlaylistFolderSidebarItem from './PlaylistFolderSidebarItem.vue'
@@ -46,16 +57,20 @@ const orphanPlaylists = computed(() =>
   }),
 )
 
-const onDragOver = (event: DragEvent) => {
+// Only show the "move out of folder" zone while a playlist is actively being dragged.
+const showOutOfFolderZone = computed(() => currentDragType.value === 'playlist')
+
+const onZoneDragOver = (event: DragEvent) => {
   if (!acceptsDrop(event)) {
     return false
   }
 
   event.preventDefault()
+  event.stopPropagation()
   droppable.value = true
 }
 
-const onDragLeave = (event: DragEvent) => {
+const onZoneDragLeave = (event: DragEvent) => {
   const relatedTarget = event.relatedTarget as Node | null
   if (relatedTarget && (event.currentTarget as Node).contains(relatedTarget)) {
     return
@@ -64,7 +79,7 @@ const onDragLeave = (event: DragEvent) => {
   droppable.value = false
 }
 
-const onDrop = async (event: DragEvent) => {
+const onZoneDrop = async (event: DragEvent) => {
   droppable.value = false
 
   if (!acceptsDrop(event)) {
@@ -72,6 +87,7 @@ const onDrop = async (event: DragEvent) => {
   }
 
   event.preventDefault()
+  event.stopPropagation()
 
   const playlist = await resolveDroppedValue<Playlist>(event)
   if (!playlist || playlist.folder_id === null) {
@@ -84,7 +100,7 @@ const onDrop = async (event: DragEvent) => {
 
 <style lang="postcss" scoped>
 @reference '@css/app.pcss';
-.droppable {
-  @apply ring-1 ring-offset-0 ring-k-highlight cursor-copy;
+.drop-zone.droppable {
+  @apply border-solid border-k-highlight text-k-highlight cursor-copy;
 }
 </style>

--- a/resources/assets/js/components/layout/main-wrapper/sidebar/SidebarPlaylistsSection.vue
+++ b/resources/assets/js/components/layout/main-wrapper/sidebar/SidebarPlaylistsSection.vue
@@ -40,15 +40,10 @@ const { acceptsDrop, resolveDroppedValue } = useDroppable(['playlist'])
 
 const isDraggingPlaylist = computed(() => currentDragType.value === 'playlist')
 
-// Folders write their id here while they are the active hover-target, and clear
-// it when the cursor leaves them. The CSS below reads this to switch between
-// the "section is the target" and "this folder is the target" states.
 const folderDropTargetId = ref<string | null>(null)
 provide(PlaylistFolderDropTargetKey, folderDropTargetId)
 const hasFolderTarget = computed(() => folderDropTargetId.value !== null)
 
-// PlaylistSidebarItem writes this on dragstart so other sidebar entries can
-// resolve the source folder and compose context-aware drag-ghost text.
 const draggedPlaylist = ref<Playlist | null>(null)
 provide(DraggedPlaylistKey, draggedPlaylist)
 
@@ -68,8 +63,6 @@ const orphanPlaylists = computed(() =>
   }),
 )
 
-// The section is the implicit "no folder" target: dropping anywhere that isn't
-// a folder (folders stop propagation on accept) means "move out of any folder".
 const onDragOver = (event: DragEvent) => {
   if (!acceptsDrop(event)) {
     return false
@@ -77,16 +70,13 @@ const onDragOver = (event: DragEvent) => {
 
   event.preventDefault()
 
-  // The browser's drag-and-drop cursor on macOS ignores CSS `cursor:`; setting
-  // dropEffect explicitly is how we get the copy (+) cursor while hovering.
+  // macOS ignores CSS cursor: during DnD; dropEffect drives the native + cursor.
   if (event.dataTransfer) {
     event.dataTransfer.dropEffect = 'copy'
   }
 
   const playlist = draggedPlaylist.value
   if (!playlist?.folder_id) {
-    // Either nothing tracked yet, or the playlist isn't in a folder so dropping
-    // here is a no-op. Don't claim a move is about to happen.
     setDragText('')
     return
   }
@@ -114,15 +104,6 @@ const onDrop = async (event: DragEvent) => {
 <style lang="postcss" scoped>
 @reference '@css/app.pcss';
 
-/* Two states while a playlist is being dragged:
-
-   1. No folder under the cursor — the section as a whole is the implicit
-      "move out of folder" target. Surface a dashed outline around the whole
-      <ul> and keep every entry at full opacity; dimming would lie about the
-      drop being unavailable.
-   2. Cursor over a folder — that folder is the specific target. Dim every
-      entry except the folder under the cursor, which keeps full opacity to
-      identify it as the accepting target. */
 ul.dragging {
   cursor: copy;
 }

--- a/resources/assets/js/components/layout/main-wrapper/sidebar/SidebarPlaylistsSection.vue
+++ b/resources/assets/js/components/layout/main-wrapper/sidebar/SidebarPlaylistsSection.vue
@@ -5,22 +5,17 @@
       <CreatePlaylistContextMenuButton />
     </SidebarSectionHeader>
 
-    <ul>
+    <ul
+      :class="{ active: showDropAffordance, droppable }"
+      class="rounded-md transition-colors"
+      @dragleave="onDragLeave"
+      @dragover="onDragOver"
+      @drop="onDrop"
+    >
       <PlaylistSidebarItem :list="{ name: 'Favorites', playables: favorites }" />
       <PlaylistSidebarItem :list="{ name: 'Recently Played', playables: [] }" />
       <PlaylistFolderSidebarItem v-for="folder in folders" :key="folder.id" :folder="folder" />
       <PlaylistSidebarItem v-for="playlist in orphanPlaylists" :key="playlist.id" :list="playlist" />
-
-      <li
-        v-if="showOutOfFolderZone"
-        :class="{ droppable }"
-        class="drop-zone mt-2 px-3 py-2 rounded-md text-sm text-k-text-secondary border border-dashed border-k-fg-30 text-center select-none"
-        @dragleave="onZoneDragLeave"
-        @dragover="onZoneDragOver"
-        @drop="onZoneDrop"
-      >
-        Drop here to move out of folder
-      </li>
     </ul>
   </SidebarSection>
 </template>
@@ -45,6 +40,10 @@ const favorites = toRef(playableStore.state, 'favorites')
 const { acceptsDrop, resolveDroppedValue } = useDroppable(['playlist'])
 const droppable = ref(false)
 
+// Show the section's "drop here to leave a folder" hint only while a playlist
+// is actively being dragged, so the rest of the time the sidebar is quiet.
+const showDropAffordance = computed(() => currentDragType.value === 'playlist')
+
 const orphanPlaylists = computed(() =>
   playlists.value.filter(({ folder_id }) => {
     if (folder_id === null) {
@@ -57,20 +56,16 @@ const orphanPlaylists = computed(() =>
   }),
 )
 
-// Only show the "move out of folder" zone while a playlist is actively being dragged.
-const showOutOfFolderZone = computed(() => currentDragType.value === 'playlist')
-
-const onZoneDragOver = (event: DragEvent) => {
+const onDragOver = (event: DragEvent) => {
   if (!acceptsDrop(event)) {
     return false
   }
 
   event.preventDefault()
-  event.stopPropagation()
   droppable.value = true
 }
 
-const onZoneDragLeave = (event: DragEvent) => {
+const onDragLeave = (event: DragEvent) => {
   const relatedTarget = event.relatedTarget as Node | null
   if (relatedTarget && (event.currentTarget as Node).contains(relatedTarget)) {
     return
@@ -79,7 +74,7 @@ const onZoneDragLeave = (event: DragEvent) => {
   droppable.value = false
 }
 
-const onZoneDrop = async (event: DragEvent) => {
+const onDrop = async (event: DragEvent) => {
   droppable.value = false
 
   if (!acceptsDrop(event)) {
@@ -87,7 +82,6 @@ const onZoneDrop = async (event: DragEvent) => {
   }
 
   event.preventDefault()
-  event.stopPropagation()
 
   const playlist = await resolveDroppedValue<Playlist>(event)
   if (!playlist || playlist.folder_id === null) {
@@ -100,7 +94,11 @@ const onZoneDrop = async (event: DragEvent) => {
 
 <style lang="postcss" scoped>
 @reference '@css/app.pcss';
-.drop-zone.droppable {
-  @apply border-solid border-k-highlight text-k-highlight cursor-copy;
+ul.active {
+  @apply bg-k-fg-5;
+}
+
+ul.droppable {
+  @apply ring-1 ring-offset-0 ring-k-highlight cursor-copy;
 }
 </style>

--- a/resources/assets/js/components/layout/main-wrapper/sidebar/SidebarPlaylistsSection.vue
+++ b/resources/assets/js/components/layout/main-wrapper/sidebar/SidebarPlaylistsSection.vue
@@ -5,11 +5,7 @@
       <CreatePlaylistContextMenuButton />
     </SidebarSectionHeader>
 
-    <ul
-      :class="{ dragging: isDraggingPlaylist, 'has-folder-target': isDraggingPlaylist && hasDropTarget }"
-      @dragover="onDragOver"
-      @drop="onDrop"
-    >
+    <ul :class="{ dragging: isDraggingPlaylist }" @dragover="onDragOver" @drop="onDrop">
       <PlaylistSidebarItem :list="{ name: 'Favorites', playables: favorites }" />
       <PlaylistSidebarItem :list="{ name: 'Recently Played', playables: [] }" />
       <PlaylistFolderSidebarItem v-for="folder in folders" :key="folder.id" :folder="folder" />
@@ -23,7 +19,7 @@ import { computed, toRef } from 'vue'
 import { playlistFolderStore } from '@/stores/playlistFolderStore'
 import { playlistStore } from '@/stores/playlistStore'
 import { playableStore } from '@/stores/playableStore'
-import { currentDragType, currentDropTargetFolderId, useDroppable } from '@/composables/useDragAndDrop'
+import { currentDragType, useDroppable } from '@/composables/useDragAndDrop'
 
 import PlaylistSidebarItem from './PlaylistSidebarItem.vue'
 import PlaylistFolderSidebarItem from './PlaylistFolderSidebarItem.vue'
@@ -38,7 +34,6 @@ const favorites = toRef(playableStore.state, 'favorites')
 const { acceptsDrop, resolveDroppedValue } = useDroppable(['playlist'])
 
 const isDraggingPlaylist = computed(() => currentDragType.value === 'playlist')
-const hasDropTarget = computed(() => currentDropTargetFolderId.value !== null)
 
 const orphanPlaylists = computed(() =>
   playlists.value.filter(({ folder_id }) => {
@@ -100,16 +95,16 @@ ul.dragging {
   cursor: copy;
 }
 
-ul.dragging:not(.has-folder-target) {
+ul.dragging:not(:has(:deep(.droppable))) {
   @apply outline-1 outline-dashed outline-offset-2 outline-k-highlight rounded-md;
 }
 
-ul.dragging.has-folder-target > :deep(*) {
+ul.dragging:has(:deep(.droppable)) > :deep(*) {
   opacity: 0.4;
   transition: opacity 0.15s ease;
 }
 
-ul.dragging.has-folder-target > :deep(.droppable) {
+ul.dragging:has(:deep(.droppable)) > :deep(.droppable) {
   opacity: 1;
 }
 </style>

--- a/resources/assets/js/components/layout/main-wrapper/sidebar/SidebarPlaylistsSection.vue
+++ b/resources/assets/js/components/layout/main-wrapper/sidebar/SidebarPlaylistsSection.vue
@@ -5,13 +5,7 @@
       <CreatePlaylistContextMenuButton />
     </SidebarSectionHeader>
 
-    <ul
-      :class="{ active: showDropAffordance, droppable }"
-      class="rounded-md transition-colors"
-      @dragleave="onDragLeave"
-      @dragover="onDragOver"
-      @drop="onDrop"
-    >
+    <ul :class="{ dragging: isDraggingPlaylist, 'has-target': hasDropTarget }" @dragover="onDragOver" @drop="onDrop">
       <PlaylistSidebarItem :list="{ name: 'Favorites', playables: favorites }" />
       <PlaylistSidebarItem :list="{ name: 'Recently Played', playables: [] }" />
       <PlaylistFolderSidebarItem v-for="folder in folders" :key="folder.id" :folder="folder" />
@@ -21,11 +15,11 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, ref, toRef } from 'vue'
+import { computed, toRef } from 'vue'
 import { playlistFolderStore } from '@/stores/playlistFolderStore'
 import { playlistStore } from '@/stores/playlistStore'
 import { playableStore } from '@/stores/playableStore'
-import { currentDragType, useDroppable } from '@/composables/useDragAndDrop'
+import { currentDragType, currentDropTargetFolderId, useDroppable } from '@/composables/useDragAndDrop'
 
 import PlaylistSidebarItem from './PlaylistSidebarItem.vue'
 import PlaylistFolderSidebarItem from './PlaylistFolderSidebarItem.vue'
@@ -38,11 +32,9 @@ const playlists = toRef(playlistStore.state, 'playlists')
 const favorites = toRef(playableStore.state, 'favorites')
 
 const { acceptsDrop, resolveDroppedValue } = useDroppable(['playlist'])
-const droppable = ref(false)
 
-// Show the section's "drop here to leave a folder" hint only while a playlist
-// is actively being dragged, so the rest of the time the sidebar is quiet.
-const showDropAffordance = computed(() => currentDragType.value === 'playlist')
+const isDraggingPlaylist = computed(() => currentDragType.value === 'playlist')
+const hasDropTarget = computed(() => currentDropTargetFolderId.value !== null)
 
 const orphanPlaylists = computed(() =>
   playlists.value.filter(({ folder_id }) => {
@@ -56,27 +48,17 @@ const orphanPlaylists = computed(() =>
   }),
 )
 
+// The section is the implicit "no folder" target: dropping anywhere that isn't
+// a folder (folders stop propagation on accept) means "move out of any folder".
 const onDragOver = (event: DragEvent) => {
   if (!acceptsDrop(event)) {
     return false
   }
 
   event.preventDefault()
-  droppable.value = true
-}
-
-const onDragLeave = (event: DragEvent) => {
-  const relatedTarget = event.relatedTarget as Node | null
-  if (relatedTarget && (event.currentTarget as Node).contains(relatedTarget)) {
-    return
-  }
-
-  droppable.value = false
 }
 
 const onDrop = async (event: DragEvent) => {
-  droppable.value = false
-
   if (!acceptsDrop(event)) {
     return false
   }
@@ -94,11 +76,29 @@ const onDrop = async (event: DragEvent) => {
 
 <style lang="postcss" scoped>
 @reference '@css/app.pcss';
-ul.active {
-  @apply bg-k-fg-5;
+
+/* Two states while a playlist is being dragged:
+
+   1. No drop target under the cursor — the source folder dims, signalling
+      "you're leaving me." Everything else stays at full opacity, so the
+      whole non-source area reads as a valid "drop to remove from folder."
+
+   2. Cursor over an accepting folder — invert: the target folder pops at
+      full opacity, everything else (including the source) dims, signalling
+      "drop here to add to this folder." */
+ul.dragging > :deep(*) {
+  transition: opacity 0.15s ease;
 }
 
-ul.droppable {
-  @apply ring-1 ring-offset-0 ring-k-highlight cursor-copy;
+ul.dragging > :deep(.drag-source) {
+  opacity: 0.4;
+}
+
+ul.dragging.has-target > :deep(*) {
+  opacity: 0.4;
+}
+
+ul.dragging.has-target > :deep(.drag-target) {
+  opacity: 1;
 }
 </style>

--- a/resources/assets/js/components/layout/main-wrapper/sidebar/SidebarPlaylistsSection.vue
+++ b/resources/assets/js/components/layout/main-wrapper/sidebar/SidebarPlaylistsSection.vue
@@ -109,8 +109,6 @@ ul.dragging > :deep(.droppable) {
 /* No folder is targeted — surface a faint dashed outline so the user can see
    that the whole section is the implicit "move out of folder" drop zone. */
 ul.dragging.no-target {
-  outline: 1px dashed var(--color-k-highlight);
-  outline-offset: 4px;
-  border-radius: 0.375rem;
+  @apply outline-1 outline-dashed outline-offset-2 outline-k-highlight rounded-md;
 }
 </style>

--- a/resources/assets/js/components/layout/main-wrapper/sidebar/SidebarPlaylistsSection.vue
+++ b/resources/assets/js/components/layout/main-wrapper/sidebar/SidebarPlaylistsSection.vue
@@ -5,7 +5,11 @@
       <CreatePlaylistContextMenuButton />
     </SidebarSectionHeader>
 
-    <ul :class="{ dragging: isDraggingPlaylist }" @dragover="onDragOver" @drop="onDrop">
+    <ul
+      :class="{ dragging: isDraggingPlaylist, 'no-target': isDraggingPlaylist && !hasDropTarget }"
+      @dragover="onDragOver"
+      @drop="onDrop"
+    >
       <PlaylistSidebarItem :list="{ name: 'Favorites', playables: favorites }" />
       <PlaylistSidebarItem :list="{ name: 'Recently Played', playables: [] }" />
       <PlaylistFolderSidebarItem v-for="folder in folders" :key="folder.id" :folder="folder" />
@@ -19,7 +23,7 @@ import { computed, toRef } from 'vue'
 import { playlistFolderStore } from '@/stores/playlistFolderStore'
 import { playlistStore } from '@/stores/playlistStore'
 import { playableStore } from '@/stores/playableStore'
-import { currentDragType, useDroppable } from '@/composables/useDragAndDrop'
+import { currentDragType, currentDropTargetFolderId, useDroppable } from '@/composables/useDragAndDrop'
 
 import PlaylistSidebarItem from './PlaylistSidebarItem.vue'
 import PlaylistFolderSidebarItem from './PlaylistFolderSidebarItem.vue'
@@ -34,6 +38,7 @@ const favorites = toRef(playableStore.state, 'favorites')
 const { acceptsDrop, resolveDroppedValue } = useDroppable(['playlist'])
 
 const isDraggingPlaylist = computed(() => currentDragType.value === 'playlist')
+const hasDropTarget = computed(() => currentDropTargetFolderId.value !== null)
 
 const orphanPlaylists = computed(() =>
   playlists.value.filter(({ folder_id }) => {
@@ -89,6 +94,7 @@ const onDrop = async (event: DragEvent) => {
    the playlist out of its folder. */
 ul.dragging {
   cursor: copy;
+  transition: outline-color 0.15s ease;
 }
 
 ul.dragging > :deep(*) {
@@ -98,5 +104,13 @@ ul.dragging > :deep(*) {
 
 ul.dragging > :deep(.droppable) {
   opacity: 1;
+}
+
+/* No folder is targeted — surface a faint dashed outline so the user can see
+   that the whole section is the implicit "move out of folder" drop zone. */
+ul.dragging.no-target {
+  outline: 1px dashed var(--color-k-highlight);
+  outline-offset: 4px;
+  border-radius: 0.375rem;
 }
 </style>

--- a/resources/assets/js/components/playlist/PlaylistContextMenu.vue
+++ b/resources/assets/js/components/playlist/PlaylistContextMenu.vue
@@ -18,6 +18,10 @@
       <Separator />
       <MenuItem @click="toggleOffline">{{ allCached ? 'Remove Offline Versions' : 'Make Available Offline' }}</MenuItem>
     </template>
+    <template v-if="canMoveOutOfFolder">
+      <Separator />
+      <MenuItem @click="moveOutOfFolder">Move Out of Folder</MenuItem>
+    </template>
     <template v-if="canEditPlaylist || canDeletePlaylist">
       <Separator />
       <MenuItem v-if="canEditPlaylist" @click="edit">Edit…</MenuItem>
@@ -41,6 +45,7 @@ import { useKoelPlus } from '@/composables/useKoelPlus'
 import { queueStore } from '@/stores/queueStore'
 import { playableStore } from '@/stores/playableStore'
 import { playback } from '@/services/playbackManager'
+import { playlistFolderStore } from '@/stores/playlistFolderStore'
 import { playlistStore } from '@/stores/playlistStore'
 import { useDialogBox } from '@/composables/useDialogBox'
 import { commonStore } from '@/stores/commonStore'
@@ -71,6 +76,7 @@ const allowEmbedding = toRef(commonStore.state, 'allows_embedding')
 
 const canEditPlaylist = computed(() => currentUserCan.editPlaylist(playlist.value))
 const canDeletePlaylist = computed(() => currentUserCan.deletePlaylist(playlist.value))
+const canMoveOutOfFolder = computed(() => playlist.value.folder_id !== null && canEditPlaylist.value)
 const canShowCollaboration = computed(() => isPlus.value && !playlist.value?.is_smart)
 const canShare = computed(() => allowEmbedding.value || canShowCollaboration.value)
 
@@ -129,6 +135,8 @@ const addToQueue = () =>
       toastWarning('The playlist is empty.')
     }
   })
+
+const moveOutOfFolder = () => trigger(() => playlistFolderStore.movePlaylistToFolder(playlist.value, null))
 
 const showCollaborationModal = () =>
   trigger(() => openModal<'PLAYLIST_COLLABORATION'>(PlaylistCollaborationModal, { playlist: playlist.value }))

--- a/resources/assets/js/composables/useDragAndDrop.ts
+++ b/resources/assets/js/composables/useDragAndDrop.ts
@@ -24,12 +24,16 @@ document.addEventListener('dragend', clearDragState)
 document.addEventListener('drop', clearDragState, true)
 
 // Update the drag-ghost label mid-drag so drop targets can surface
-// context-aware text (e.g. "Move A into folder B").
+// context-aware text (e.g. "Move A to B"). Pass an empty string to hide the
+// ghost entirely — useful when the cursor is over a target that would no-op.
 export const setDragText = (text: string): void => {
   const ghost = document.querySelector<HTMLElement>('#dragGhost')
-  if (ghost) {
-    ghost.textContent = text
+  if (!ghost) {
+    return
   }
+
+  ghost.textContent = text
+  ghost.style.display = text ? 'block' : 'none'
 }
 
 // A transparent 1x1 image used to suppress the browser's default drag ghost.

--- a/resources/assets/js/composables/useDragAndDrop.ts
+++ b/resources/assets/js/composables/useDragAndDrop.ts
@@ -1,3 +1,4 @@
+import { ref } from 'vue'
 import { pluralize } from '@/utils/formatters'
 import { arrayify, getPlayableProp } from '@/utils/helpers'
 import { logger } from '@/utils/logger'
@@ -11,6 +12,14 @@ import { mediaBrowser } from '@/services/mediaBrowser'
 type Draggable = MaybeArray<Playable> | Album | Artist | Genre | Playlist | PlaylistFolder | MaybeArray<Song | Folder>
 const draggableTypes = <const>['playables', 'album', 'artist', 'genre', 'playlist', 'playlist-folder', 'browser-media']
 type DraggableType = (typeof draggableTypes)[number]
+
+// Reactive type of the currently-active drag. Set on dragstart, cleared on dragend.
+// Components can read this to render drag-type-specific drop affordances
+// (e.g. show a "remove from folder" target only while a playlist is being dragged).
+export const currentDragType = ref<DraggableType | null>(null)
+
+document.addEventListener('dragend', () => (currentDragType.value = null))
+document.addEventListener('drop', () => (currentDragType.value = null), true)
 
 // A transparent 1x1 image used to suppress the browser's default drag ghost.
 const emptyDragImage = (() => {
@@ -89,6 +98,7 @@ export const useDraggable = (type: DraggableType) => {
       return
     }
 
+    currentDragType.value = type
     event.dataTransfer.effectAllowed = 'copyMove'
 
     let text: string

--- a/resources/assets/js/composables/useDragAndDrop.ts
+++ b/resources/assets/js/composables/useDragAndDrop.ts
@@ -13,9 +13,6 @@ type Draggable = MaybeArray<Playable> | Album | Artist | Genre | Playlist | Play
 const draggableTypes = <const>['playables', 'album', 'artist', 'genre', 'playlist', 'playlist-folder', 'browser-media']
 type DraggableType = (typeof draggableTypes)[number]
 
-// Reactive type of the currently-active drag. Set on dragstart, cleared on dragend.
-// Components can read this to render drag-type-specific drop affordances
-// (e.g. show a "remove from folder" target only while a playlist is being dragged).
 export const currentDragType = ref<DraggableType | null>(null)
 
 const clearDragState = () => (currentDragType.value = null)
@@ -23,9 +20,7 @@ const clearDragState = () => (currentDragType.value = null)
 document.addEventListener('dragend', clearDragState)
 document.addEventListener('drop', clearDragState, true)
 
-// Update the drag-ghost label mid-drag so drop targets can surface
-// context-aware text (e.g. "Move A to B"). Pass an empty string to hide the
-// ghost entirely — useful when the cursor is over a target that would no-op.
+// Empty text hides the ghost — used when the hover target would no-op.
 export const setDragText = (text: string): void => {
   const ghost = document.querySelector<HTMLElement>('#dragGhost')
   if (!ghost) {

--- a/resources/assets/js/composables/useDragAndDrop.ts
+++ b/resources/assets/js/composables/useDragAndDrop.ts
@@ -18,8 +18,22 @@ type DraggableType = (typeof draggableTypes)[number]
 // (e.g. show a "remove from folder" target only while a playlist is being dragged).
 export const currentDragType = ref<DraggableType | null>(null)
 
-document.addEventListener('dragend', () => (currentDragType.value = null))
-document.addEventListener('drop', () => (currentDragType.value = null), true)
+// The playlist currently being dragged (only meaningful when currentDragType === 'playlist').
+// Lets the sidebar identify the source folder so it can render the "leaving" affordance.
+export const currentDraggedPlaylist = ref<Playlist | null>(null)
+
+// Id of the folder the cursor is currently over as an accepting drop target.
+// The folder itself sets/clears this from its dragover/dragleave handlers.
+export const currentDropTargetFolderId = ref<string | null>(null)
+
+const clearDragState = () => {
+  currentDragType.value = null
+  currentDraggedPlaylist.value = null
+  currentDropTargetFolderId.value = null
+}
+
+document.addEventListener('dragend', clearDragState)
+document.addEventListener('drop', clearDragState, true)
 
 // A transparent 1x1 image used to suppress the browser's default drag ghost.
 const emptyDragImage = (() => {
@@ -131,6 +145,7 @@ export const useDraggable = (type: DraggableType) => {
         dragged = <Playlist>dragged
         text = dragged.name
         data = dragged.id
+        currentDraggedPlaylist.value = dragged
         break
 
       case 'playlist-folder':

--- a/resources/assets/js/composables/useDragAndDrop.ts
+++ b/resources/assets/js/composables/useDragAndDrop.ts
@@ -18,16 +18,7 @@ type DraggableType = (typeof draggableTypes)[number]
 // (e.g. show a "remove from folder" target only while a playlist is being dragged).
 export const currentDragType = ref<DraggableType | null>(null)
 
-// Id of the folder the cursor is currently over as an accepting drop target.
-// The sidebar reads this to render the "no folder targeted" affordance for the
-// implicit "move out of folder" drop. Each folder sets it on dragover and
-// clears it on dragleave.
-export const currentDropTargetFolderId = ref<string | null>(null)
-
-const clearDragState = () => {
-  currentDragType.value = null
-  currentDropTargetFolderId.value = null
-}
+const clearDragState = () => (currentDragType.value = null)
 
 document.addEventListener('dragend', clearDragState)
 document.addEventListener('drop', clearDragState, true)

--- a/resources/assets/js/composables/useDragAndDrop.ts
+++ b/resources/assets/js/composables/useDragAndDrop.ts
@@ -23,6 +23,15 @@ const clearDragState = () => (currentDragType.value = null)
 document.addEventListener('dragend', clearDragState)
 document.addEventListener('drop', clearDragState, true)
 
+// Update the drag-ghost label mid-drag so drop targets can surface
+// context-aware text (e.g. "Move A into folder B").
+export const setDragText = (text: string): void => {
+  const ghost = document.querySelector<HTMLElement>('#dragGhost')
+  if (ghost) {
+    ghost.textContent = text
+  }
+}
+
 // A transparent 1x1 image used to suppress the browser's default drag ghost.
 const emptyDragImage = (() => {
   const img = new Image()

--- a/resources/assets/js/composables/useDragAndDrop.ts
+++ b/resources/assets/js/composables/useDragAndDrop.ts
@@ -18,19 +18,7 @@ type DraggableType = (typeof draggableTypes)[number]
 // (e.g. show a "remove from folder" target only while a playlist is being dragged).
 export const currentDragType = ref<DraggableType | null>(null)
 
-// The playlist currently being dragged (only meaningful when currentDragType === 'playlist').
-// Lets the sidebar identify the source folder so it can render the "leaving" affordance.
-export const currentDraggedPlaylist = ref<Playlist | null>(null)
-
-// Id of the folder the cursor is currently over as an accepting drop target.
-// The folder itself sets/clears this from its dragover/dragleave handlers.
-export const currentDropTargetFolderId = ref<string | null>(null)
-
-const clearDragState = () => {
-  currentDragType.value = null
-  currentDraggedPlaylist.value = null
-  currentDropTargetFolderId.value = null
-}
+const clearDragState = () => (currentDragType.value = null)
 
 document.addEventListener('dragend', clearDragState)
 document.addEventListener('drop', clearDragState, true)
@@ -145,7 +133,6 @@ export const useDraggable = (type: DraggableType) => {
         dragged = <Playlist>dragged
         text = dragged.name
         data = dragged.id
-        currentDraggedPlaylist.value = dragged
         break
 
       case 'playlist-folder':

--- a/resources/assets/js/composables/useDragAndDrop.ts
+++ b/resources/assets/js/composables/useDragAndDrop.ts
@@ -18,7 +18,16 @@ type DraggableType = (typeof draggableTypes)[number]
 // (e.g. show a "remove from folder" target only while a playlist is being dragged).
 export const currentDragType = ref<DraggableType | null>(null)
 
-const clearDragState = () => (currentDragType.value = null)
+// Id of the folder the cursor is currently over as an accepting drop target.
+// The sidebar reads this to render the "no folder targeted" affordance for the
+// implicit "move out of folder" drop. Each folder sets it on dragover and
+// clears it on dragleave.
+export const currentDropTargetFolderId = ref<string | null>(null)
+
+const clearDragState = () => {
+  currentDragType.value = null
+  currentDropTargetFolderId.value = null
+}
 
 document.addEventListener('dragend', clearDragState)
 document.addEventListener('drop', clearDragState, true)

--- a/resources/assets/js/config/symbols.ts
+++ b/resources/assets/js/config/symbols.ts
@@ -42,13 +42,5 @@ export const PlayableListContextKey: InjectionKey<Ref<PlayableListContext>> = Sy
 
 export const BlockActionsHostKey: InjectionKey<Ref<HTMLElement | null>> = Symbol('BlockActionsHost')
 
-// Shared between SidebarPlaylistsSection (provider) and PlaylistFolderSidebarItem (consumer):
-// the id of the folder the cursor is currently hovering over as a drop target,
-// or null when no folder is targeted (i.e. the section as a whole is the implicit
-// 'move out of folder' target). Sidebar-scoped concern, not part of useDragAndDrop.
 export const PlaylistFolderDropTargetKey: InjectionKey<Ref<string | null>> = Symbol('PlaylistFolderDropTarget')
-
-// The playlist currently being dragged from the sidebar. PlaylistSidebarItem
-// writes it on dragstart; SidebarPlaylistsSection clears it on dragend.
-// Sidebar drop targets read it to compose context-aware drag-ghost text.
 export const DraggedPlaylistKey: InjectionKey<Ref<Playlist | null>> = Symbol('DraggedPlaylist')

--- a/resources/assets/js/config/symbols.ts
+++ b/resources/assets/js/config/symbols.ts
@@ -41,3 +41,9 @@ export const PlayableListSortOrderKey: ReadonlyInjectionKey<Ref<SortOrder>> = Sy
 export const PlayableListContextKey: InjectionKey<Ref<PlayableListContext>> = Symbol('PlayableListContext')
 
 export const BlockActionsHostKey: InjectionKey<Ref<HTMLElement | null>> = Symbol('BlockActionsHost')
+
+// Shared between SidebarPlaylistsSection (provider) and PlaylistFolderSidebarItem (consumer):
+// the id of the folder the cursor is currently hovering over as a drop target,
+// or null when no folder is targeted (i.e. the section as a whole is the implicit
+// 'move out of folder' target). Sidebar-scoped concern, not part of useDragAndDrop.
+export const PlaylistFolderDropTargetKey: InjectionKey<Ref<string | null>> = Symbol('PlaylistFolderDropTarget')

--- a/resources/assets/js/config/symbols.ts
+++ b/resources/assets/js/config/symbols.ts
@@ -47,3 +47,8 @@ export const BlockActionsHostKey: InjectionKey<Ref<HTMLElement | null>> = Symbol
 // or null when no folder is targeted (i.e. the section as a whole is the implicit
 // 'move out of folder' target). Sidebar-scoped concern, not part of useDragAndDrop.
 export const PlaylistFolderDropTargetKey: InjectionKey<Ref<string | null>> = Symbol('PlaylistFolderDropTarget')
+
+// The playlist currently being dragged from the sidebar. PlaylistSidebarItem
+// writes it on dragstart; SidebarPlaylistsSection clears it on dragend.
+// Sidebar drop targets read it to compose context-aware drag-ghost text.
+export const DraggedPlaylistKey: InjectionKey<Ref<Playlist | null>> = Symbol('DraggedPlaylist')

--- a/resources/assets/js/stores/playlistFolderStore.spec.ts
+++ b/resources/assets/js/stores/playlistFolderStore.spec.ts
@@ -150,6 +150,16 @@ describe('playlistFolderStore', () => {
     expect(http.delete).not.toHaveBeenCalled()
   })
 
+  it('rolls folder_id back when the move request fails', async () => {
+    const folder = h.factory('playlist-folder').make()
+    const playlist = h.factory('playlist').make({ folder_id: null })
+    vi.mocked(http.post).mockRejectedValue(new Error('boom'))
+
+    await expect(playlistFolderStore.movePlaylistToFolder(playlist, folder)).rejects.toThrow('boom')
+
+    expect(playlist.folder_id).toBeNull()
+  })
+
   it('sorts folders alphabetically', () => {
     const sorted = playlistFolderStore.sort([
       h.factory('playlist-folder').make({ name: 'Zebra' }),

--- a/resources/assets/js/stores/playlistFolderStore.spec.ts
+++ b/resources/assets/js/stores/playlistFolderStore.spec.ts
@@ -96,26 +96,58 @@ describe('playlistFolderStore', () => {
     expect(playlistFolderStore.byId(folder.id)!.name).toBe('New')
   })
 
-  it('adds a playlist to folder', async () => {
+  it('moves a playlist into a folder', async () => {
     const folder = h.factory('playlist-folder').make()
     const playlist = h.factory('playlist').make({ folder_id: null })
     vi.mocked(http.post).mockResolvedValue({})
 
-    await playlistFolderStore.addPlaylistToFolder(folder, playlist)
+    await playlistFolderStore.movePlaylistToFolder(playlist, folder)
 
     expect(playlist.folder_id).toBe(folder.id)
     expect(http.post).toHaveBeenCalledWith(`playlist-folders/${folder.id}/playlists`, { playlists: [playlist.id] })
   })
 
-  it('removes a playlist from folder', async () => {
+  it('moves a playlist out of a folder', async () => {
     const folder = h.factory('playlist-folder').make()
     const playlist = h.factory('playlist').make({ folder_id: folder.id })
     vi.mocked(http.delete).mockResolvedValue({})
 
-    await playlistFolderStore.removePlaylistFromFolder(folder, playlist)
+    await playlistFolderStore.movePlaylistToFolder(playlist, null)
 
     expect(playlist.folder_id).toBeNull()
     expect(http.delete).toHaveBeenCalledWith(`playlist-folders/${folder.id}/playlists`, { playlists: [playlist.id] })
+  })
+
+  it('moves a playlist between folders via the target folder POST', async () => {
+    const fromFolder = h.factory('playlist-folder').make()
+    const toFolder = h.factory('playlist-folder').make()
+    const playlist = h.factory('playlist').make({ folder_id: fromFolder.id })
+    vi.mocked(http.post).mockResolvedValue({})
+
+    await playlistFolderStore.movePlaylistToFolder(playlist, toFolder)
+
+    expect(playlist.folder_id).toBe(toFolder.id)
+    expect(http.post).toHaveBeenCalledWith(`playlist-folders/${toFolder.id}/playlists`, { playlists: [playlist.id] })
+    expect(http.delete).not.toHaveBeenCalled()
+  })
+
+  it('no-ops when the playlist is already in the target folder', async () => {
+    const folder = h.factory('playlist-folder').make()
+    const playlist = h.factory('playlist').make({ folder_id: folder.id })
+
+    await playlistFolderStore.movePlaylistToFolder(playlist, folder)
+
+    expect(http.post).not.toHaveBeenCalled()
+    expect(http.delete).not.toHaveBeenCalled()
+  })
+
+  it('no-ops when moving an already-orphan playlist to no folder', async () => {
+    const playlist = h.factory('playlist').make({ folder_id: null })
+
+    await playlistFolderStore.movePlaylistToFolder(playlist, null)
+
+    expect(http.post).not.toHaveBeenCalled()
+    expect(http.delete).not.toHaveBeenCalled()
   })
 
   it('sorts folders alphabetically', () => {

--- a/resources/assets/js/stores/playlistFolderStore.ts
+++ b/resources/assets/js/stores/playlistFolderStore.ts
@@ -49,10 +49,16 @@ export const playlistFolderStore = {
     // Update folder_id locally so the UI reflects the move immediately.
     playlist.folder_id = targetFolderId
 
-    if (folder) {
-      await http.post(`playlist-folders/${folder.id}/playlists`, { playlists: [playlist.id] })
-    } else if (sourceFolderId) {
-      await http.delete(`playlist-folders/${sourceFolderId}/playlists`, { playlists: [playlist.id] })
+    try {
+      if (folder) {
+        await http.post(`playlist-folders/${folder.id}/playlists`, { playlists: [playlist.id] })
+      } else if (sourceFolderId) {
+        await http.delete(`playlist-folders/${sourceFolderId}/playlists`, { playlists: [playlist.id] })
+      }
+    } catch (error) {
+      // Roll the optimistic mutation back so the UI doesn't diverge from the server.
+      playlist.folder_id = sourceFolderId
+      throw error
     }
   },
 

--- a/resources/assets/js/stores/playlistFolderStore.ts
+++ b/resources/assets/js/stores/playlistFolderStore.ts
@@ -37,18 +37,23 @@ export const playlistFolderStore = {
     this.byId(folder.id)!.name = name
   },
 
-  async addPlaylistToFolder(folder: PlaylistFolder, playlist: Playlist) {
-    // Update the folder ID right away, so that the UI can be refreshed immediately.
-    // The actual HTTP request will be done in the background.
-    playlist.folder_id = folder.id
-    await http.post(`playlist-folders/${folder.id}/playlists`, { playlists: [playlist.id] })
-  },
+  async movePlaylistToFolder(playlist: Playlist, folder: PlaylistFolder | null) {
+    const targetFolderId = folder?.id ?? null
 
-  async removePlaylistFromFolder(folder: PlaylistFolder, playlist: Playlist) {
-    // Update the folder ID right away, so that the UI can be updated immediately.
-    // The actual update will be done in the background.
-    playlist.folder_id = null
-    await http.delete(`playlist-folders/${folder.id}/playlists`, { playlists: [playlist.id] })
+    if (playlist.folder_id === targetFolderId) {
+      return
+    }
+
+    const sourceFolderId = playlist.folder_id
+
+    // Update folder_id locally so the UI reflects the move immediately.
+    playlist.folder_id = targetFolderId
+
+    if (folder) {
+      await http.post(`playlist-folders/${folder.id}/playlists`, { playlists: [playlist.id] })
+    } else if (sourceFolderId) {
+      await http.delete(`playlist-folders/${sourceFolderId}/playlists`, { playlists: [playlist.id] })
+    }
   },
 
   sort: (folders: PlaylistFolder[] | UnwrapNestedRefs<PlaylistFolder>[]) => orderBy(folders, 'name'),


### PR DESCRIPTION
## Summary

Reworks the drag-and-drop UX for moving playlists in and out of folders.

**Before:** add-to-folder used the folder body as the drop target; remove-from-folder needed a 1px-tall absolutely-positioned "hatch" at the bottom of each folder. The hatch was undiscoverable, hard to hit, asymmetric with adding, and required a separate store method to back it.

**After:** both operations go through one model — `playlistFolderStore.movePlaylistToFolder(playlist, folder | null)`. The sidebar's outer `<ul>` (the area where standalone playlists live) becomes the drop target for "move out of folder": drop any folder-bound playlist anywhere outside a folder and it moves to no-folder. The folder body remains the add-target. Hatch deleted.

## What's in the diff

**Store consolidation**
- One method, `movePlaylistToFolder(playlist, folder | null)`, replaces `addPlaylistToFolder` + `removePlaylistFromFolder`. Internally branches on the target: POST when target is a folder (also covers folder-to-folder reassignments), DELETE only when moving from-folder to no-folder. No-ops when target equals current. The two HTTP endpoints stay as-is.

**Sidebar wiring**
- `SidebarPlaylistsSection`'s `<ul>` is a `'playlist'`-type drop target. Drop = `movePlaylistToFolder(playlist, null)`.
- `PlaylistFolderSidebarItem` drops the hatch and its three hatch handlers. The folder body is still the add target.
- `PlaylistSidebarItem` no longer stops propagation indiscriminately. The `.stop` modifiers came off the drag events; the handlers call `stopPropagation()` only when this item accepts the drop. A `playlist`-type drag (which the item rejects) now bubbles up to the folder or section to be handled there — that was the missing piece for "drop on a playlist item inside folder A bubbles to folder A."

**Timer hygiene in the folder component**
- `expandTimeout` is now a `ref<number | null>(null)` with one `cancelAutoExpand()` clear point.
- `onBeforeUnmount(cancelAutoExpand)` — fixes the unmount leak.
- `onDragLeave` uses `event.relatedTarget` + `currentTarget.contains(...)` to ignore the spurious `dragleave` that fires when the cursor enters a child element. No more flicker killing the auto-expand mid-hover.
- `onDrop` calls `event.stopPropagation()` so the section-level handler doesn't ALSO process the drop and undo the move.

## Test plan

- [x] `vp check resources/assets/js` — formatter, lint, typecheck clean
- [x] Affected specs pass (18/18): `playlistFolderStore`, `PlaylistSidebarItem`, `PlaylistFolderSidebarItem`, `SidebarPlaylistsSection`
- [x] Store covers: add, remove, folder→folder move, no-op-same-folder, no-op-already-orphan
- [ ] Manual smoke after merge:
  - Drag an orphan playlist onto a folder → folder ring lights up, drop adds to folder
  - Drag a folder-bound playlist onto the section outside any folder → section ring lights up, drop removes from folder
  - Drag a folder-bound playlist onto a different folder → reassigns folders
  - Hover over a closed folder for ~500ms while dragging → folder auto-expands
  - Drag away from a folder before 500ms → folder doesn't spontaneously open later
  - Drop songs/album/artist onto a playlist inside a folder → still adds to that playlist (no folder-level interference)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a “Move out of folder” drop area in the playlists sidebar.
  * Added a “Move out of folder” context menu option for editable playlists currently inside a folder.

* **Bug Fixes**
  * Improved drag-and-drop handling so droppable feedback and event actions only occur when a drop is actually accepted.
  * Refined folder drag behavior, including more reliable auto-expansion and better handling of drag leaving child elements.

* **Tests**
  * Updated coverage to focus on moving playlists into/out of folders, including no-op moves and rollback on failed requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->