### PR TITLE
feat: return synced lyrics from getLyricsBySongId when available

### DIFF
--- a/app/Http/Controllers/Subsonic/GetLyricsBySongIdController.php
+++ b/app/Http/Controllers/Subsonic/GetLyricsBySongIdController.php
@@ -4,8 +4,10 @@ namespace App\Http\Controllers\Subsonic;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Subsonic\IdRequest;
+use App\Http\Responses\Subsonic\Resources\StructuredLyricsResource;
 use App\Http\Responses\Subsonic\SubsonicResponse;
 use App\Repositories\SongRepository;
+use App\Values\ParsedLyrics;
 
 class GetLyricsBySongIdController extends Controller
 {
@@ -16,26 +18,16 @@ class GetLyricsBySongIdController extends Controller
     public function __invoke(IdRequest $request)
     {
         $song = $this->songRepository->getOne($request->id);
+        $lyrics = ParsedLyrics::fromRawLyrics((string) $song->lyrics);
 
-        $lyrics = trim((string) $song->lyrics);
-
-        if ($lyrics === '') {
+        if (!$lyrics->lines) {
             return SubsonicResponse::ok(['lyricsList' => []]);
         }
-
-        $lines = array_map(static fn (string $line) => ['value' => $line], preg_split('/\r\n|\r|\n/', $lyrics) ?: []);
 
         return SubsonicResponse::ok([
             'lyricsList' => [
                 'structuredLyrics' => [
-                    [
-                        'displayArtist' => $song->artist_name,
-                        'displayTitle' => $song->title,
-                        'lang' => 'und',
-                        'offset' => 0,
-                        'synced' => false,
-                        'line' => $lines,
-                    ],
+                    StructuredLyricsResource::toArray($song, $lyrics),
                 ],
             ],
         ]);

--- a/app/Http/Responses/Subsonic/Resources/StructuredLyricsResource.php
+++ b/app/Http/Responses/Subsonic/Resources/StructuredLyricsResource.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Responses\Subsonic\Resources;
+
+use App\Models\Song;
+use App\Values\ParsedLyrics;
+
+/**
+ * Renders a single `<structuredLyrics>` entry of the OpenSubsonic `<lyricsList>`
+ * returned by `getLyricsBySongId`.
+ */
+final class StructuredLyricsResource
+{
+    /**
+     * @return array{
+     *     displayArtist: string,
+     *     displayTitle: string,
+     *     lang: string,
+     *     offset: int,
+     *     synced: bool,
+     *     line: list<array{start?: int, value: string}>,
+     * }
+     */
+    public static function toArray(Song $song, ParsedLyrics $lyrics): array
+    {
+        return [
+            'displayArtist' => $song->artist_name,
+            'displayTitle' => $song->title,
+            'lang' => 'und',
+            'offset' => $lyrics->offset,
+            'synced' => $lyrics->synced,
+            'line' => $lyrics->lines,
+        ];
+    }
+}

--- a/app/Values/ParsedLyrics.php
+++ b/app/Values/ParsedLyrics.php
@@ -35,14 +35,20 @@ final readonly class ParsedLyrics
                 continue;
             }
 
-            if (preg_match('/^\s*\[(\d{1,2}):(\d{2})(?:[.:](\d{1,3}))?]\s*(.*)$/', $line, $matches)) {
-                $start = ((int) $matches[1] * 60_000) + ((int) $matches[2] * 1000);
+            if (preg_match('/^\s*((?:\[\d{1,2}:\d{2}(?:[.:]\d{1,3})?]\s*)+)(.*)$/', $line, $matches)) {
+                $text = trim($matches[2]);
+                preg_match_all('/\[(\d{1,2}):(\d{2})(?:[.:](\d{1,3}))?]/', $matches[1], $tags, PREG_SET_ORDER);
 
-                if ($matches[3] !== '') {
-                    $start += (int) round((float) "0.{$matches[3]}" * 1000);
+                foreach ($tags as $tag) {
+                    $start = ((int) $tag[1] * 60_000) + ((int) $tag[2] * 1000);
+                    $fraction = $tag[3] ?? '';
+
+                    if ($fraction !== '') {
+                        $start += (int) round((float) "0.$fraction" * 1000);
+                    }
+
+                    $timedLines[] = ['start' => $start, 'value' => $text];
                 }
-
-                $timedLines[] = ['start' => $start, 'value' => trim($matches[4])];
 
                 continue;
             }

--- a/app/Values/ParsedLyrics.php
+++ b/app/Values/ParsedLyrics.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Values;
+
+final readonly class ParsedLyrics
+{
+    /** @param list<array{start?: int, value: string}> $lines */
+    private function __construct(
+        public bool $synced,
+        public int $offset,
+        public array $lines,
+    ) {}
+
+    /** @param list<array{start?: int, value: string}> $lines */
+    public static function make(bool $synced, int $offset, array $lines): self
+    {
+        return new self($synced, $offset, $lines);
+    }
+
+    public static function fromRawLyrics(string $raw): self
+    {
+        $raw = trim($raw);
+
+        if ($raw === '') {
+            return new self(synced: false, offset: 0, lines: []);
+        }
+
+        $offset = 0;
+        $timedLines = [];
+        $plainLines = [];
+
+        foreach (preg_split('/\r\n|\r|\n/', $raw) ?: [] as $line) {
+            if (preg_match('/^\s*\[offset:\s*([+-]?\d+)\s*]\s*$/i', $line, $matches)) {
+                $offset = (int) $matches[1];
+                continue;
+            }
+
+            if (preg_match('/^\s*\[(\d{1,2}):(\d{2})(?:[.:](\d{1,3}))?]\s*(.*)$/', $line, $matches)) {
+                $start = ((int) $matches[1] * 60_000) + ((int) $matches[2] * 1000);
+
+                if ($matches[3] !== '') {
+                    $start += (int) round((float) "0.{$matches[3]}" * 1000);
+                }
+
+                $timedLines[] = ['start' => $start, 'value' => trim($matches[4])];
+
+                continue;
+            }
+
+            $plainLines[] = ['value' => $line];
+        }
+
+        if ($timedLines) {
+            usort($timedLines, static fn (array $a, array $b) => $a['start'] <=> $b['start']);
+
+            return new self(synced: true, offset: $offset, lines: $timedLines);
+        }
+
+        return new self(synced: false, offset: $offset, lines: $plainLines);
+    }
+}

--- a/tests/Feature/Subsonic/GetLyricsBySongIdTest.php
+++ b/tests/Feature/Subsonic/GetLyricsBySongIdTest.php
@@ -39,6 +39,30 @@ class GetLyricsBySongIdTest extends TestCase
     }
 
     #[Test]
+    public function returnsSyncedLyricsWhenTimestampsPresent(): void
+    {
+        $user = create_user();
+        $song = Song::factory()->createOne([
+            'title' => 'Karma Police',
+            'artist_name' => 'Radiohead',
+            'lyrics' => "[00:12.34]Karma police\n[00:15.00]Arrest this man",
+            'owner_id' => $user->id,
+        ]);
+
+        $response = $this
+            ->getJson("/rest/getLyricsBySongId.view?apiKey={$user->subsonic_api_key}&f=json&id={$song->id}")
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.status', 'ok');
+
+        $structured = $response->json('subsonic-response.lyricsList.structuredLyrics.0');
+        self::assertTrue($structured['synced']);
+        self::assertSame(
+            [['start' => 12_340, 'value' => 'Karma police'], ['start' => 15_000, 'value' => 'Arrest this man']],
+            $structured['line'],
+        );
+    }
+
+    #[Test]
     public function emptyLyricsReturnsEmptyList(): void
     {
         $user = create_user();

--- a/tests/Unit/Values/ParsedLyricsTest.php
+++ b/tests/Unit/Values/ParsedLyricsTest.php
@@ -49,6 +49,22 @@ class ParsedLyricsTest extends TestCase
     }
 
     #[Test]
+    public function expandsRepeatedTimestampsOnOneLineIntoSeparateEntries(): void
+    {
+        $lyrics = ParsedLyrics::fromRawLyrics('[00:10.00][00:20.00][00:30.00]Chorus');
+
+        self::assertTrue($lyrics->synced);
+        self::assertSame(
+            [
+                ['start' => 10_000, 'value' => 'Chorus'],
+                ['start' => 20_000, 'value' => 'Chorus'],
+                ['start' => 30_000, 'value' => 'Chorus'],
+            ],
+            $lyrics->lines,
+        );
+    }
+
+    #[Test]
     public function extractsOffsetMetadataAndSortsByStart(): void
     {
         $lyrics = ParsedLyrics::fromRawLyrics("[offset:-250]\n[00:10.00]Later\n[00:05.00]Earlier");

--- a/tests/Unit/Values/ParsedLyricsTest.php
+++ b/tests/Unit/Values/ParsedLyricsTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\Unit\Values;
+
+use App\Values\ParsedLyrics;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class ParsedLyricsTest extends TestCase
+{
+    #[Test]
+    public function parsesPlainLyricsAsUnsynced(): void
+    {
+        $lyrics = ParsedLyrics::fromRawLyrics("Line one\nLine two\nLine three");
+
+        self::assertFalse($lyrics->synced);
+        self::assertSame(0, $lyrics->offset);
+        self::assertSame([['value' => 'Line one'], ['value' => 'Line two'], ['value' => 'Line three']], $lyrics->lines);
+    }
+
+    #[Test]
+    public function parsesLrcLyricsAsSyncedWithMillisecondOffsets(): void
+    {
+        $lyrics = ParsedLyrics::fromRawLyrics("[00:12.34]First line\n[01:05.06]Second line");
+
+        self::assertTrue($lyrics->synced);
+        self::assertSame(
+            [
+                ['start' => 12_340, 'value' => 'First line'],
+                ['start' => 65_060, 'value' => 'Second line'],
+            ],
+            $lyrics->lines,
+        );
+    }
+
+    #[Test]
+    public function handlesMissingAndThreeDigitFractions(): void
+    {
+        $lyrics = ParsedLyrics::fromRawLyrics("[00:30]No fraction\n[00:01.500]Millis");
+
+        self::assertTrue($lyrics->synced);
+        self::assertSame(
+            [
+                ['start' => 1500, 'value' => 'Millis'],
+                ['start' => 30_000, 'value' => 'No fraction'],
+            ],
+            $lyrics->lines,
+        );
+    }
+
+    #[Test]
+    public function extractsOffsetMetadataAndSortsByStart(): void
+    {
+        $lyrics = ParsedLyrics::fromRawLyrics("[offset:-250]\n[00:10.00]Later\n[00:05.00]Earlier");
+
+        self::assertTrue($lyrics->synced);
+        self::assertSame(-250, $lyrics->offset);
+        self::assertSame(
+            [
+                ['start' => 5000, 'value' => 'Earlier'],
+                ['start' => 10_000, 'value' => 'Later'],
+            ],
+            $lyrics->lines,
+        );
+    }
+
+    #[Test]
+    public function ignoresNonTimestampTagsInSyncedLyrics(): void
+    {
+        $lyrics = ParsedLyrics::fromRawLyrics("[ar:Radiohead]\n[ti:Karma Police]\n[00:00.00]Karma police");
+
+        self::assertTrue($lyrics->synced);
+        self::assertSame([['start' => 0, 'value' => 'Karma police']], $lyrics->lines);
+    }
+
+    #[Test]
+    public function emptyLyricsYieldNoLines(): void
+    {
+        $lyrics = ParsedLyrics::fromRawLyrics('   ');
+
+        self::assertFalse($lyrics->synced);
+        self::assertSame([], $lyrics->lines);
+    }
+}


### PR DESCRIPTION
Addresses #2596.

`getLyricsBySongId` previously always returned `synced: false` with plain text, so Subsonic clients that support scrolling lyrics showed raw LRC content as flat text. It now returns `synced: true` with structured, millisecond-timed line entries when the song has timed lyrics, per the OpenSubsonic `songLyrics` extension spec.

## How it works

koel already stores LRC-formatted lyrics (with `[mm:ss.xx]` timestamps) in `song->lyrics` — the same field the web UI parses to render scrolling lyrics. This change exposes that timing over Subsonic:

- **`App\Values\ParsedLyrics`** — a value object whose `fromRawLyrics()` factory parses the raw lyrics: detects synced vs. plain, converts `[mm:ss.xx(x)]` to `start` in milliseconds (handles 2- and 3-digit fractions and the no-fraction `[mm:ss]` form), sorts timed lines by start, extracts the `[offset:N]` metadata tag into the response `offset`, and drops non-timing LRC tags (`[ar:]`, `[ti:]`, …). Plain (untimed) lyrics keep the previous behavior exactly.
- **`StructuredLyricsResource`** — shapes one `structuredLyrics` entry (mirrors the existing `LyricsResource`).
- **`GetLyricsBySongIdController`** — stays thin: fetch → parse → resource.

## Scope

This covers the **`.lrc` sidecar** path (and any timed LRC text in `song->lyrics`, e.g. pasted via the editor) — the common case, and the one koel already supports end-to-end in its web player.

It does **not** cover **embedded SYLT** frames: koel's scanner only extracts *unsynchronised* lyric frames (`ScanInformation` reads `unsynchronised_lyric` / `unsyncedlyrics` / `lyrics`), so embedded synced timing is never stored and there's nothing for this endpoint to surface. Adding SYLT requires a separate scanner-side change (read getID3's SYLT frame → store as LRC text), tracked as a follow-up.

## Tests

- `tests/Unit/Values/ParsedLyricsTest.php` (new): plain→unsynced, LRC→synced with ms, missing & 3-digit fractions, `[offset:]` extraction + sorting, ignoring `[ar:]`/`[ti:]` tags, empty input.
- `GetLyricsBySongIdTest`: added an end-to-end synced-response assertion; existing plain-text and empty-list cases unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lyrics are now returned in a structured format that supports both plain text and timestamped lines.
  * Timestamped lyrics are surfaced as synced entries with millisecond-accurate timing and proper ordering.

* **Bug Fixes**
  * Empty or whitespace-only lyrics now return no lyrics data instead of a blank structure.
  * Improved handling of LRC metadata, including `[offset:...]`, millisecond fractions, and multiple timestamps per line.

* **Tests**
  * Added coverage for synced/timestamped lyrics and detailed parsing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->