### PR TITLE
fix: populate starred and played dates in Subsonic responses

### DIFF
--- a/app/Builders/AlbumBuilder.php
+++ b/app/Builders/AlbumBuilder.php
@@ -101,6 +101,19 @@ class AlbumBuilder extends FavoriteableBuilder
         ]);
     }
 
+    private function withLastPlayedSubquery(): self
+    {
+        throw_unless($this->user, new LogicException('User must be set to query last played timestamps.'));
+
+        return $this->addSelect([
+            'last_played_at' => DB::table('interactions')
+                ->join('songs as songs_for_last_played', 'songs_for_last_played.id', 'interactions.song_id')
+                ->whereColumn('songs_for_last_played.album_id', 'albums.id')
+                ->where('interactions.user_id', $this->user->id)
+                ->selectRaw('MAX(interactions.last_played_at)'),
+        ]);
+    }
+
     private function withRatingSubquery(): self
     {
         throw_unless($this->user, new LogicException('User must be set to query album ratings.'));
@@ -132,6 +145,7 @@ class AlbumBuilder extends FavoriteableBuilder
             ->when($includeFavoriteStatus, static fn (self $query) => $query->withFavoriteStatus($favoritesOnly))
             ->when($includePlayCount, static fn (self $query) => $query->withPlayCount($includeFavoriteStatus))
             ->withLengthSubquery()
+            ->withLastPlayedSubquery()
             ->withRatingSubquery();
     }
 

--- a/app/Builders/FavoriteableBuilder.php
+++ b/app/Builders/FavoriteableBuilder.php
@@ -35,7 +35,9 @@ abstract class FavoriteableBuilder extends Builder
             )->where('favorites.user_id', $this->user->id);
         });
 
-        $this->addSelect(DB::raw('(CASE WHEN favorites.created_at IS NULL THEN false ELSE true END) AS favorite'));
+        $this->addSelect(DB::raw(
+            '(CASE WHEN favorites.created_at IS NULL THEN false ELSE true END) AS favorite',
+        ))->addSelect('favorites.created_at as favorited_at');
 
         return $this;
     }

--- a/app/Http/Responses/Subsonic/Resources/AlbumResource.php
+++ b/app/Http/Responses/Subsonic/Resources/AlbumResource.php
@@ -31,6 +31,7 @@ final class AlbumResource
      *     year: ?int,
      *     userRating: ?int,
      *     starred: ?string,
+     *     played: ?string,
      * }
      */
     public static function toArray(Album $album, User $user): array
@@ -47,6 +48,7 @@ final class AlbumResource
             'year' => $album->year,
             'userRating' => $album->getRatingFor($user) ?: null,
             'starred' => $album->favorited_at?->toIso8601String(),
+            'played' => $album->last_played_at?->toIso8601String(),
         ];
     }
 }

--- a/app/Http/Responses/Subsonic/Resources/AlbumResource.php
+++ b/app/Http/Responses/Subsonic/Resources/AlbumResource.php
@@ -30,6 +30,7 @@ final class AlbumResource
      *     created: string,
      *     year: ?int,
      *     userRating: ?int,
+     *     starred: ?string,
      * }
      */
     public static function toArray(Album $album, User $user): array
@@ -45,6 +46,7 @@ final class AlbumResource
             'created' => $album->created_at->toIso8601String(),
             'year' => $album->year,
             'userRating' => $album->getRatingFor($user) ?: null,
+            'starred' => $album->favorited_at?->toIso8601String(),
         ];
     }
 }

--- a/app/Http/Responses/Subsonic/Resources/ArtistResource.php
+++ b/app/Http/Responses/Subsonic/Resources/ArtistResource.php
@@ -21,6 +21,7 @@ final class ArtistResource
      *     coverArt: ?string,
      *     albumCount: int,
      *     userRating: ?int,
+     *     starred: ?string,
      * }
      */
     public static function toArray(Artist $artist, User $user): array
@@ -31,6 +32,7 @@ final class ArtistResource
             'coverArt' => $artist->image ? $artist->id : null,
             'albumCount' => $artist->albums_count ?? 0,
             'userRating' => $artist->getRatingFor($user) ?: null,
+            'starred' => $artist->favorited_at?->toIso8601String(),
         ];
     }
 }

--- a/app/Http/Responses/Subsonic/Resources/SongResource.php
+++ b/app/Http/Responses/Subsonic/Resources/SongResource.php
@@ -44,6 +44,7 @@ final class SongResource
      *     discNumber: ?int,
      *     isVideo: bool,
      *     userRating: ?int,
+     *     starred: ?string,
      * }
      */
     public static function toArray(Song $song, User $user): array
@@ -70,6 +71,7 @@ final class SongResource
             'discNumber' => $song->disc ?: null,
             'isVideo' => false,
             'userRating' => $song->getRatingFor($user) ?: null,
+            'starred' => $song->favorited_at?->toIso8601String(),
         ];
     }
 }

--- a/app/Models/Album.php
+++ b/app/Models/Album.php
@@ -31,6 +31,7 @@ use OwenIt\Auditing\Contracts\Auditable as AuditableContract;
 
 /**
  * @property ?boolean $favorite Whether the album is liked by the scoped user
+ * @property ?Carbon $favorited_at When the scoped user favorited the album, if at all
  * @property ?int $year
  * @property ?string $thumbnail The album's thumbnail file name
  * @property Artist $artist The album's artist
@@ -74,6 +75,7 @@ class Album extends Model implements AuditableContract, Embeddable, Favoriteable
     {
         return [
             'favorite' => 'boolean',
+            'favorited_at' => 'datetime',
         ];
     }
 

--- a/app/Models/Album.php
+++ b/app/Models/Album.php
@@ -32,6 +32,7 @@ use OwenIt\Auditing\Contracts\Auditable as AuditableContract;
 /**
  * @property ?boolean $favorite Whether the album is liked by the scoped user
  * @property ?Carbon $favorited_at When the scoped user favorited the album, if at all
+ * @property ?Carbon $last_played_at When the scoped user last played the album, if at all
  * @property ?int $year
  * @property ?string $thumbnail The album's thumbnail file name
  * @property Artist $artist The album's artist
@@ -76,6 +77,7 @@ class Album extends Model implements AuditableContract, Embeddable, Favoriteable
         return [
             'favorite' => 'boolean',
             'favorited_at' => 'datetime',
+            'last_played_at' => 'datetime',
         ];
     }
 

--- a/app/Models/Artist.php
+++ b/app/Models/Artist.php
@@ -41,6 +41,8 @@ use OwenIt\Auditing\Contracts\Auditable as AuditableContract;
  * @property int $user_id The ID of the user that owns this artist
  * @property string $id
  * @property string $name
+ * @property ?bool $favorite Whether the artist is liked by the scoped user
+ * @property ?Carbon $favorited_at When the scoped user favorited the artist, if at all
  *
  * @method static ArtistFactory factory(...$parameters)
  */
@@ -68,6 +70,7 @@ class Artist extends Model implements AuditableContract, Embeddable, Favoriteabl
     {
         return [
             'favorite' => 'boolean',
+            'favorited_at' => 'datetime',
         ];
     }
 

--- a/app/Models/Song.php
+++ b/app/Models/Song.php
@@ -40,6 +40,7 @@ use PhanAn\Poddle\Values\EpisodeMetadata;
  * @property ?Artist $artist
  * @property ?Folder $folder
  * @property ?bool $favorite Whether the song is liked by the current user (dynamically calculated)
+ * @property ?Carbon $favorited_at When the current user favorited the song, if at all
  * @property ?int $play_count The number of times the song has been played by the current user (dynamically calculated)
  * @property ?string $album_name
  * @property ?string $artist_name
@@ -116,6 +117,7 @@ class Song extends Model implements AuditableContract, Favoriteable, Embeddable,
             'storage' => SongStorageCast::class,
             'episode_metadata' => EpisodeMetadataCast::class,
             'favorite' => 'boolean',
+            'favorited_at' => 'datetime',
         ];
     }
 

--- a/app/Repositories/AlbumRepository.php
+++ b/app/Repositories/AlbumRepository.php
@@ -13,7 +13,6 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\Query\JoinClause;
-use Illuminate\Support\Facades\DB;
 
 /**
  * @extends Repository<Album>
@@ -69,7 +68,7 @@ class AlbumRepository extends Repository implements ScoutableRepository
             ->withUserContext(user: $user)
             ->whereExists(static function (QueryBuilder $query) use ($user): void {
                 $query
-                    ->select(DB::raw(1))
+                    ->selectRaw('1')
                     ->from('interactions')
                     ->join('songs as recently_played_songs', 'recently_played_songs.id', 'interactions.song_id')
                     ->whereColumn('recently_played_songs.album_id', 'albums.id')

--- a/app/Repositories/AlbumRepository.php
+++ b/app/Repositories/AlbumRepository.php
@@ -11,6 +11,7 @@ use Illuminate\Contracts\Pagination\CursorPaginator;
 use Illuminate\Contracts\Pagination\Paginator;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\Query\JoinClause;
 use Illuminate\Support\Facades\DB;
 
@@ -61,11 +62,20 @@ class AlbumRepository extends Repository implements ScoutableRepository
 
     public function getRecentlyPlayed(int $count = 6, ?User $user = null): Collection
     {
+        $user ??= $this->auth->user();
+
         return Album::query()
             ->onlyStandard()
-            ->withUserContext(user: $user ?? $this->auth->user(), includePlayCount: true)
-            ->addSelect(DB::raw('MAX(interactions.last_played_at) as last_played_at'))
-            ->havingRaw('MAX(interactions.last_played_at) IS NOT NULL')
+            ->withUserContext(user: $user)
+            ->whereExists(static function (QueryBuilder $query) use ($user): void {
+                $query
+                    ->select(DB::raw(1))
+                    ->from('interactions')
+                    ->join('songs as recently_played_songs', 'recently_played_songs.id', 'interactions.song_id')
+                    ->whereColumn('recently_played_songs.album_id', 'albums.id')
+                    ->where('interactions.user_id', $user->id)
+                    ->whereNotNull('interactions.last_played_at');
+            })
             ->orderByDesc('last_played_at')
             ->limit($count)
             ->get();

--- a/database/migrations/2026_07_01_192707_add_composite_index_to_interactions_table.php
+++ b/database/migrations/2026_07_01_192707_add_composite_index_to_interactions_table.php
@@ -1,0 +1,14 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('interactions', static function (Blueprint $table): void {
+            $table->index(['song_id', 'user_id', 'last_played_at']);
+        });
+    }
+};

--- a/tests/Feature/Subsonic/GetAlbumTest.php
+++ b/tests/Feature/Subsonic/GetAlbumTest.php
@@ -7,6 +7,7 @@ use App\Http\Responses\Subsonic\Resources\AlbumResource;
 use App\Http\Responses\Subsonic\Resources\SongResource;
 use App\Models\Album;
 use App\Models\Favorite;
+use App\Models\Interaction;
 use App\Models\Song;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
@@ -76,6 +77,49 @@ class GetAlbumTest extends TestCase
         )->assertOk();
 
         self::assertArrayNotHasKey('starred', $response->json('subsonic-response.album'));
+    }
+
+    #[Test]
+    public function populatesPlayedDateFromMostRecentlyPlayedSong(): void
+    {
+        $user = create_user();
+        $album = Album::factory()->createOne(['user_id' => $user->id]);
+
+        $stale = Song::factory()->createOne(['album_id' => $album->id, 'owner_id' => $user->id]);
+        $recent = Song::factory()->createOne(['album_id' => $album->id, 'owner_id' => $user->id]);
+
+        Interaction::factory()->createOne([
+            'user_id' => $user->id,
+            'song_id' => $stale->id,
+            'last_played_at' => now()->subDays(9),
+        ]);
+
+        $lastPlayedAt = now()->subMinutes(2)->startOfSecond();
+
+        Interaction::factory()->createOne([
+            'user_id' => $user->id,
+            'song_id' => $recent->id,
+            'last_played_at' => $lastPlayedAt,
+        ]);
+
+        $this
+            ->getJson("/rest/getAlbum.view?apiKey={$user->subsonic_api_key}&f=json&id={$album->id}")
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.album.played', $lastPlayedAt->toIso8601String());
+    }
+
+    #[Test]
+    public function omitsPlayedDateWhenNeverPlayed(): void
+    {
+        $user = create_user();
+        $album = Album::factory()->createOne(['user_id' => $user->id]);
+        Song::factory()->createOne(['album_id' => $album->id, 'owner_id' => $user->id]);
+
+        $response = $this->getJson(
+            "/rest/getAlbum.view?apiKey={$user->subsonic_api_key}&f=json&id={$album->id}",
+        )->assertOk();
+
+        self::assertArrayNotHasKey('played', $response->json('subsonic-response.album'));
     }
 
     #[Test]

--- a/tests/Feature/Subsonic/GetAlbumTest.php
+++ b/tests/Feature/Subsonic/GetAlbumTest.php
@@ -2,9 +2,11 @@
 
 namespace Tests\Feature\Subsonic;
 
+use App\Enums\FavoriteableType;
 use App\Http\Responses\Subsonic\Resources\AlbumResource;
 use App\Http\Responses\Subsonic\Resources\SongResource;
 use App\Models\Album;
+use App\Models\Favorite;
 use App\Models\Song;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
@@ -40,6 +42,40 @@ class GetAlbumTest extends TestCase
         $titles = collect($response->json('subsonic-response.album.song'))->pluck('title')->all();
         self::assertContains('Airbag', $titles);
         self::assertContains('Paranoid Android', $titles);
+    }
+
+    #[Test]
+    public function populatesStarredDateWhenFavorited(): void
+    {
+        $user = create_user();
+        $album = Album::factory()->createOne(['user_id' => $user->id]);
+
+        $favoritedAt = now()->subDays(2)->startOfSecond();
+
+        Favorite::factory()->createOne([
+            'user_id' => $user->id,
+            'favoriteable_type' => FavoriteableType::ALBUM->value,
+            'favoriteable_id' => $album->id,
+            'created_at' => $favoritedAt,
+        ]);
+
+        $this
+            ->getJson("/rest/getAlbum.view?apiKey={$user->subsonic_api_key}&f=json&id={$album->id}")
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.album.starred', $favoritedAt->toIso8601String());
+    }
+
+    #[Test]
+    public function omitsStarredDateWhenNotFavorited(): void
+    {
+        $user = create_user();
+        $album = Album::factory()->createOne(['user_id' => $user->id]);
+
+        $response = $this->getJson(
+            "/rest/getAlbum.view?apiKey={$user->subsonic_api_key}&f=json&id={$album->id}",
+        )->assertOk();
+
+        self::assertArrayNotHasKey('starred', $response->json('subsonic-response.album'));
     }
 
     #[Test]

--- a/tests/Feature/Subsonic/GetStarred2Test.php
+++ b/tests/Feature/Subsonic/GetStarred2Test.php
@@ -74,6 +74,49 @@ class GetStarred2Test extends TestCase
     }
 
     #[Test]
+    public function populatesStarredDateForEachType(): void
+    {
+        $user = create_user();
+
+        $song = Song::factory()->createOne(['owner_id' => $user->id]);
+        $album = Album::factory()->createOne(['user_id' => $user->id]);
+        $artist = Artist::factory()->createOne(['user_id' => $user->id]);
+
+        $favoritedAt = now()->subDays(3)->startOfSecond();
+
+        Favorite::factory()->createMany([
+            [
+                'user_id' => $user->id,
+                'favoriteable_type' => FavoriteableType::PLAYABLE->value,
+                'favoriteable_id' => $song->id,
+                'created_at' => $favoritedAt,
+            ],
+            [
+                'user_id' => $user->id,
+                'favoriteable_type' => FavoriteableType::ALBUM->value,
+                'favoriteable_id' => $album->id,
+                'created_at' => $favoritedAt,
+            ],
+            [
+                'user_id' => $user->id,
+                'favoriteable_type' => FavoriteableType::ARTIST->value,
+                'favoriteable_id' => $artist->id,
+                'created_at' => $favoritedAt,
+            ],
+        ]);
+
+        $payload = $this
+            ->getJson("/rest/getStarred2.view?apiKey={$user->subsonic_api_key}&f=json")
+            ->assertOk()
+            ->json('subsonic-response.starred2');
+
+        $expected = $favoritedAt->toIso8601String();
+        self::assertSame($expected, collect($payload['song'])->firstWhere('id', $song->id)['starred']);
+        self::assertSame($expected, collect($payload['album'])->firstWhere('id', $album->id)['starred']);
+        self::assertSame($expected, collect($payload['artist'])->firstWhere('id', $artist->id)['starred']);
+    }
+
+    #[Test]
     public function emptyWhenNothingStarred(): void
     {
         $user = create_user();


### PR DESCRIPTION
## Summary

Subsonic responses never carried the per-item `starred` (favorited) or `played` (last-played) dates, even though Koel already stores both. Clients that infer starred/played state from `getAlbum`/`getSong`/`getArtist` (rather than repeatedly polling `getStarred2`) had no way to know an item was favorited or when an album was last played.

This addresses two related issues in one PR since both touch the same Subsonic serializers.

### Starred date (#2604)

- `FavoriteableBuilder::withFavoriteStatus` now also selects the favorite's `created_at` (aliased `favorited_at`, so it doesn't clobber the model's own `created_at`), in addition to the existing boolean.
- `Album`, `Song`, and `Artist` gained a `favorited_at` datetime cast.
- `AlbumResource`, `SongResource`, and `ArtistResource` now emit `starred` (the ISO-8601 favorited date), omitted when the item isn't favorited.

This populates `starred` on `getStarred2` **and** the standalone `getAlbum`/`getSong`/`getArtist` endpoints.

### Played date (#2605)

- `AlbumBuilder` gained a correlated `last_played_at` subquery (`MAX` of the user's interactions over the album's songs), wired into `withUserContext` alongside the existing length/rating subqueries.
- `Album` gained a `last_played_at` datetime cast, and `AlbumResource` now emits `played`, omitted when never played.
- `AlbumRepository::getRecentlyPlayed` was refactored to consume the new subquery alias (ordering + a `whereExists` "has been played" filter) instead of its own grouped `MAX`, which would otherwise collide.

## Tests

- `GetStarred2Test::populatesStarredDateForEachType` — asserts the exact `starred` date for a favorited song, album, and artist.
- `GetAlbumTest` — `starred`/`played` populated when favorited/played, and omitted otherwise.
- Existing `recentReturnsMostRecentlyPlayedAlbums` (the `getRecentlyPlayed` refactor) and the full Subsonic suite remain green.

## Notes

- The `last_played_at` subquery is added unconditionally in `withUserContext`, matching the existing always-on length and rating subqueries. All added SQL (aliased selects, `whereExists`, correlated subqueries) is portable across MySQL, SQLite, and PostgreSQL.

Fixes #2604
Fixes #2605


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `starred` metadata to album, song, and artist responses (ISO-8601) and `played` metadata to album responses for last-played information.

* **Bug Fixes**
  * Improved recently played album results to better reflect actual user playback activity.
  * Ensure `starred`/`played` fields are omitted when there’s no corresponding history.

* **Tests**
  * Added/expanded feature tests validating `starred` and `played` timestamps across album and starred-item endpoints.

* **Chores**
  * Added a composite index on interaction history for improved query performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->