### PR TITLE
fix: show album/artist card separator in production as a standalone element

### DIFF
--- a/resources/assets/js/components/album/AlbumCard.spec.ts
+++ b/resources/assets/js/components/album/AlbumCard.spec.ts
@@ -66,6 +66,22 @@ describe('albumCard', () => {
     expect(screen.queryByText('Download')).toBeNull()
   })
 
+  it('separates Shuffle and Download with a standalone, non-link separator', () => {
+    commonStore.state.allows_download = true
+    renderComponent()
+
+    const separator = screen.getByText('•')
+    expect(separator.tagName).toBe('SPAN')
+    expect(separator.closest('a')).toBeNull()
+  })
+
+  it('does not render the separator when download is disabled', () => {
+    commonStore.state.allows_download = false
+    renderComponent()
+
+    expect(screen.queryByText('•')).toBeNull()
+  })
+
   it('shuffles', async () => {
     h.createAudioPlayer()
 

--- a/resources/assets/js/components/album/AlbumCard.vue
+++ b/resources/assets/js/components/album/AlbumCard.vue
@@ -36,6 +36,7 @@
 
     <template #meta>
       <a :title="`Shuffle all songs in the album ${album.name}`" role="button" @click.prevent="shuffle"> Shuffle </a>
+      <span v-if="allowDownload" aria-hidden="true">•</span>
       <a
         v-if="allowDownload"
         :title="`Download all songs in the album ${album.name}`"

--- a/resources/assets/js/components/artist/ArtistCard.spec.ts
+++ b/resources/assets/js/components/artist/ArtistCard.spec.ts
@@ -60,6 +60,22 @@ describe('artistCard.vue', () => {
     expect(screen.queryByText('Download')).toBeNull()
   })
 
+  it('separates Shuffle and Download with a standalone, non-link separator', () => {
+    commonStore.state.allows_download = true
+    renderComponent()
+
+    const separator = screen.getByText('•')
+    expect(separator.tagName).toBe('SPAN')
+    expect(separator.closest('a')).toBeNull()
+  })
+
+  it('does not render the separator when download is disabled', () => {
+    commonStore.state.allows_download = false
+    renderComponent()
+
+    expect(screen.queryByText('•')).toBeNull()
+  })
+
   it('shuffles', async () => {
     h.createAudioPlayer()
 

--- a/resources/assets/js/components/artist/ArtistCard.vue
+++ b/resources/assets/js/components/artist/ArtistCard.vue
@@ -19,6 +19,7 @@
     </template>
     <template #meta>
       <a :title="`Shuffle all songs by ${artist.name}`" role="button" @click.prevent="shuffle"> Shuffle </a>
+      <span v-if="allowDownload" aria-hidden="true">•</span>
       <a v-if="allowDownload" :title="`Download all songs by ${artist.name}`" role="button" @click.prevent="download">
         Download
       </a>

--- a/resources/assets/js/components/ui/album-artist/AlbumOrArtistCard.vue
+++ b/resources/assets/js/components/ui/album-artist/AlbumOrArtistCard.vue
@@ -96,24 +96,6 @@ article {
       @apply w-[80px] rounded-md;
     }
   }
-
-  .meta {
-    :deep(a),
-    :deep(button) {
-      & + a,
-      & + button {
-        &::before {
-          @apply mr-0.5 content-['•'];
-        }
-      }
-
-      & + button {
-        &::before {
-          @apply mr-1;
-        }
-      }
-    }
-  }
 }
 
 .compact {


### PR DESCRIPTION
The "•" separator between the **Shuffle** and **Download** buttons on artist/album cards showed in dev but disappeared in production builds. It now renders reliably in both — and is no longer part of the Download link.

## Cause

The dot was generated with `@apply … content-['•']`. In Tailwind v4 `content-[…]` doesn't set `content` directly; it compiles to `content: var(--tw-content)` plus a separate `--tw-content: "•"`, alongside the base reset `*, ::before, ::after { --tw-content: "" }`. In dev the cascade-layer order let the component's `--tw-content` win, but in the production build (different `@layer` ordering after minification) the base reset won, so `var(--tw-content)` resolved to an empty string and the bullet vanished. Confirmed by diffing the built CSS.

## Fix

Replaced the CSS-generated `::before` pseudo-element with an explicit, standalone separator element in each card's `#meta` slot:

```html
<a … @click.prevent="shuffle"> Shuffle </a>
<span v-if="allowDownload" aria-hidden="true">•</span>
<a v-if="allowDownload" … @click.prevent="download"> Download </a>
```

`.meta` is a `flex gap-1.5` container, so the `<span>` is its own flex item — spacing handled by the gap, not clickable, inheriting the meta's neutral color instead of the link's, and `aria-hidden` keeps it out of the accessibility tree. The `v-if="allowDownload"` guard avoids an orphan separator when Download is hidden. The now-unused `.meta … ::before` block was removed from the shared `AlbumOrArtistCard.vue`.

Putting `•` in the template as plain text also sidesteps the Tailwind `--tw-content` mechanism entirely, so the production-only disappearance can't recur here.

## Tests

Added tests to `AlbumCard.spec.ts` and `ArtistCard.spec.ts`: the separator is a `SPAN` whose `closest('a')` is `null` (it's not inside a link), and it's absent when downloads are disabled.

## Not included

`ScreenHeader.vue` uses the same `before:content-['•']` pattern for screen-level meta (artist/album/playlist headers) and has the identical latent issue. Left out of this PR to keep it scoped to the card; can follow up separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for download separator behavior in album and artist card components.

* **Style**
  * Added visual separator (•) between Shuffle and Download actions when downloads are enabled on album and artist cards.
  * Refined separator rendering implementation for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->