### PR TITLE
fix: close context menu after rating from it

### DIFF
--- a/resources/assets/js/components/album/AlbumContextMenu.spec.ts
+++ b/resources/assets/js/components/album/AlbumContextMenu.spec.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it, vi } from 'vite-plus/test'
 import { screen } from '@testing-library/vue'
+import { shallowRef } from 'vue'
 import { createHarness } from '@/__tests__/TestHarness'
 import { assertOpenModal } from '@/__tests__/assertions'
 import factory from '@/__tests__/factory'
+import { ContextMenuKey } from '@/config/symbols'
 import { downloadService } from '@/services/downloadService'
 import { playbackService } from '@/services/QueuePlaybackService'
+import { albumStore } from '@/stores/albumStore'
 import { commonStore } from '@/stores/commonStore'
 import { playableStore } from '@/stores/playableStore'
 import EditAlbumForm from '@/components/album/EditAlbumForm.vue'
@@ -124,5 +127,21 @@ describe('albumContextMenu.vue', () => {
     await renderComponent()
 
     expect(screen.queryByText('Embed…')).toBeNull()
+  })
+
+  it('closes the menu after rating', async () => {
+    h.mock(playableStore, 'fetchSongsForAlbum').mockResolvedValue([])
+    h.mock(albumStore, 'rate').mockResolvedValue()
+    const menu = shallowRef<any>({ component: Component, position: { top: 0, left: 0 } })
+    const album = h.factory('album').make({ rating: 0 })
+
+    h.actingAsAdmin().render(Component, {
+      props: { album },
+      global: { provide: { [ContextMenuKey as symbol]: menu } },
+    })
+
+    await h.user.click(screen.getByRole('radio', { name: 'Rate 4 of 5' }))
+
+    expect(menu.value.component).toBeNull()
   })
 })

--- a/resources/assets/js/components/album/AlbumContextMenu.spec.ts
+++ b/resources/assets/js/components/album/AlbumContextMenu.spec.ts
@@ -131,7 +131,7 @@ describe('albumContextMenu.vue', () => {
 
   it('closes the menu after rating', async () => {
     h.mock(playableStore, 'fetchSongsForAlbum').mockResolvedValue([])
-    h.mock(albumStore, 'rate').mockResolvedValue(undefined)
+    h.mock(albumStore, 'rate')
     const menu = shallowRef<any>({ component: Component, position: { top: 0, left: 0 } })
     const album = h.factory('album').make({ rating: 0 })
 

--- a/resources/assets/js/components/album/AlbumContextMenu.spec.ts
+++ b/resources/assets/js/components/album/AlbumContextMenu.spec.ts
@@ -131,7 +131,7 @@ describe('albumContextMenu.vue', () => {
 
   it('closes the menu after rating', async () => {
     h.mock(playableStore, 'fetchSongsForAlbum').mockResolvedValue([])
-    h.mock(albumStore, 'rate').mockResolvedValue()
+    h.mock(albumStore, 'rate').mockResolvedValue(undefined)
     const menu = shallowRef<any>({ component: Component, position: { top: 0, left: 0 } })
     const album = h.factory('album').make({ rating: 0 })
 

--- a/resources/assets/js/components/album/AlbumContextMenu.vue
+++ b/resources/assets/js/components/album/AlbumContextMenu.vue
@@ -10,7 +10,7 @@
       class="px-4 py-2 focus:outline-hidden"
       @mouseover="($event.currentTarget as HTMLLIElement).focus()"
     >
-      <StarRating :rateable="album" />
+      <StarRating :rateable="album" @rate="closeContextMenu" />
     </li>
     <Separator />
     <template v-if="allowEdit">
@@ -56,7 +56,7 @@ const EditAlbumForm = defineAsyncComponent(() => import('@/components/album/Edit
 const CreateEmbedForm = defineAsyncComponent(() => import('@/components/embed/CreateEmbedForm.vue'))
 
 const { go, url } = useRouter()
-const { MenuItem, Separator, trigger } = useContextMenu()
+const { MenuItem, Separator, closeContextMenu, trigger } = useContextMenu()
 const { openModal } = useModal()
 const { currentUserCan } = usePolicies()
 

--- a/resources/assets/js/components/artist/ArtistContextMenu.spec.ts
+++ b/resources/assets/js/components/artist/ArtistContextMenu.spec.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it, vi } from 'vite-plus/test'
 import { screen } from '@testing-library/vue'
+import { shallowRef } from 'vue'
 import { createHarness } from '@/__tests__/TestHarness'
 import { assertOpenModal } from '@/__tests__/assertions'
 import factory from '@/__tests__/factory'
+import { ContextMenuKey } from '@/config/symbols'
 import { downloadService } from '@/services/downloadService'
 import { playbackService } from '@/services/QueuePlaybackService'
+import { artistStore } from '@/stores/artistStore'
 import { commonStore } from '@/stores/commonStore'
 import { playableStore } from '@/stores/playableStore'
 import CreateEmbedForm from '@/components/embed/CreateEmbedForm.vue'
@@ -114,5 +117,20 @@ describe('artistContextMenu.vue', () => {
     await renderComponent()
 
     expect(screen.queryByText('Embed…')).toBeNull()
+  })
+
+  it('closes the menu after rating', async () => {
+    h.mock(artistStore, 'rate').mockResolvedValue()
+    const menu = shallowRef<any>({ component: Component, position: { top: 0, left: 0 } })
+    const artist = h.factory('artist').make({ rating: 0 })
+
+    h.render(Component, {
+      props: { artist },
+      global: { provide: { [ContextMenuKey as symbol]: menu } },
+    })
+
+    await h.user.click(screen.getByRole('radio', { name: 'Rate 4 of 5' }))
+
+    expect(menu.value.component).toBeNull()
   })
 })

--- a/resources/assets/js/components/artist/ArtistContextMenu.spec.ts
+++ b/resources/assets/js/components/artist/ArtistContextMenu.spec.ts
@@ -120,7 +120,7 @@ describe('artistContextMenu.vue', () => {
   })
 
   it('closes the menu after rating', async () => {
-    h.mock(artistStore, 'rate').mockResolvedValue(undefined)
+    h.mock(artistStore, 'rate')
     const menu = shallowRef<any>({ component: Component, position: { top: 0, left: 0 } })
     const artist = h.factory('artist').make({ rating: 0 })
 

--- a/resources/assets/js/components/artist/ArtistContextMenu.spec.ts
+++ b/resources/assets/js/components/artist/ArtistContextMenu.spec.ts
@@ -120,7 +120,7 @@ describe('artistContextMenu.vue', () => {
   })
 
   it('closes the menu after rating', async () => {
-    h.mock(artistStore, 'rate').mockResolvedValue()
+    h.mock(artistStore, 'rate').mockResolvedValue(undefined)
     const menu = shallowRef<any>({ component: Component, position: { top: 0, left: 0 } })
     const artist = h.factory('artist').make({ rating: 0 })
 

--- a/resources/assets/js/components/artist/ArtistContextMenu.vue
+++ b/resources/assets/js/components/artist/ArtistContextMenu.vue
@@ -10,7 +10,7 @@
       class="px-4 py-2 focus:outline-hidden"
       @mouseover="($event.currentTarget as HTMLLIElement).focus()"
     >
-      <StarRating :rateable="artist" />
+      <StarRating :rateable="artist" @rate="closeContextMenu" />
     </li>
     <Separator />
     <MenuItem v-if="allowEdit" @click="requestEditForm">Edit…</MenuItem>
@@ -47,7 +47,7 @@ const EditArtistForm = defineAsyncComponent(() => import('@/components/artist/Ed
 const CreateEmbedForm = defineAsyncComponent(() => import('@/components/embed/CreateEmbedForm.vue'))
 
 const { go, url } = useRouter()
-const { MenuItem, Separator, trigger } = useContextMenu()
+const { MenuItem, Separator, closeContextMenu, trigger } = useContextMenu()
 const { openModal } = useModal()
 const { currentUserCan } = usePolicies()
 

--- a/resources/assets/js/components/playable/PlayableContextMenu.spec.ts
+++ b/resources/assets/js/components/playable/PlayableContextMenu.spec.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it, vi } from 'vite-plus/test'
-import { ref } from 'vue'
+import { ref, shallowRef } from 'vue'
 import { createHarness } from '@/__tests__/TestHarness'
 import { assertOpenModal } from '@/__tests__/assertions'
 import factory from '@/__tests__/factory'
+import { ContextMenuKey } from '@/config/symbols'
 import { arrayify } from '@/utils/helpers'
 import { eventBus } from '@/utils/eventBus'
 import { screen, waitFor } from '@testing-library/vue'
@@ -521,5 +522,21 @@ describe('playableContextMenu.vue', () => {
     for (const playable of playables) {
       expect(removeOfflineCacheMock).toHaveBeenCalledWith(playable)
     }
+  })
+
+  it('closes the menu after rating', async () => {
+    h.mock(playableStore, 'rate').mockResolvedValue()
+    const menu = shallowRef<any>({ component: Component, position: { top: 0, left: 0 } })
+    const song = h.factory('song').make({ rating: 0 })
+
+    h.render(Component, {
+      props: { playables: [song] },
+      global: { provide: { [ContextMenuKey as symbol]: menu } },
+    })
+
+    await h.tick(2)
+    await h.user.click(screen.getByRole('radio', { name: 'Rate 4 of 5' }))
+
+    expect(menu.value.component).toBeNull()
   })
 })

--- a/resources/assets/js/components/playable/PlayableContextMenu.spec.ts
+++ b/resources/assets/js/components/playable/PlayableContextMenu.spec.ts
@@ -525,7 +525,7 @@ describe('playableContextMenu.vue', () => {
   })
 
   it('closes the menu after rating', async () => {
-    h.mock(playableStore, 'rate').mockResolvedValue()
+    h.mock(playableStore, 'rate').mockResolvedValue(undefined)
     const menu = shallowRef<any>({ component: Component, position: { top: 0, left: 0 } })
     const song = h.factory('song').make({ rating: 0 })
 

--- a/resources/assets/js/components/playable/PlayableContextMenu.spec.ts
+++ b/resources/assets/js/components/playable/PlayableContextMenu.spec.ts
@@ -525,7 +525,7 @@ describe('playableContextMenu.vue', () => {
   })
 
   it('closes the menu after rating', async () => {
-    h.mock(playableStore, 'rate').mockResolvedValue(undefined)
+    h.mock(playableStore, 'rate')
     const menu = shallowRef<any>({ component: Component, position: { top: 0, left: 0 } })
     const song = h.factory('song').make({ rating: 0 })
 

--- a/resources/assets/js/components/playable/PlayableContextMenu.vue
+++ b/resources/assets/js/components/playable/PlayableContextMenu.vue
@@ -79,7 +79,7 @@
         class="px-4 py-2 focus:outline-hidden"
         @mouseover="($event.currentTarget as HTMLLIElement).focus()"
       >
-        <StarRating :rateable="playables[0] as Song" />
+        <StarRating :rateable="playables[0] as Song" @rate="closeContextMenu" />
       </li>
       <Separator />
     </template>

--- a/resources/assets/js/components/podcast/PodcastContextMenu.spec.ts
+++ b/resources/assets/js/components/podcast/PodcastContextMenu.spec.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vite-plus/test'
 import { screen } from '@testing-library/vue'
+import { shallowRef } from 'vue'
 import { createHarness } from '@/__tests__/TestHarness'
+import { ContextMenuKey } from '@/config/symbols'
 import { playbackService } from '@/services/QueuePlaybackService'
 import { playableStore as episodeStore } from '@/stores/playableStore'
 import Component from './PodcastContextMenu.vue'
@@ -87,5 +89,20 @@ describe('podcastContextMenu.vue', () => {
     await h.user.click(screen.getByText('Unsubscribe'))
 
     expect(unsubMock).toHaveBeenCalledWith(podcast)
+  })
+
+  it('closes the menu after rating', async () => {
+    h.mock(podcastStore, 'rate').mockResolvedValue()
+    const menu = shallowRef<any>({ component: Component, position: { top: 0, left: 0 } })
+    const podcast = h.factory('podcast').make({ rating: 0 })
+
+    h.actingAsAdmin().render(Component, {
+      props: { podcast },
+      global: { provide: { [ContextMenuKey as symbol]: menu } },
+    })
+
+    await h.user.click(screen.getByRole('radio', { name: 'Rate 4 of 5' }))
+
+    expect(menu.value.component).toBeNull()
   })
 })

--- a/resources/assets/js/components/podcast/PodcastContextMenu.spec.ts
+++ b/resources/assets/js/components/podcast/PodcastContextMenu.spec.ts
@@ -92,7 +92,7 @@ describe('podcastContextMenu.vue', () => {
   })
 
   it('closes the menu after rating', async () => {
-    h.mock(podcastStore, 'rate').mockResolvedValue()
+    h.mock(podcastStore, 'rate').mockResolvedValue(undefined)
     const menu = shallowRef<any>({ component: Component, position: { top: 0, left: 0 } })
     const podcast = h.factory('podcast').make({ rating: 0 })
 

--- a/resources/assets/js/components/podcast/PodcastContextMenu.spec.ts
+++ b/resources/assets/js/components/podcast/PodcastContextMenu.spec.ts
@@ -92,7 +92,7 @@ describe('podcastContextMenu.vue', () => {
   })
 
   it('closes the menu after rating', async () => {
-    h.mock(podcastStore, 'rate').mockResolvedValue(undefined)
+    h.mock(podcastStore, 'rate')
     const menu = shallowRef<any>({ component: Component, position: { top: 0, left: 0 } })
     const podcast = h.factory('podcast').make({ rating: 0 })
 

--- a/resources/assets/js/components/podcast/PodcastContextMenu.vue
+++ b/resources/assets/js/components/podcast/PodcastContextMenu.vue
@@ -10,7 +10,7 @@
       class="px-4 py-2 focus:outline-hidden"
       @mouseover="($event.currentTarget as HTMLLIElement).focus()"
     >
-      <StarRating :rateable="podcast" />
+      <StarRating :rateable="podcast" @rate="closeContextMenu" />
     </li>
     <Separator />
     <MenuItem @click="visitWebsite">Visit Website</MenuItem>
@@ -36,7 +36,7 @@ const props = defineProps<{ podcast: Podcast }>()
 const { podcast } = toRefs(props)
 
 const { go, url } = useRouter()
-const { MenuItem, Separator, trigger } = useContextMenu()
+const { MenuItem, Separator, closeContextMenu, trigger } = useContextMenu()
 const { showConfirmDialog } = useDialogBox()
 const { toastSuccess } = useMessageToaster()
 


### PR DESCRIPTION
Clicking a star in the rating component embedded in the song, album, artist, and podcast context menus rated the item but left the menu open. It now closes, matching every other menu action.

## Cause

Every other action in these menus runs through `useContextMenu().trigger()`, which closes the menu once the action completes. The embedded `<StarRating>` had no `@rate` handler, so choosing a rating never closed the menu. `StarRating` already emits a `rate` event (and persists the rating itself when given a `:rateable`) — the menus just weren't listening.

## Fix

Wired `@rate="closeContextMenu"` on the four `<StarRating>` usages in context menus:

- `PlayableContextMenu.vue`
- `AlbumContextMenu.vue`
- `ArtistContextMenu.vue`
- `PodcastContextMenu.vue`

The handler is intentionally scoped to the context menus only — `StarRating`'s other call sites (screens, list rows, card thumbnails) should not close anything, so the behavior stays opt-in at the menu level rather than baked into the shared component.

## Tests

Added a `closes the menu after rating` regression test to each of the four context-menu specs. Each seeds a custom `ContextMenuKey` ref with an open menu, clicks a star, and asserts the ref's `component` becomes `null` — the same injected-state pattern `ContextMenu.spec.ts` uses. All four files pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Context menus now properly close immediately after selecting a rating option in the album, artist, song, and podcast views.

* **Tests**
  * Expanded automated coverage for context-menu closing after rating, including updated event handling assertions and necessary menu injection setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->