### PR TITLE
fix: keep lyrics zoom controls pinned to the pane's top-right corner

### DIFF
--- a/resources/assets/js/components/ui/lyrics/LyricsPane.vue
+++ b/resources/assets/js/components/ui/lyrics/LyricsPane.vue
@@ -2,7 +2,11 @@
   <div v-if="hasLyrics" class="group relative h-full">
     <LrcLyricsPane v-if="isLrc" :font-size="fontSize" :lyrics="lrcLyrics" class="absolute inset-0 px-6 py-8" />
 
-    <div v-else class="lyrics px-6 py-8 whitespace-pre-wrap leading-relaxed" data-testid="plain-text-lyrics">
+    <div
+      v-else
+      class="lyrics absolute inset-0 px-6 py-8 overflow-y-auto scroll-mask-y whitespace-pre-wrap leading-relaxed"
+      data-testid="plain-text-lyrics"
+    >
       {{ plainTextLyrics }}
     </div>
 

--- a/resources/assets/js/components/ui/lyrics/__snapshots__/LyricsPane.spec.ts.snap
+++ b/resources/assets/js/components/ui/lyrics/__snapshots__/LyricsPane.spec.ts.snap
@@ -2,6 +2,6 @@
 
 exports[`lyricsPane.vue > renders 1`] = `
 <div data-v-0910b162="" class="group relative h-full">
-  <div data-v-0910b162="" class="lyrics px-6 py-8 whitespace-pre-wrap leading-relaxed" data-testid="plain-text-lyrics">Foo bar baz qux</div><br data-v-0910b162="" data-testid="magnifier" class="absolute top-4 right-4 opacity-0 group-hover:opacity-50 hover:opacity-100! transition-opacity no-hover:opacity-100!">
+  <div data-v-0910b162="" class="lyrics absolute inset-0 px-6 py-8 overflow-y-auto scroll-mask-y whitespace-pre-wrap leading-relaxed" data-testid="plain-text-lyrics">Foo bar baz qux</div><br data-v-0910b162="" data-testid="magnifier" class="absolute top-4 right-4 opacity-0 group-hover:opacity-50 hover:opacity-100! transition-opacity no-hover:opacity-100!">
 </div>
 `;


### PR DESCRIPTION
The lyrics zoom controls scrolled away with the content and, once made sticky, were faded out by the side sheet's scroll mask. They now stay pinned, crisp, to the top-right corner of the lyrics pane.

## Cause

In `LyricsPane.vue` the plain-text lyrics rendered in the normal flow of the side sheet's `<main>` scroll container. That made `<main>` itself scroll, which:

1. carried the `absolute`-positioned controls up out of view, and
2. activated `<main>`'s `scroll-mask-y` fade over its entire subtree — including the controls — so even a `sticky` element faded out near the top edge (a CSS mask can't be cancelled on a descendant).

The synced (LRC) pane never had this problem because it's `absolute inset-0` with its own internal scroller, leaving `<main>` unscrolled and its mask inert.

## Fix

Made the plain-text pane scroll itself, mirroring the LRC pane:

```html
<div class="lyrics absolute inset-0 px-6 py-8 overflow-y-auto scroll-mask-y ...">
```

Now `<main>` never scrolls on the lyrics tab, its mask stays inert, and the Magnifier — a sibling outside both scrolling panes — is no longer inside any masked region. The controls go back to a plain `absolute top-4 right-4`, genuinely pinned to the pane's top-right corner regardless of scroll. The plain-text pane also gains the same top/bottom scroll fade the synced pane already had.

The Artist/Album/YouTube tabs are unaffected — they still flow in `<main>` and use its mask as before.

## Tests

Updated the `LyricsPane` snapshot; all 5 tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the lyrics display pane with improved scrolling functionality and better positioning. Users can now navigate extended lyrics content more smoothly with optimized readability and visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->