### PR TITLE
fix: green drop indicator no longer leaves a gap on the left

### DIFF
--- a/resources/assets/js/components/playable/playable-list/PlayableListItem.vue
+++ b/resources/assets/js/components/playable/playable-list/PlayableListItem.vue
@@ -141,7 +141,7 @@ const toggleFavorite = () => playableStore.toggleFavorite(playable.value)
 @reference '@css/app.pcss';
 article {
   &.droppable {
-    @apply relative transition-none after:absolute after:w-full after:h-[3px] after:rounded-sm after:bg-k-success after:top-0;
+    @apply relative transition-none after:absolute after:inset-x-0 after:h-[3px] after:rounded-sm after:bg-k-success after:top-0;
 
     &.dragover-bottom {
       @apply after:top-auto after:bottom-0;
@@ -152,7 +152,7 @@ article {
     .title,
     .track-number,
     .favorite {
-      @apply text-k-highlight!;
+      @apply text-k-highlight;
     }
   }
 


### PR DESCRIPTION
The .droppable ::after relied on the default static position inside the flex row, which started the bar a few pixels in from the article's left edge. `after:w-full` then rendered 100% width from that offset, so the bar fell short of the row's left boundary.

Anchor it with `after:inset-x-0` so both edges align with the row.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined visual styling for playlist items, improving appearance of active and dragging states with adjusted underline positioning and text styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->