### PR TITLE
fix: keep the peeked sidebar open briefly after the cursor leaves

### DIFF
--- a/resources/assets/js/components/layout/main-wrapper/sidebar/Sidebar.spec.ts
+++ b/resources/assets/js/components/layout/main-wrapper/sidebar/Sidebar.spec.ts
@@ -1,5 +1,5 @@
-import { describe, it } from 'vite-plus/test'
-import { screen } from '@testing-library/vue'
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test'
+import { fireEvent, screen } from '@testing-library/vue'
 import { createHarness } from '@/__tests__/TestHarness'
 import { commonStore } from '@/stores/commonStore'
 import { eventBus } from '@/utils/eventBus'
@@ -30,5 +30,75 @@ describe('sidebar.vue', () => {
     await h.tick()
 
     screen.getByText('A Random Video')
+  })
+})
+
+describe('sidebar.vue temporary expand on hover', () => {
+  const h = createHarness({
+    beforeEach: () => {
+      vi.useFakeTimers()
+      localStorage.clear()
+    },
+  })
+
+  afterEach(() => vi.useRealTimers())
+
+  const nav = () => screen.getByRole('navigation')
+
+  const renderCollapsed = async () => {
+    const rendered = h.render(Component)
+    await fireEvent.click(rendered.container.querySelector('.btn-toggle input[type="checkbox"]')!)
+
+    return rendered
+  }
+
+  const hoverInUntilExpanded = async () => {
+    await fireEvent.mouseEnter(nav())
+    vi.advanceTimersByTime(500)
+    await h.tick()
+  }
+
+  it('peeks open after hovering past the expand delay', async () => {
+    await renderCollapsed()
+    expect(nav().classList.contains('tmp-showing')).toBe(false)
+
+    await hoverInUntilExpanded()
+
+    expect(nav().classList.contains('tmp-showing')).toBe(true)
+  })
+
+  it('does not collapse the moment the cursor leaves', async () => {
+    await renderCollapsed()
+    await hoverInUntilExpanded()
+
+    await fireEvent.mouseLeave(nav(), { relatedTarget: document.body })
+    vi.advanceTimersByTime(200)
+    await h.tick()
+
+    expect(nav().classList.contains('tmp-showing')).toBe(true)
+  })
+
+  it('stays open when the cursor returns within the grace period', async () => {
+    await renderCollapsed()
+    await hoverInUntilExpanded()
+
+    await fireEvent.mouseLeave(nav(), { relatedTarget: document.body })
+    vi.advanceTimersByTime(200)
+    await fireEvent.mouseEnter(nav())
+    vi.advanceTimersByTime(1000)
+    await h.tick()
+
+    expect(nav().classList.contains('tmp-showing')).toBe(true)
+  })
+
+  it('collapses once the grace period elapses', async () => {
+    await renderCollapsed()
+    await hoverInUntilExpanded()
+
+    await fireEvent.mouseLeave(nav(), { relatedTarget: document.body })
+    vi.advanceTimersByTime(500)
+    await h.tick()
+
+    expect(nav().classList.contains('tmp-showing')).toBe(false)
   })
 })

--- a/resources/assets/js/components/layout/main-wrapper/sidebar/Sidebar.vue
+++ b/resources/assets/js/components/layout/main-wrapper/sidebar/Sidebar.vue
@@ -38,7 +38,7 @@
 
 <script lang="ts" setup>
 import { faTimes } from '@fortawesome/free-solid-svg-icons'
-import { computed, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, ref, watch } from 'vue'
 import { eventBus } from '@/utils/eventBus'
 import { useKoelPlus } from '@/composables/useKoelPlus'
 import { useLocalStorage } from '@/composables/useLocalStorage'
@@ -63,38 +63,77 @@ const mobileShowing = ref(false)
 const searchFocused = ref(false)
 
 const onSearchFocusChange = (focused: boolean) => (searchFocused.value = focused)
+const EXPAND_DELAY = 500
+const COLLAPSE_DELAY = 500
+
 const expanded = ref(!lsGet('sidebar-collapsed', false))
-
-watch(expanded, value => lsSet('sidebar-collapsed', !value))
-
-let tmpShowingHandler: number | undefined
 const tmpShowing = ref(false)
+
+let expandTimer: number | undefined
+let collapseTimer: number | undefined
+
+const clearExpandTimer = () => {
+  if (expandTimer) {
+    clearTimeout(expandTimer)
+    expandTimer = undefined
+  }
+}
+
+const clearCollapseTimer = () => {
+  if (collapseTimer) {
+    clearTimeout(collapseTimer)
+    collapseTimer = undefined
+  }
+}
+
+watch(expanded, value => {
+  lsSet('sidebar-collapsed', !value)
+  clearExpandTimer()
+  clearCollapseTimer()
+  tmpShowing.value = false
+})
 
 const onMouseEnter = () => {
   if (expanded.value) {
     return
   }
 
-  tmpShowingHandler = window.setTimeout(() => {
-    if (expanded.value) {
-      return
-    }
-    tmpShowing.value = true
-  }, 500)
-}
+  clearCollapseTimer()
 
-const onMouseLeave = (e: MouseEvent) => {
-  if (!e.relatedTarget) {
+  if (tmpShowing.value) {
     return
   }
 
-  if (tmpShowingHandler) {
-    clearTimeout(tmpShowingHandler)
-    tmpShowingHandler = undefined
+  expandTimer = window.setTimeout(() => {
+    expandTimer = undefined
+
+    if (!expanded.value) {
+      tmpShowing.value = true
+    }
+  }, EXPAND_DELAY)
+}
+
+const onMouseLeave = (event: MouseEvent) => {
+  if (!event.relatedTarget) {
+    return
   }
 
-  tmpShowing.value = false
+  clearExpandTimer()
+
+  if (!tmpShowing.value) {
+    return
+  }
+
+  collapseTimer = window.setTimeout(() => {
+    collapseTimer = undefined
+    tmpShowing.value = false
+  }, COLLAPSE_DELAY)
 }
+
+onBeforeUnmount(() => {
+  clearExpandTimer()
+  clearCollapseTimer()
+})
 
 const showManageOptions = computed(
   () => currentUserCan.manageSettings() || currentUserCan.manageUsers() || currentUserCan.uploadSongs(),


### PR DESCRIPTION
## Problem

When the sidebar is collapsed, hovering peeks it open (after a 500ms delay), but it collapsed the **instant** the cursor left. Because the toggle button sits half-outside the sidebar (`right-[-12px]`), users trying to click it to pin the sidebar open would often have the cursor briefly exit the menu — collapsing it right away before they could click.

## Fix

Added hover-intent symmetry in `Sidebar.vue`. There was already a delay-*in* (500ms) but no delay-*out*; now there's a matching 500ms grace period before collapsing, cancelled if the cursor returns:

- `onMouseLeave` arms a collapse timer instead of collapsing synchronously.
- `onMouseEnter` clears any pending collapse timer, so returning within the grace window keeps it open.
- A `watch(expanded)` clears the timers and resets the peeked state when the user pins/unpins via the toggle.
- Added `onBeforeUnmount` cleanup for both timers (the original leaked its hover timer).

Delays are now named constants (`EXPAND_DELAY`, `COLLAPSE_DELAY`) instead of a bare magic number.

## Tests

New fake-timer cases in `Sidebar.spec.ts`: peeks open after the expand delay, doesn't collapse the instant the cursor leaves, stays open if the cursor returns within the grace period, and collapses once it elapses. Also added `localStorage.clear()` to the block's `beforeEach` — `useLocalStorage` persists `sidebar-collapsed` across tests, which otherwise made the toggle-to-collapse setup non-deterministic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test coverage for sidebar temporary expand on hover behavior, including hover/leave and grace-delay scenarios.

* **Improvements**
  * Enhanced sidebar hover/collapse interactions with explicit 500ms expand and collapse delays and improved timer management for state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->