### PR TITLE
feat: support fast AAC transcoding with ffmpeg

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -197,7 +197,7 @@ YOUTUBE_API_KEY=
 CDN_URL=
 
 
-# To transcode FLAC to MP3 and stream it on the fly, make sure the following settings are sane.
+# To transcode FLAC to AAC and stream it on the fly, make sure the following settings are sane.
 # If you don't want to transcode FLAC (i.e. to stream it as-is), set this to false.
 TRANSCODE_FLAC=false
 
@@ -208,6 +208,9 @@ FFMPEG_PATH=
 # The bit rate of the transcoded audio. Higher value results in better quality,
 # but slower streaming and more bandwidth. Defaults to 128.
 TRANSCODE_BIT_RATE=128
+
+# Set to true to use FFmpeg's faster AAC coding algorithm.
+TRANSCODE_AAC_FAST=false
 
 # The maximum time in seconds allowed for transcoding a single file.
 # Increase this if you have very large files that take long to transcode.

--- a/.env.example
+++ b/.env.example
@@ -209,7 +209,8 @@ FFMPEG_PATH=
 # but slower streaming and more bandwidth. Defaults to 128.
 TRANSCODE_BIT_RATE=128
 
-# Set to false to use FFmpeg's default AAC coder.
+# Use FFmpeg's "fast" AAC encoder coding method, which is better and much faster at higher bitrates. 
+# Set to false to use the "twoloop" method (FFmpeg's default, much slower).
 TRANSCODE_AAC_FAST=true
 
 # The maximum time in seconds allowed for transcoding a single file.

--- a/.env.example
+++ b/.env.example
@@ -209,8 +209,8 @@ FFMPEG_PATH=
 # but slower streaming and more bandwidth. Defaults to 128.
 TRANSCODE_BIT_RATE=128
 
-# Set to true to use FFmpeg's faster AAC coding algorithm.
-TRANSCODE_AAC_FAST=false
+# Set to false to use FFmpeg's default AAC coder.
+TRANSCODE_AAC_FAST=true
 
 # The maximum time in seconds allowed for transcoding a single file.
 # Increase this if you have very large files that take long to transcode.

--- a/app/Services/Transcoding/Transcoder.php
+++ b/app/Services/Transcoding/Transcoder.php
@@ -15,7 +15,7 @@ class Transcoder
         #[Config('koel.streaming.ffmpeg_path')]
         private readonly string $ffmpegPath = '',
         #[Config('koel.streaming.aac_fast')]
-        private readonly bool $aacFast = false,
+        private readonly bool $aacFast = true,
     ) {}
 
     public function transcode(string $source, string $destination, int $bitRate): void

--- a/app/Services/Transcoding/Transcoder.php
+++ b/app/Services/Transcoding/Transcoder.php
@@ -14,6 +14,8 @@ class Transcoder
         private readonly int $transcodeTimeout = 0,
         #[Config('koel.streaming.ffmpeg_path')]
         private readonly string $ffmpegPath = '',
+        #[Config('koel.streaming.aac_fast')]
+        private readonly bool $aacFast = false,
     ) {}
 
     public function transcode(string $source, string $destination, int $bitRate): void
@@ -34,6 +36,7 @@ class Transcoder
             'aac',
             '-b:a',
             "{$bitRate}k",
+            ...($this->aacFast ? ['-aac_coder', 'fast'] : []),
             '-threads',
             '0',
             '-movflags',

--- a/config/koel.php
+++ b/config/koel.php
@@ -41,7 +41,7 @@ return [
 
     'streaming' => [
         'bitrate' => env('TRANSCODE_BIT_RATE') ?: env('OUTPUT_BIT_RATE', 128),
-        'aac_fast' => env('TRANSCODE_AAC_FAST', false),
+        'aac_fast' => env('TRANSCODE_AAC_FAST', true),
         'method' => env('STREAMING_METHOD'),
         'ffmpeg_path' => env('FFMPEG_PATH') ?: find_ffmpeg_path(),
         'transcode_flac' => env('TRANSCODE_FLAC', true),

--- a/config/koel.php
+++ b/config/koel.php
@@ -41,6 +41,7 @@ return [
 
     'streaming' => [
         'bitrate' => env('TRANSCODE_BIT_RATE') ?: env('OUTPUT_BIT_RATE', 128),
+        'aac_fast' => env('TRANSCODE_AAC_FAST', false),
         'method' => env('STREAMING_METHOD'),
         'ffmpeg_path' => env('FFMPEG_PATH') ?: find_ffmpeg_path(),
         'transcode_flac' => env('TRANSCODE_FLAC', true),

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -105,7 +105,7 @@ Required when `STORAGE_DRIVER=webdav`.
 | `STREAMING_METHOD` | The streaming method. Options: `php`, `x-sendfile`, `x-accel-redirect`. See [Streaming Music](usage/streaming). Using `x-sendfile` or `x-accel-redirect` is highly recommended for better performance. | `php` |
 | `TRANSCODE_FLAC` | Whether to transcode FLAC to AAC on the fly. Set to `false` to stream FLAC as-is. | `true` |
 | `TRANSCODE_BIT_RATE` | The bit rate (in kbps) for transcoded audio. Higher values mean better quality but slower streaming. | `128` |
-| `TRANSCODE_AAC_FAST` | Whether to use FFmpeg's faster AAC coding algorithm. | `false` |
+| `TRANSCODE_AAC_FAST` | Whether to use FFmpeg's faster AAC coding algorithm. Set to `false` to use its default AAC coder. | `true` |
 | `FFMPEG_PATH` | The full path to the ffmpeg binary. Automatically detected if left empty. | _(auto-detected)_ |
 | `TRANSCODE_TIMEOUT` | The maximum time in seconds allowed for transcoding a single file. Increase for very large files. `0` disables the timeout. | `300` |
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -103,8 +103,9 @@ Required when `STORAGE_DRIVER=webdav`.
 | Variable | Description | Default |
 |---|---|---|
 | `STREAMING_METHOD` | The streaming method. Options: `php`, `x-sendfile`, `x-accel-redirect`. See [Streaming Music](usage/streaming). Using `x-sendfile` or `x-accel-redirect` is highly recommended for better performance. | `php` |
-| `TRANSCODE_FLAC` | Whether to transcode FLAC to MP3 on the fly. Set to `false` to stream FLAC as-is. | `true` |
+| `TRANSCODE_FLAC` | Whether to transcode FLAC to AAC on the fly. Set to `false` to stream FLAC as-is. | `true` |
 | `TRANSCODE_BIT_RATE` | The bit rate (in kbps) for transcoded audio. Higher values mean better quality but slower streaming. | `128` |
+| `TRANSCODE_AAC_FAST` | Whether to use FFmpeg's faster AAC coding algorithm. | `false` |
 | `FFMPEG_PATH` | The full path to the ffmpeg binary. Automatically detected if left empty. | _(auto-detected)_ |
 | `TRANSCODE_TIMEOUT` | The maximum time in seconds allowed for transcoding a single file. Increase for very large files. `0` disables the timeout. | `300` |
 

--- a/tests/Unit/Services/Transcoding/TranscoderTest.php
+++ b/tests/Unit/Services/Transcoding/TranscoderTest.php
@@ -54,6 +54,40 @@ class TranscoderTest extends TestCase
     }
 
     #[Test]
+    public function transcodeWithFastAacCoder(): void
+    {
+        Process::fake();
+        File::expects('ensureDirectoryExists')->with('/path/to');
+
+        $transcoder = new Transcoder(transcodeTimeout: 300, ffmpegPath: '/usr/bin/ffmpeg', aacFast: true);
+        $transcoder->transcode('/path/to/song.aiff', '/path/to/output.m4a', 320);
+
+        Process::assertRanTimes(static function (PendingProcess $process): bool {
+            return (
+                $process->command === [
+                    '/usr/bin/ffmpeg',
+                    '-nostdin',
+                    '-i',
+                    '/path/to/song.aiff',
+                    '-vn',
+                    '-c:a',
+                    'aac',
+                    '-b:a',
+                    '320k',
+                    '-aac_coder',
+                    'fast',
+                    '-threads',
+                    '0',
+                    '-movflags',
+                    '+faststart',
+                    '-y',
+                    '/path/to/output.m4a',
+                ]
+            );
+        }, 1);
+    }
+
+    #[Test]
     public function throwOnFailure(): void
     {
         Process::fake([

--- a/tests/Unit/Services/Transcoding/TranscoderTest.php
+++ b/tests/Unit/Services/Transcoding/TranscoderTest.php
@@ -40,6 +40,8 @@ class TranscoderTest extends TestCase
                     'aac',
                     '-b:a',
                     '128k',
+                    '-aac_coder',
+                    'fast',
                     '-threads',
                     '0',
                     '-movflags',
@@ -54,12 +56,12 @@ class TranscoderTest extends TestCase
     }
 
     #[Test]
-    public function transcodeWithFastAacCoder(): void
+    public function transcodeWithoutFastAacCoder(): void
     {
         Process::fake();
         File::expects('ensureDirectoryExists')->with('/path/to');
 
-        $transcoder = new Transcoder(transcodeTimeout: 300, ffmpegPath: '/usr/bin/ffmpeg', aacFast: true);
+        $transcoder = new Transcoder(transcodeTimeout: 300, ffmpegPath: '/usr/bin/ffmpeg', aacFast: false);
         $transcoder->transcode('/path/to/song.aiff', '/path/to/output.m4a', 320);
 
         Process::assertRanTimes(static function (PendingProcess $process): bool {
@@ -74,8 +76,6 @@ class TranscoderTest extends TestCase
                     'aac',
                     '-b:a',
                     '320k',
-                    '-aac_coder',
-                    'fast',
                     '-threads',
                     '0',
                     '-movflags',


### PR DESCRIPTION
## Description
Adds a new environment variable to use the "fast" setting with ffmpeg for AAC transcodes. The dramatically speeds up transcode times. It is left as an optional enablement (via env var) and will be a no-op to existing instances. 

`TRANSCODE_AAC_FAST={true,false}`

This also updates a few old stale comments and docs for accuracy (To transcode FLAC to MP3 -> FLAC to AAC).

## Motivation
I store most of my media as aiff on my server so it can have the broadest compatibility with DJ gear (Rekordbox). I was noticing ffmpeg transcodes were taking awhile, and applied the `fast` settings for a big performance uplift (and no discernible audio quality difference to my ear). I left it as an opt-in env flag to not change anyone's current experience though. I plan on looking into adding in support for pre-transcoding queued media next.

Benchmarks: 
| AAC coder | Run 1 | Run 2 | Run 3 | Average | Relative speed | Output size |
|---|---:|---:|---:|---:|---:|---:|
| Default | 16.615s | 16.549s | 16.651s | 16.605s | 1.00× | 15.79 MB |
| Fast | 6.908s | 6.890s | 6.906s | 6.901s | 2.41× | 15.45 MB |

Tested on a 6:24 stereo AIFF at 320 kbps using Koel's production FFmpeg arguments. The fast AAC coder reduced transcoding time by 58.4%, saving approximately 9.7 seconds per cold transcode.

AI Disclaimer: I used LLMs to assist with authoring these changes. All changes were manually reviewed and manually tested. 

## Screenshots (if applicable)
N/A - backend only changes.

## Checklist
- [x] I've tested my changes thoroughly and added tests where applicable
- [x] I've updated relevant documentation (if any)
- [x] My code follows the project's conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable option to control FFmpeg’s fast AAC encoder during transcoding (default: enabled via `TRANSCODE_AAC_FAST`).
  * Streaming/transcoding now targets FLAC → AAC, aligning with updated transcoding guidance.

* **Documentation**
  * Updated the environment variable docs and `.env` example to describe `TRANSCODE_AAC_FAST` and the FLAC → AAC behavior.

* **Tests**
  * Expanded unit coverage to verify the generated FFmpeg command includes `-aac_coder fast` when enabled, and omits it when disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->