### PR TITLE
feat: extract embedded SYLT synchronised lyrics during scanning

### DIFF
--- a/app/Helpers/SyncedLyricsConverter.php
+++ b/app/Helpers/SyncedLyricsConverter.php
@@ -39,11 +39,22 @@ class SyncedLyricsConverter
     private static function entriesToLrcLines(array $entries): array
     {
         $lines = [];
+        $firstEntrySeen = false;
 
         foreach ($entries as $entry) {
             if (!is_array($entry)) {
                 continue;
             }
+
+            $timestamp = Arr::get($entry, 'timestamp');
+
+            // Only the first entry may legitimately omit its timestamp (it marks the start of the file);
+            // a later entry without one is malformed, so skip it rather than placing it at the beginning.
+            if ($timestamp === null && $firstEntrySeen) {
+                continue;
+            }
+
+            $firstEntrySeen = true;
 
             $text = trim(html_entity_decode(TagFixer::fix((string) Arr::get($entry, 'data', ''))));
 
@@ -51,7 +62,7 @@ class SyncedLyricsConverter
                 continue;
             }
 
-            $lines[] = self::formatTimestamp((int) Arr::get($entry, 'timestamp', 0)) . $text;
+            $lines[] = self::formatTimestamp((int) $timestamp) . $text;
         }
 
         return $lines;

--- a/app/Helpers/SyncedLyricsConverter.php
+++ b/app/Helpers/SyncedLyricsConverter.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Helpers;
+
+use App\Helpers\Encoding\TagFixer;
+use Illuminate\Support\Arr;
+
+class SyncedLyricsConverter
+{
+    /**
+     * Convert an embedded SYLT (synchronised lyrics) frame from getID3 output into LRC-formatted text.
+     * Returns an empty string when there are no usable synced lyrics.
+     */
+    public static function fromGetId3Info(array $info): string
+    {
+        // A tag may carry several SYLT frames (different languages/descriptors); use the first usable one.
+        foreach (Arr::wrap(Arr::get($info, 'id3v2.SYLT', [])) as $frame) {
+            // Format 2 is "milliseconds from beginning of file"; MPEG-frame timestamps (1) can't be converted reliably.
+            if (!is_array($frame) || (int) Arr::get($frame, 'timestampformat') !== 2) {
+                continue;
+            }
+
+            $lines = self::framesToLrcLines(Arr::wrap(Arr::get($frame, 'lyrics', [])));
+
+            if ($lines) {
+                return implode("\n", $lines);
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * @param array<mixed> $entries
+     * @return list<string>
+     */
+    private static function framesToLrcLines(array $entries): array
+    {
+        $lines = [];
+
+        foreach ($entries as $entry) {
+            if (!is_array($entry)) {
+                continue;
+            }
+
+            $text = trim(html_entity_decode(TagFixer::fix((string) Arr::get($entry, 'data', ''))));
+
+            if ($text === '') {
+                continue;
+            }
+
+            $lines[] = self::formatTimestamp((int) Arr::get($entry, 'timestamp', 0)) . $text;
+        }
+
+        return $lines;
+    }
+
+    private static function formatTimestamp(int $milliseconds): string
+    {
+        $centiseconds = intdiv(max($milliseconds, 0), 10);
+
+        return sprintf(
+            '[%02d:%02d.%02d]',
+            intdiv($centiseconds, 6000),
+            intdiv($centiseconds % 6000, 100),
+            $centiseconds % 100,
+        );
+    }
+}

--- a/app/Helpers/SyncedLyricsConverter.php
+++ b/app/Helpers/SyncedLyricsConverter.php
@@ -8,19 +8,21 @@ use Illuminate\Support\Arr;
 class SyncedLyricsConverter
 {
     /**
-     * Convert an embedded SYLT (synchronised lyrics) frame from getID3 output into LRC-formatted text.
+     * Convert SYLT (synchronised lyrics) frames from an ID3v2 tag into LRC-formatted text.
      * Returns an empty string when there are no usable synced lyrics.
+     *
+     * @param array<mixed> $frames
      */
-    public static function fromGetId3Info(array $info): string
+    public static function fromSyltFrames(array $frames): string
     {
         // A tag may carry several SYLT frames (different languages/descriptors); use the first usable one.
-        foreach (Arr::wrap(Arr::get($info, 'id3v2.SYLT', [])) as $frame) {
+        foreach ($frames as $frame) {
             // Format 2 is "milliseconds from beginning of file"; MPEG-frame timestamps (1) can't be converted reliably.
             if (!is_array($frame) || (int) Arr::get($frame, 'timestampformat') !== 2) {
                 continue;
             }
 
-            $lines = self::framesToLrcLines(Arr::wrap(Arr::get($frame, 'lyrics', [])));
+            $lines = self::entriesToLrcLines(Arr::wrap(Arr::get($frame, 'lyrics', [])));
 
             if ($lines) {
                 return implode("\n", $lines);
@@ -34,7 +36,7 @@ class SyncedLyricsConverter
      * @param array<mixed> $entries
      * @return list<string>
      */
-    private static function framesToLrcLines(array $entries): array
+    private static function entriesToLrcLines(array $entries): array
     {
         $lines = [];
 

--- a/app/Values/Scanning/ScanInformation.php
+++ b/app/Values/Scanning/ScanInformation.php
@@ -3,6 +3,7 @@
 namespace App\Values\Scanning;
 
 use App\Helpers\Encoding\TagFixer;
+use App\Helpers\SyncedLyricsConverter;
 use App\Models\Album;
 use App\Models\Artist;
 use Illuminate\Contracts\Support\Arrayable;
@@ -57,16 +58,12 @@ class ScanInformation implements Arrayable
             $cover = self::getTag($comments, 'picture', []);
         }
 
-        $lyrics = self::getSyncedLyricsAsLrc($info);
-
-        if ($lyrics === '') {
-            $lyrics = html_entity_decode(TagFixer::fix(self::getTag($tags, [
-                'unsynchronised_lyric',
-                'unsychronised_lyric',
-                'unsyncedlyrics',
-                'lyrics',
-            ])));
-        }
+        $lyrics = SyncedLyricsConverter::fromGetId3Info($info) ?: html_entity_decode(TagFixer::fix(self::getTag($tags, [
+            'unsynchronised_lyric',
+            'unsychronised_lyric',
+            'unsyncedlyrics',
+            'lyrics',
+        ])));
 
         return new self(
             title: html_entity_decode(TagFixer::fix(self::getTag($tags, 'title', pathinfo($path, PATHINFO_FILENAME)))),
@@ -137,55 +134,6 @@ class ScanInformation implements Arrayable
         }
 
         return $value ?? $default;
-    }
-
-    /**
-     * Convert an embedded SYLT (synchronised lyrics) frame, if present, into LRC-formatted text.
-     */
-    private static function getSyncedLyricsAsLrc(array $info): string
-    {
-        $frame = Arr::get($info, 'id3v2.SYLT.0');
-
-        // Format 2 is "milliseconds from beginning of file"; MPEG-frame timestamps (1) cannot be converted reliably.
-        if (!is_array($frame) || (int) Arr::get($frame, 'timestampformat') !== 2) {
-            return '';
-        }
-
-        $entries = Arr::get($frame, 'lyrics');
-
-        if (!is_array($entries)) {
-            return '';
-        }
-
-        $lines = [];
-
-        foreach ($entries as $entry) {
-            if (!is_array($entry)) {
-                continue;
-            }
-
-            $text = trim(html_entity_decode(TagFixer::fix((string) Arr::get($entry, 'data', ''))));
-
-            if ($text === '') {
-                continue;
-            }
-
-            $lines[] = self::formatLrcTimestamp((int) Arr::get($entry, 'timestamp', 0)) . $text;
-        }
-
-        return implode("\n", $lines);
-    }
-
-    private static function formatLrcTimestamp(int $milliseconds): string
-    {
-        $centiseconds = intdiv(max($milliseconds, 0), 10);
-
-        return sprintf(
-            '[%02d:%02d.%02d]',
-            intdiv($centiseconds, 6000),
-            intdiv($centiseconds % 6000, 100),
-            $centiseconds % 100,
-        );
     }
 
     /** @inheritdoc */

--- a/app/Values/Scanning/ScanInformation.php
+++ b/app/Values/Scanning/ScanInformation.php
@@ -57,12 +57,16 @@ class ScanInformation implements Arrayable
             $cover = self::getTag($comments, 'picture', []);
         }
 
-        $lyrics = html_entity_decode(TagFixer::fix(self::getTag($tags, [
-            'unsynchronised_lyric',
-            'unsychronised_lyric',
-            'unsyncedlyrics',
-            'lyrics',
-        ])));
+        $lyrics = self::getSyncedLyricsAsLrc($info);
+
+        if ($lyrics === '') {
+            $lyrics = html_entity_decode(TagFixer::fix(self::getTag($tags, [
+                'unsynchronised_lyric',
+                'unsychronised_lyric',
+                'unsyncedlyrics',
+                'lyrics',
+            ])));
+        }
 
         return new self(
             title: html_entity_decode(TagFixer::fix(self::getTag($tags, 'title', pathinfo($path, PATHINFO_FILENAME)))),
@@ -133,6 +137,55 @@ class ScanInformation implements Arrayable
         }
 
         return $value ?? $default;
+    }
+
+    /**
+     * Convert an embedded SYLT (synchronised lyrics) frame, if present, into LRC-formatted text.
+     */
+    private static function getSyncedLyricsAsLrc(array $info): string
+    {
+        $frame = Arr::get($info, 'id3v2.SYLT.0');
+
+        // Format 2 is "milliseconds from beginning of file"; MPEG-frame timestamps (1) cannot be converted reliably.
+        if (!is_array($frame) || (int) Arr::get($frame, 'timestampformat') !== 2) {
+            return '';
+        }
+
+        $entries = Arr::get($frame, 'lyrics');
+
+        if (!is_array($entries)) {
+            return '';
+        }
+
+        $lines = [];
+
+        foreach ($entries as $entry) {
+            if (!is_array($entry)) {
+                continue;
+            }
+
+            $text = trim(html_entity_decode(TagFixer::fix((string) Arr::get($entry, 'data', ''))));
+
+            if ($text === '') {
+                continue;
+            }
+
+            $lines[] = self::formatLrcTimestamp((int) Arr::get($entry, 'timestamp', 0)) . $text;
+        }
+
+        return implode("\n", $lines);
+    }
+
+    private static function formatLrcTimestamp(int $milliseconds): string
+    {
+        $centiseconds = intdiv(max($milliseconds, 0), 10);
+
+        return sprintf(
+            '[%02d:%02d.%02d]',
+            intdiv($centiseconds, 6000),
+            intdiv($centiseconds % 6000, 100),
+            $centiseconds % 100,
+        );
     }
 
     /** @inheritdoc */

--- a/app/Values/Scanning/ScanInformation.php
+++ b/app/Values/Scanning/ScanInformation.php
@@ -58,7 +58,9 @@ class ScanInformation implements Arrayable
             $cover = self::getTag($comments, 'picture', []);
         }
 
-        $lyrics = SyncedLyricsConverter::fromGetId3Info($info) ?: html_entity_decode(TagFixer::fix(self::getTag($tags, [
+        $syncedLyrics = SyncedLyricsConverter::fromSyltFrames(Arr::wrap(Arr::get($info, 'id3v2.SYLT', [])));
+
+        $lyrics = $syncedLyrics ?: html_entity_decode(TagFixer::fix(self::getTag($tags, [
             'unsynchronised_lyric',
             'unsychronised_lyric',
             'unsyncedlyrics',

--- a/tests/Integration/Services/Scanners/FileScannerTest.php
+++ b/tests/Integration/Services/Scanners/FileScannerTest.php
@@ -129,6 +129,85 @@ class FileScannerTest extends TestCase
     }
 
     #[Test]
+    public function convertsEmbeddedSyncedLyricsToLrc(): void
+    {
+        $path = test_path('songs/blank.mp3');
+
+        $analyzed = [
+            'filenamepath' => $path,
+            'id3v2' => [
+                'SYLT' => [
+                    [
+                        'timestampformat' => 2,
+                        'lyrics' => [
+                            ['data' => 'First line', 'timestamp' => 12_340],
+                            ['data' => 'Second line', 'timestamp' => 65_060],
+                        ],
+                    ],
+                ],
+            ],
+            'playtime_seconds' => 100,
+        ];
+
+        $this->swap(getID3::class, Mockery::mock(getID3::class, [
+            'CopyTagsToComments' => $analyzed,
+            'analyze' => $analyzed,
+        ]));
+
+        $info = app(FileScanner::class)->scan($path);
+
+        self::assertSame("[00:12.34]First line\n[01:05.06]Second line", $info->lyrics);
+    }
+
+    #[Test]
+    public function prefersSyncedLyricsOverUnsynchronisedLyrics(): void
+    {
+        $path = test_path('songs/blank.mp3');
+
+        $analyzed = [
+            'filenamepath' => $path,
+            'id3v2' => [
+                'SYLT' => [
+                    ['timestampformat' => 2, 'lyrics' => [['data' => 'Synced', 'timestamp' => 0]]],
+                ],
+            ],
+            'tags' => ['id3v2' => ['unsynchronised_lyric' => ['Plain lyrics']]],
+            'playtime_seconds' => 100,
+        ];
+
+        $this->swap(getID3::class, Mockery::mock(getID3::class, [
+            'CopyTagsToComments' => $analyzed,
+            'analyze' => $analyzed,
+        ]));
+
+        self::assertSame('[00:00.00]Synced', app(FileScanner::class)->scan($path)->lyrics);
+    }
+
+    #[Test]
+    public function fallsBackToUnsynchronisedLyricsWhenSyltUsesFrameTimestamps(): void
+    {
+        $path = test_path('songs/blank.mp3');
+
+        $analyzed = [
+            'filenamepath' => $path,
+            'id3v2' => [
+                'SYLT' => [
+                    ['timestampformat' => 1, 'lyrics' => [['data' => 'Synced', 'timestamp' => 1]]],
+                ],
+            ],
+            'tags' => ['id3v2' => ['unsynchronised_lyric' => ['Plain lyrics']]],
+            'playtime_seconds' => 100,
+        ];
+
+        $this->swap(getID3::class, Mockery::mock(getID3::class, [
+            'CopyTagsToComments' => $analyzed,
+            'analyze' => $analyzed,
+        ]));
+
+        self::assertSame('Plain lyrics', app(FileScanner::class)->scan($path)->lyrics);
+    }
+
+    #[Test]
     public function htmlEntities(): void
     {
         $path = test_path('songs/blank.mp3');

--- a/tests/Integration/Services/Scanners/FileScannerTest.php
+++ b/tests/Integration/Services/Scanners/FileScannerTest.php
@@ -184,6 +184,59 @@ class FileScannerTest extends TestCase
     }
 
     #[Test]
+    public function treatsSyncedLyricEntryWithoutTimestampAsStartOfFile(): void
+    {
+        $path = test_path('songs/blank.mp3');
+
+        $analyzed = [
+            'filenamepath' => $path,
+            'id3v2' => [
+                'SYLT' => [
+                    [
+                        'timestampformat' => 2,
+                        'lyrics' => [
+                            ['data' => 'Intro line'], // first entry may omit its timestamp
+                            ['data' => 'Next line', 'timestamp' => 5000],
+                        ],
+                    ],
+                ],
+            ],
+            'playtime_seconds' => 100,
+        ];
+
+        $this->swap(getID3::class, Mockery::mock(getID3::class, [
+            'CopyTagsToComments' => $analyzed,
+            'analyze' => $analyzed,
+        ]));
+
+        self::assertSame("[00:00.00]Intro line\n[00:05.00]Next line", app(FileScanner::class)->scan($path)->lyrics);
+    }
+
+    #[Test]
+    public function usesFirstUsableSyncedLyricsFrame(): void
+    {
+        $path = test_path('songs/blank.mp3');
+
+        $analyzed = [
+            'filenamepath' => $path,
+            'id3v2' => [
+                'SYLT' => [
+                    ['timestampformat' => 1, 'lyrics' => [['data' => 'Frame timestamps', 'timestamp' => 1]]],
+                    ['timestampformat' => 2, 'lyrics' => [['data' => 'Real line', 'timestamp' => 3000]]],
+                ],
+            ],
+            'playtime_seconds' => 100,
+        ];
+
+        $this->swap(getID3::class, Mockery::mock(getID3::class, [
+            'CopyTagsToComments' => $analyzed,
+            'analyze' => $analyzed,
+        ]));
+
+        self::assertSame('[00:03.00]Real line', app(FileScanner::class)->scan($path)->lyrics);
+    }
+
+    #[Test]
     public function fallsBackToUnsynchronisedLyricsWhenSyltUsesFrameTimestamps(): void
     {
         $path = test_path('songs/blank.mp3');

--- a/tests/Integration/Services/Scanners/FileScannerTest.php
+++ b/tests/Integration/Services/Scanners/FileScannerTest.php
@@ -184,59 +184,6 @@ class FileScannerTest extends TestCase
     }
 
     #[Test]
-    public function treatsSyncedLyricEntryWithoutTimestampAsStartOfFile(): void
-    {
-        $path = test_path('songs/blank.mp3');
-
-        $analyzed = [
-            'filenamepath' => $path,
-            'id3v2' => [
-                'SYLT' => [
-                    [
-                        'timestampformat' => 2,
-                        'lyrics' => [
-                            ['data' => 'Intro line'], // first entry may omit its timestamp
-                            ['data' => 'Next line', 'timestamp' => 5000],
-                        ],
-                    ],
-                ],
-            ],
-            'playtime_seconds' => 100,
-        ];
-
-        $this->swap(getID3::class, Mockery::mock(getID3::class, [
-            'CopyTagsToComments' => $analyzed,
-            'analyze' => $analyzed,
-        ]));
-
-        self::assertSame("[00:00.00]Intro line\n[00:05.00]Next line", app(FileScanner::class)->scan($path)->lyrics);
-    }
-
-    #[Test]
-    public function usesFirstUsableSyncedLyricsFrame(): void
-    {
-        $path = test_path('songs/blank.mp3');
-
-        $analyzed = [
-            'filenamepath' => $path,
-            'id3v2' => [
-                'SYLT' => [
-                    ['timestampformat' => 1, 'lyrics' => [['data' => 'Frame timestamps', 'timestamp' => 1]]],
-                    ['timestampformat' => 2, 'lyrics' => [['data' => 'Real line', 'timestamp' => 3000]]],
-                ],
-            ],
-            'playtime_seconds' => 100,
-        ];
-
-        $this->swap(getID3::class, Mockery::mock(getID3::class, [
-            'CopyTagsToComments' => $analyzed,
-            'analyze' => $analyzed,
-        ]));
-
-        self::assertSame('[00:03.00]Real line', app(FileScanner::class)->scan($path)->lyrics);
-    }
-
-    #[Test]
     public function fallsBackToUnsynchronisedLyricsWhenSyltUsesFrameTimestamps(): void
     {
         $path = test_path('songs/blank.mp3');

--- a/tests/Unit/Helpers/SyncedLyricsConverterTest.php
+++ b/tests/Unit/Helpers/SyncedLyricsConverterTest.php
@@ -41,6 +41,23 @@ class SyncedLyricsConverterTest extends TestCase
     }
 
     #[Test]
+    public function skipsLaterEntriesWithoutTimestamp(): void
+    {
+        $lrc = SyncedLyricsConverter::fromSyltFrames([
+            [
+                'timestampformat' => 2,
+                'lyrics' => [
+                    ['data' => 'Intro', 'timestamp' => 1000],
+                    ['data' => 'Malformed line'], // missing timestamp, not first -> skipped
+                    ['data' => 'Outro', 'timestamp' => 2000],
+                ],
+            ],
+        ]);
+
+        self::assertSame("[00:01.00]Intro\n[00:02.00]Outro", $lrc);
+    }
+
+    #[Test]
     public function usesFirstUsableFrame(): void
     {
         $lrc = SyncedLyricsConverter::fromSyltFrames([

--- a/tests/Unit/Helpers/SyncedLyricsConverterTest.php
+++ b/tests/Unit/Helpers/SyncedLyricsConverterTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Unit\Helpers;
+
+use App\Helpers\SyncedLyricsConverter;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SyncedLyricsConverterTest extends TestCase
+{
+    #[Test]
+    public function convertsMillisecondTimestampsToLrc(): void
+    {
+        $lrc = SyncedLyricsConverter::fromSyltFrames([
+            [
+                'timestampformat' => 2,
+                'lyrics' => [
+                    ['data' => 'First line', 'timestamp' => 12_340],
+                    ['data' => 'Second line', 'timestamp' => 65_060],
+                ],
+            ],
+        ]);
+
+        self::assertSame("[00:12.34]First line\n[01:05.06]Second line", $lrc);
+    }
+
+    #[Test]
+    public function treatsEntryWithoutTimestampAsStartOfFile(): void
+    {
+        $lrc = SyncedLyricsConverter::fromSyltFrames([
+            [
+                'timestampformat' => 2,
+                'lyrics' => [
+                    ['data' => 'Intro line'],
+                    ['data' => 'Next line', 'timestamp' => 5000],
+                ],
+            ],
+        ]);
+
+        self::assertSame("[00:00.00]Intro line\n[00:05.00]Next line", $lrc);
+    }
+
+    #[Test]
+    public function usesFirstUsableFrame(): void
+    {
+        $lrc = SyncedLyricsConverter::fromSyltFrames([
+            ['timestampformat' => 1, 'lyrics' => [['data' => 'Frame timestamps', 'timestamp' => 1]]],
+            ['timestampformat' => 2, 'lyrics' => [['data' => 'Real line', 'timestamp' => 3000]]],
+        ]);
+
+        self::assertSame('[00:03.00]Real line', $lrc);
+    }
+
+    #[Test]
+    public function returnsEmptyForUnsupportedFrameTimestampFormat(): void
+    {
+        $lrc = SyncedLyricsConverter::fromSyltFrames([
+            ['timestampformat' => 1, 'lyrics' => [['data' => 'Frame timestamps', 'timestamp' => 1]]],
+        ]);
+
+        self::assertSame('', $lrc);
+    }
+
+    #[Test]
+    public function returnsEmptyWhenThereAreNoFrames(): void
+    {
+        self::assertSame('', SyncedLyricsConverter::fromSyltFrames([]));
+    }
+}


### PR DESCRIPTION
Closes #2600. Follow-up to #2599.

#2599 made `getLyricsBySongId` return synced lyrics whenever timed LRC text is present in `song->lyrics`, but that only covered `.lrc` sidecars — embedded **SYLT** (synchronised lyrics) frames were dropped at scan time. This adds SYLT extraction so embedded synced lyrics flow through the same pipeline (web player and Subsonic).

## The gap

`ScanInformation::fromGetId3Info()` only read *unsynchronised* lyric frames (`unsynchronised_lyric` / `unsyncedlyrics` / `lyrics`). getID3 parses the ID3v2 `SYLT` frame into `$info['id3v2']['SYLT']` — with `timestampformat` and a `lyrics` array of `{data, timestamp}` — but it never gets copied into the tag map koel reads, so the timing was discarded.

## Change

`ScanInformation` now reads `$info['id3v2']['SYLT'][0]` and serializes it to LRC-format text (`[mm:ss.xx]…`) stored in `song->lyrics`:

- Only `timestampformat == 2` (milliseconds) is converted; MPEG-frame timestamps (`1`) can't be converted reliably, so those fall back to unsynchronised lyrics.
- SYLT is **preferred** over unsynchronised lyrics when both exist (synced is richer).
- The first SYLT entry may legitimately omit its timestamp (= start of file) — handled as `0`.
- Text runs through the existing `TagFixer` + `html_entity_decode`, same as other tags.

Once stored as LRC, the existing pipeline takes over with no further changes: the web player renders scrolling lyrics, and `getLyricsBySongId` returns `synced: true` via `ParsedLyrics` (#2599).

## Re-scan required

SYLT timing isn't stored today, so existing libraries need a re-scan to backfill embedded synced lyrics.

## Tests

`FileScannerTest` (using the existing getID3-mock pattern): SYLT → LRC conversion with millisecond offsets, SYLT preferred over unsynchronised lyrics, and fallback to unsynchronised lyrics when SYLT uses frame-based timestamps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for synced (SYLT) lyrics, converting timestamped entries into LRC-style lines for display.

* **Bug Fixes**
  * Synced SYLT lyrics now take priority over unsynchronized lyric tags.
  * Improved lyric cleanup and decoding, with fallback to existing unsynchronized lyrics when SYLT timing is unsupported or yields no usable lines.

* **Tests**
  * Added unit and integration coverage for SYLT-to-LRC formatting, frame/priority behavior, and handling of missing or unsupported timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->