### PR TITLE
feat: make the default role for first-time SSO users configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -255,6 +255,9 @@ SSO_OIDC_CLIENT_SECRET=
 # Optional. Label shown on the login button. Defaults to "OpenID Connect".
 SSO_OIDC_BUTTON_LABEL=
 
+# Optional. The role given to users on their first SSO login: user (default) or guest.
+SSO_DEFAULT_ROLE=user
+
 
 # Koel can be configured to authenticate users via a reverse proxy.
 # To enable this feature, set PROXY_AUTH_ENABLED to true and provide the necessary configuration below.

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Enums\Acl\Role;
 use App\Exceptions\UserProspectUpdateDeniedException;
 use App\Models\Organization;
 use App\Models\User;
@@ -11,6 +12,7 @@ use App\Values\ImageWritingConfig;
 use App\Values\User\SsoUser;
 use App\Values\User\UserCreateData;
 use App\Values\User\UserUpdateData;
+use Illuminate\Container\Attributes\Config;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use SensitiveParameter;
@@ -21,6 +23,8 @@ class UserService
         private readonly UserRepository $repository,
         private readonly ImageStorage $imageStorage,
         private readonly OrganizationService $organizationService,
+        #[Config('koel.sso.default_role')]
+        private readonly Role $defaultSsoRole = Role::USER,
     ) {}
 
     public function createUser(UserCreateData $dto, ?Organization $organization = null): User
@@ -51,7 +55,7 @@ class UserService
             return $existingUser;
         }
 
-        return $this->createUser(UserCreateData::fromSsoUser($ssoUser));
+        return $this->createUser(UserCreateData::fromSsoUser($ssoUser, $this->defaultSsoRole));
     }
 
     public function changePassword(User $user, #[SensitiveParameter] string $newPassword): void

--- a/app/Values/User/UserCreateData.php
+++ b/app/Values/User/UserCreateData.php
@@ -27,13 +27,13 @@ final readonly class UserCreateData implements Arrayable
         $this->password = $plainTextPassword === '' ? null : $plainTextPassword;
     }
 
-    public static function fromSsoUser(SsoUser $ssoUser): self
+    public static function fromSsoUser(SsoUser $ssoUser, ?Role $role = null): self
     {
         return new self(
             name: $ssoUser->name,
             email: $ssoUser->email,
             plainTextPassword: null,
-            role: Role::default(),
+            role: $role ?? Role::default(),
             avatar: $ssoUser->avatar,
             ssoId: $ssoUser->id,
             ssoProvider: $ssoUser->provider,

--- a/config/koel.php
+++ b/config/koel.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Enums\Acl\Role;
+
 return [
     'storage_driver' => env('STORAGE_DRIVER', 'local') ?: 'local',
 
@@ -202,6 +204,10 @@ return [
         'user_header' => env('PROXY_AUTH_USER_HEADER', 'remote-user'),
         'preferred_name_header' => env('PROXY_AUTH_PREFERRED_NAME_HEADER', 'remote-preferred-name'),
         'allow_list' => array_map(static fn ($entry) => trim($entry), explode(',', env('PROXY_AUTH_ALLOW_LIST', ''))),
+    ],
+
+    'sso' => [
+        'default_role' => Role::tryFrom(strtolower((string) env('SSO_DEFAULT_ROLE', ''))) ?? Role::default(),
     ],
 
     'ai' => [

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -145,6 +145,7 @@ Koel Plus only. See [Single Sign-On](plus/sso).
 | `SSO_OIDC_CLIENT_ID` | OAuth client ID registered with the IdP. | _(empty)_ |
 | `SSO_OIDC_CLIENT_SECRET` | OAuth client secret. | _(empty)_ |
 | `SSO_OIDC_BUTTON_LABEL` | Label shown on the OIDC login button. | `OpenID Connect` |
+| `SSO_DEFAULT_ROLE` | The role given to a user on their first SSO login: `user` or `guest`. Applies to OIDC, Google, and reverse-proxy auth. | `user` |
 
 ## Proxy Authentication
 

--- a/docs/plus/sso.md
+++ b/docs/plus/sso.md
@@ -58,6 +58,8 @@ Save the `.env` file and reload Koel. A corresponding button appears on the logi
 When a user logs in via SSO for the first time, a new user account will be created in Koel with the email address, name, avatar, and the SSO ID obtained from the SSO provider.
 If, however, there's already an existing user with the same email address, Koel will merge the two accounts with a sensible merging strategy.
 
+New SSO users are given the **User** role by default. To place them in the **Guest** role instead, set `SSO_DEFAULT_ROLE=guest` in your `.env` file.
+
 SSO users can update their name and avatar, but not their email address. Furthermore, a new user created via SSO does not have a password set and won't be able to log in via the email+password method.
 
 <script lang="ts" setup>

--- a/tests/Integration/KoelPlus/Services/UserServiceTest.php
+++ b/tests/Integration/KoelPlus/Services/UserServiceTest.php
@@ -67,6 +67,25 @@ class UserServiceTest extends PlusTestCase
         self::assertSame('bruce@iron.com', $user->email);
         self::assertSame('123', $user->sso_id);
         self::assertSame('https://lh3.googleusercontent.com/a/vatar', $user->avatar);
+        self::assertSame(Role::default(), $user->role);
+    }
+
+    #[Test]
+    public function createUserFromSsoUsesConfiguredDefaultRole(): void
+    {
+        config(['koel.sso.default_role' => Role::GUEST]);
+        $service = app(UserService::class);
+
+        $socialiteUser = Mockery::mock(SocialiteUser::class, [
+            'getId' => '456',
+            'getEmail' => 'steve@iron.com',
+            'getName' => 'Steve Harris',
+            'getAvatar' => null,
+        ]);
+
+        $user = $service->createOrUpdateUserFromSso(SsoUser::fromSocialite($socialiteUser, 'Google'));
+
+        self::assertSame(Role::GUEST, $user->role);
     }
 
     #[Test]


### PR DESCRIPTION
Closes #2592.

Lets operators choose which role first-time SSO users land in, via a new `SSO_DEFAULT_ROLE` env variable — e.g. `guest` instead of the default `user`.

## Background

The role for newly-provisioned SSO users was hardcoded at `UserCreateData::fromSsoUser()` → `Role::default()` (= `User`), with no way to change it.

## Change

- **`config/koel.php`** — new `koel.sso.default_role`, parsed to a `Role` enum with a graceful fallback: `Role::tryFrom(strtolower((string) env('SSO_DEFAULT_ROLE', ''))) ?? Role::default()`. Unset or invalid values fall back to `User`.
- **`UserCreateData::fromSsoUser()`** — now accepts an optional `?Role $role` (defaults to `Role::default()`, so existing callers are unaffected).
- **`UserService`** — injects the config via `#[Config('koel.sso.default_role')]` and passes it through in `createOrUpdateUserFromSso()`.

Because every first-login provisioning path builds an `SsoUser` and funnels through `createOrUpdateUserFromSso()`, this covers **OIDC, Google, and reverse-proxy auth** uniformly. The value object stays config-free — the service resolves the role and passes it in.

## Tests

`tests/Integration/KoelPlus/Services/UserServiceTest.php`: `createUserFromSso` now also asserts the default role is `User`, and a new `createUserFromSsoUsesConfiguredDefaultRole` sets `koel.sso.default_role` to `Guest` and asserts the provisioned user lands in `Guest`.

## Docs

`.env.example`, `docs/environment-variables.md`, and `docs/plus/sso.md` updated.

## Note

`admin` is intentionally allowed as a configured value (operator-set, server-side env var, consistent with how Koel trusts other operator config like `proxy_auth.allow_list`). Happy to clamp it to non-admin roles if preferred.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Administrators can now configure the default role assigned to users on their first SSO login.

* **Documentation**
  * Updated SSO documentation to explain the new role assignment configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->