### PR TITLE
fix: read DATE vorbis tag for year when scanning FLAC/OGG files

### DIFF
--- a/app/Values/Scanning/ScanInformation.php
+++ b/app/Values/Scanning/ScanInformation.php
@@ -74,7 +74,7 @@ class ScanInformation implements Arrayable
             albumArtistName: html_entity_decode($albumArtistName),
             track: (int) self::getTag($tags, ['track', 'tracknumber', 'track_number']),
             disc: (int) self::getTag($tags, ['discnumber', 'part_of_a_set'], 1),
-            year: (int) self::getTag($tags, 'year') ?: null,
+            year: (int) self::getTag($tags, ['year', 'date']) ?: null,
             genre: TagFixer::fix(self::getTag($tags, 'genre')),
             lyrics: $lyrics,
             length: (float) Arr::get($info, 'playtime_seconds'),

--- a/tests/Integration/Services/Scanners/FileScannerTest.php
+++ b/tests/Integration/Services/Scanners/FileScannerTest.php
@@ -90,6 +90,7 @@ class FileScannerTest extends TestCase
             ],
             'path' => realpath($flacPath),
             'mtime' => filemtime($flacPath),
+            'year' => 2015,
             'mime_type' => 'audio/flac',
             'file_size' => 532_201,
         ];


### PR DESCRIPTION
## Description

When scanning FLAC, OGG, or Opus files, the scanner now reads the `DATE` Vorbis comment tag in addition to `year` when extracting release year. Previously only `year` was checked, which is an ID3 (MP3) tag — Vorbis-comment-based formats store the year in `DATE`, so those files were always scanned with a `null` year.

`getTag()` already accepts an array of keys. PHP's `(int) "1969-09-26"` correctly coerces a full ISO date string to `1969`, so both bare-year (`DATE=1969`) and full-date (`DATE=1969-09-26`) values are handled.

## Motivation

Albums ripped from FLAC had no year in Koel, and therefore no year in Subsonic API responses (`getAlbum`, `getAlbumList2`, etc.), even when the files were properly tagged. Only MP3s were unaffected.

Users with existing libraries can backfill affected albums by running a force rescan:
```
php artisan koel:scan --force
```

## Screenshots (if applicable)

N/A

## Checklist
- [x] I've tested my changes thoroughly and added tests where applicable
- [x] I've updated relevant documentation (if any)
- [x] My code follows the project's conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date metadata detection when scanning files.
  * The `year` metadata now uses the `year` tag when available, otherwise falls back to the `date` tag, and remains empty when neither exists.

* **Tests**
  * Updated FLAC/Vorbis comment scanning integration expectations to include the `year` metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->