### PR TITLE
fix: report Subsonic playlist owner as username

### DIFF
--- a/app/Http/Responses/Subsonic/Resources/PlaylistResource.php
+++ b/app/Http/Responses/Subsonic/Resources/PlaylistResource.php
@@ -39,7 +39,7 @@ final class PlaylistResource
             'id' => $playlist->id,
             'name' => $playlist->name,
             'comment' => (string) $playlist->description,
-            'owner' => $playlist->owner->name,
+            'owner' => $playlist->owner->email,
             'public' => false,
             'songCount' => $playlist->playables_count ?? 0,
             'duration' => (int) round($playlist->playables_sum_length ?? 0),

--- a/tests/Feature/Subsonic/GetPlaylistTest.php
+++ b/tests/Feature/Subsonic/GetPlaylistTest.php
@@ -34,6 +34,19 @@ class GetPlaylistTest extends TestCase
     }
 
     #[Test]
+    public function ownerIsReportedAsSubsonicUsername(): void
+    {
+        $user = create_user(['name' => 'Jane Doe', 'email' => 'jane@example.com']);
+        $playlist = self::playlistOwnedBy($user);
+
+        $this
+            ->getJson("/rest/getPlaylist.view?apiKey={$user->subsonic_api_key}&f=json&id={$playlist->id}")
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.status', 'ok')
+            ->assertJsonPath('subsonic-response.playlist.owner', $user->email);
+    }
+
+    #[Test]
     public function unknownIdReturnsCode70(): void
     {
         $user = create_user();


### PR DESCRIPTION
The Subsonic `getPlaylist`/`getPlaylists` responses reported the playlist `owner` as the user's display name, but Koel uses the email as the Subsonic username everywhere else — the token/password authenticators resolve the `u` parameter via `findOneByEmail`, and `getUser`/`getPlayQueue` both emit `username => $user->email`. The Subsonic spec defines a playlist's `owner` as the username, so a client couldn't match the reported owner back to a user.

This changes `PlaylistResource` to report the owner's email, consistent with the rest of the Subsonic surface.

Added a `GetPlaylistTest` case asserting the `owner` field equals the owner's email.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Playlist responses now report the owner’s email address in the owner field, providing consistent Subsonic username information.

* **Tests**
  * Added coverage to verify that playlist ownership is returned using the owner’s email address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->