### PR TITLE
fix: don't upscale images smaller than the max width

### DIFF
--- a/app/Services/Image/ImageWriter.php
+++ b/app/Services/Image/ImageWriter.php
@@ -51,7 +51,7 @@ class ImageWriter
             }
         }
 
-        $img = Image::read($source)->scale(width: $config->maxWidth);
+        $img = Image::read($source)->scaleDown(width: $config->maxWidth);
 
         if ($config->blur) {
             $img->blur($config->blur);

--- a/tests/Unit/Services/Image/ImageWriterTest.php
+++ b/tests/Unit/Services/Image/ImageWriterTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Unit\Services\Image;
+
+use App\Services\Image\ImageWriter;
+use App\Values\ImageWritingConfig;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use Intervention\Image\Laravel\Facades\Image;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+use function Tests\test_path;
+
+class ImageWriterTest extends TestCase
+{
+    #[Test]
+    public function doesNotUpscaleImagesNarrowerThanTheMaxWidth(): void
+    {
+        $source = test_path('fixtures/cover.png');
+        $sourceWidth = Image::read($source)->width();
+
+        $destination = sys_get_temp_dir() . '/' . Str::uuid() . '.img';
+
+        (new ImageWriter())->write($destination, $source, ImageWritingConfig::make(maxWidth: $sourceWidth * 2));
+
+        self::assertSame($sourceWidth, Image::read($destination)->width());
+
+        File::delete($destination);
+    }
+}


### PR DESCRIPTION
**Description**

`ImageWriter::write()` resized every image with `scale(width: $config->maxWidth)`. In Intervention Image v3, `scale()` fits the image to the given width in both directions, so it enlarges a source narrower than the target. But `maxWidth` is a cap (`ImageWritingConfig`, default 640), not a target — so any image smaller than the cap was being upscaled. Switched to `scaleDown()`, which only ever shrinks; a source already at or below the cap is left at its native size.

**Motivation**

Album covers embedded in audio files are frequently smaller than 640px (300–512px is common). With `scale()`, a 512×512 embedded cover was blown up to 640×640 — a softer, interpolated image in a bigger file, for no visual gain. Thumbnails (maxWidth 48) and other downscales are unaffected because their sources are always larger than the cap, which is why this went unnoticed.

**Checklist**
- [x] I've tested my changes thoroughly and added tests where applicable
- [ ] I've updated relevant documentation (if any) — n/a
- [x] My code follows the project's conventions
