### PR TITLE
fix: honor offset in Subsonic getAlbumList/getAlbumList2 for newest, frequent and recent types

### DIFF
--- a/app/Ai/Tools/PlayMostPlayedAlbum.php
+++ b/app/Ai/Tools/PlayMostPlayedAlbum.php
@@ -33,7 +33,7 @@ class PlayMostPlayedAlbum implements Tool
 
     public function handle(Request $request): Stringable|string
     {
-        $albums = $this->albumRepository->getMostPlayed(1, $this->context->user);
+        $albums = $this->albumRepository->getMostPlayed(1, user: $this->context->user);
 
         if ($albums->isEmpty()) {
             return 'No play history found yet.';

--- a/app/Ai/Tools/PlayRecentlyAddedAlbum.php
+++ b/app/Ai/Tools/PlayRecentlyAddedAlbum.php
@@ -33,7 +33,7 @@ class PlayRecentlyAddedAlbum implements Tool
 
     public function handle(Request $request): Stringable|string
     {
-        $albums = $this->albumRepository->getRecentlyAdded(1, $this->context->user);
+        $albums = $this->albumRepository->getRecentlyAdded(1, user: $this->context->user);
 
         if ($albums->isEmpty()) {
             return 'No albums found in the library.';

--- a/app/Http/Controllers/Subsonic/Concerns/LoadsAlbumsByType.php
+++ b/app/Http/Controllers/Subsonic/Concerns/LoadsAlbumsByType.php
@@ -24,11 +24,11 @@ trait LoadsAlbumsByType
         int $offset,
     ): Collection {
         return match ($request->type) {
-            'newest' => $albumRepository->getRecentlyAdded($size),
-            'frequent' => $albumRepository->getMostPlayed($size),
+            'newest' => $albumRepository->getRecentlyAdded($size, $offset),
+            'frequent' => $albumRepository->getMostPlayed($size, $offset),
             'random' => $albumRepository->getRandom($size),
             'starred' => $albumRepository->getFavorites($size, $offset),
-            'recent' => $albumRepository->getRecentlyPlayed($size),
+            'recent' => $albumRepository->getRecentlyPlayed($size, $offset),
             'highest' => $albumRepository->getHighestRated($size, $offset),
             'byYear' => $albumRepository->getByYearRange(
                 $request->integer('fromYear'),

--- a/app/Repositories/AlbumRepository.php
+++ b/app/Repositories/AlbumRepository.php
@@ -39,27 +39,29 @@ class AlbumRepository extends Repository implements ScoutableRepository
             ->find($id);
     }
 
-    public function getRecentlyAdded(int $count = 6, ?User $user = null): Collection
+    public function getRecentlyAdded(int $count = 6, int $offset = 0, ?User $user = null): Collection
     {
         return Album::query()
             ->onlyStandard()
             ->withUserContext(user: $user ?? $this->auth->user())
             ->latest()
+            ->offset($offset)
             ->limit($count)
             ->get();
     }
 
-    public function getMostPlayed(int $count = 6, ?User $user = null): Collection
+    public function getMostPlayed(int $count = 6, int $offset = 0, ?User $user = null): Collection
     {
         return Album::query()
             ->onlyStandard()
             ->withUserContext(user: $user ?? $this->auth->user(), includePlayCount: true)
             ->orderByDesc('play_count')
+            ->offset($offset)
             ->limit($count)
             ->get();
     }
 
-    public function getRecentlyPlayed(int $count = 6, ?User $user = null): Collection
+    public function getRecentlyPlayed(int $count = 6, int $offset = 0, ?User $user = null): Collection
     {
         $user ??= $this->auth->user();
 
@@ -76,6 +78,7 @@ class AlbumRepository extends Repository implements ScoutableRepository
                     ->whereNotNull('interactions.last_played_at');
             })
             ->orderByDesc('last_played_at')
+            ->offset($offset)
             ->limit($count)
             ->get();
     }

--- a/tests/Feature/Subsonic/GetAlbumList2Test.php
+++ b/tests/Feature/Subsonic/GetAlbumList2Test.php
@@ -36,6 +36,29 @@ class GetAlbumList2Test extends TestCase
     }
 
     #[Test]
+    public function newestRespectsOffset(): void
+    {
+        $user = create_user();
+
+        Album::factory()->createMany([
+            ['name' => 'Oldest', 'user_id' => $user->id, 'created_at' => now()->subDays(20)],
+            ['name' => 'Middle', 'user_id' => $user->id, 'created_at' => now()->subDays(10)],
+            ['name' => 'Newest', 'user_id' => $user->id, 'created_at' => now()],
+        ]);
+
+        $firstPage = $this->getJson(
+            "/rest/getAlbumList2.view?apiKey={$user->subsonic_api_key}&f=json&type=newest&size=1&offset=0",
+        )->assertOk();
+
+        $secondPage = $this->getJson(
+            "/rest/getAlbumList2.view?apiKey={$user->subsonic_api_key}&f=json&type=newest&size=1&offset=1",
+        )->assertOk();
+
+        self::assertSame(['Newest'], array_column($firstPage->json('subsonic-response.albumList2.album'), 'name'));
+        self::assertSame(['Middle'], array_column($secondPage->json('subsonic-response.albumList2.album'), 'name'));
+    }
+
+    #[Test]
     public function alphabeticalByNameRespectsOffsetAndSize(): void
     {
         $user = create_user();


### PR DESCRIPTION
## Summary

`getAlbumList2` (and `getAlbumList`) ignored the `offset` parameter for the `newest`, `frequent`, and `recent` list types, so paging through those lists returned the same albums on every page.

The Subsonic `type` is dispatched onto `AlbumRepository` methods in the shared `LoadsAlbumsByType` trait. Most arms already forwarded `$offset`, but `getRecentlyAdded` (newest), `getMostPlayed` (frequent), and `getRecentlyPlayed` (recent) had no `$offset` parameter at all, so the trait had no way to page them. `random` intentionally stays offset-less.

## Changes

- Add `int $offset = 0` to `getRecentlyAdded`, `getMostPlayed`, and `getRecentlyPlayed` (positioned as `(count, offset, user)` to match the sibling paged methods) and apply `->offset($offset)`.
- Forward `$offset` from the trait's `newest`/`frequent`/`recent` arms.
- Two AI tools that called these methods with a positional `$user` now pass it as a named argument.

## Tests

- New `GetAlbumList2Test::newestRespectsOffset` reproduces the reporter's exact scenario (`size=1&offset=0` vs `size=1&offset=1`).

Fixes #2603


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced album list pagination to support offset-based browsing across “newest”, “frequent”, and “recent” album views.
* **Bug Fixes**
  * Fixed album list navigation so pagination pages correctly respect the requested offset instead of repeating the first items.
* **Tests**
  * Added feature coverage to confirm “newest” album lists return the expected items for multiple offsets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->