### PR TITLE
fix: return the whole library for a blank Subsonic search query

### DIFF
--- a/app/Http/Controllers/Subsonic/Search2Controller.php
+++ b/app/Http/Controllers/Subsonic/Search2Controller.php
@@ -7,17 +7,13 @@ use App\Http\Requests\Subsonic\Search2Request;
 use App\Http\Responses\Subsonic\Resources\SearchResult2Resource;
 use App\Http\Responses\Subsonic\SubsonicResponse;
 use App\Models\User;
-use App\Repositories\AlbumRepository;
-use App\Repositories\ArtistRepository;
-use App\Repositories\SongRepository;
+use App\Services\Subsonic\SubsonicSearchService;
 use Illuminate\Contracts\Auth\Authenticatable;
 
 class Search2Controller extends Controller
 {
     public function __construct(
-        private readonly ArtistRepository $artistRepository,
-        private readonly AlbumRepository $albumRepository,
-        private readonly SongRepository $songRepository,
+        private readonly SubsonicSearchService $searchService,
     ) {}
 
     /** @param User $user */
@@ -25,13 +21,23 @@ class Search2Controller extends Controller
     {
         $query = (string) $request->input('query');
 
-        if ($query === '') {
-            return SubsonicResponse::ok(['searchResult2' => SearchResult2Resource::empty()]);
-        }
+        $artists = $this->searchService
+            ->searchArtists($query, $request->integer('artistCount', 20), $request->integer('artistOffset'), $user)
+            ->loadCount('albums');
 
-        $artists = $this->artistRepository->search($query, $request->integer('artistCount', 20))->loadCount('albums');
-        $albums = $this->albumRepository->search($query, $request->integer('albumCount', 20));
-        $songs = $this->songRepository->search($query, $request->integer('songCount', 20));
+        $albums = $this->searchService->searchAlbums(
+            $query,
+            $request->integer('albumCount', 20),
+            $request->integer('albumOffset'),
+            $user,
+        );
+
+        $songs = $this->searchService->searchSongs(
+            $query,
+            $request->integer('songCount', 20),
+            $request->integer('songOffset'),
+            $user,
+        );
 
         return SubsonicResponse::ok([
             'searchResult2' => SearchResult2Resource::toArray($artists, $albums, $songs, $user),

--- a/app/Http/Controllers/Subsonic/Search3Controller.php
+++ b/app/Http/Controllers/Subsonic/Search3Controller.php
@@ -7,17 +7,13 @@ use App\Http\Requests\Subsonic\Search3Request;
 use App\Http\Responses\Subsonic\Resources\SearchResultResource;
 use App\Http\Responses\Subsonic\SubsonicResponse;
 use App\Models\User;
-use App\Repositories\AlbumRepository;
-use App\Repositories\ArtistRepository;
-use App\Repositories\SongRepository;
+use App\Services\Subsonic\SubsonicSearchService;
 use Illuminate\Contracts\Auth\Authenticatable;
 
 class Search3Controller extends Controller
 {
     public function __construct(
-        private readonly ArtistRepository $artistRepository,
-        private readonly AlbumRepository $albumRepository,
-        private readonly SongRepository $songRepository,
+        private readonly SubsonicSearchService $searchService,
     ) {}
 
     /** @param User $user */
@@ -25,18 +21,21 @@ class Search3Controller extends Controller
     {
         $query = (string) $request->input('query');
 
-        if ($query === '') {
-            return SubsonicResponse::ok(['searchResult3' => SearchResultResource::empty()]);
-        }
+        $artists = $this->searchService
+            ->searchArtists($query, $request->integer('artistCount', 20), $request->integer('artistOffset'), $user)
+            ->loadCount('albums');
 
-        $artists = $this->artistRepository->search($query, $request->integer('artistCount', 20))->loadCount('albums');
-
-        $albums = $this->albumRepository
-            ->search($query, $request->integer('albumCount', 20))
+        $albums = $this->searchService
+            ->searchAlbums($query, $request->integer('albumCount', 20), $request->integer('albumOffset'), $user)
             ->loadCount('songs')
             ->loadSum('songs', 'length');
 
-        $songs = $this->songRepository->search($query, $request->integer('songCount', 20));
+        $songs = $this->searchService->searchSongs(
+            $query,
+            $request->integer('songCount', 20),
+            $request->integer('songOffset'),
+            $user,
+        );
 
         return SubsonicResponse::ok([
             'searchResult3' => SearchResultResource::toArray($artists, $albums, $songs, $user),

--- a/app/Http/Requests/Subsonic/Search3Request.php
+++ b/app/Http/Requests/Subsonic/Search3Request.php
@@ -12,8 +12,11 @@ class Search3Request extends Request
         return [
             'query' => ['nullable', 'string'],
             'artistCount' => ['integer', 'min:0', 'max:500'],
+            'artistOffset' => ['integer', 'min:0'],
             'albumCount' => ['integer', 'min:0', 'max:500'],
+            'albumOffset' => ['integer', 'min:0'],
             'songCount' => ['integer', 'min:0', 'max:500'],
+            'songOffset' => ['integer', 'min:0'],
         ];
     }
 }

--- a/app/Http/Responses/Subsonic/Resources/SearchResult2Resource.php
+++ b/app/Http/Responses/Subsonic/Resources/SearchResult2Resource.php
@@ -41,12 +41,4 @@ final class SearchResult2Resource
             'song' => $songs->map(static fn (Song $song) => SongResource::toArray($song, $user))->all(),
         ];
     }
-
-    /**
-     * @return array{artist: array<empty>, album: array<empty>, song: array<empty>}
-     */
-    public static function empty(): array
-    {
-        return ['artist' => [], 'album' => [], 'song' => []];
-    }
 }

--- a/app/Http/Responses/Subsonic/Resources/SearchResultResource.php
+++ b/app/Http/Responses/Subsonic/Resources/SearchResultResource.php
@@ -39,12 +39,4 @@ final class SearchResultResource
             'song' => $songs->map(static fn (Song $song) => SongResource::toArray($song, $user))->all(),
         ];
     }
-
-    /**
-     * @return array{artist: array<empty>, album: array<empty>, song: array<empty>}
-     */
-    public static function empty(): array
-    {
-        return ['artist' => [], 'album' => [], 'song' => []];
-    }
 }

--- a/app/Repositories/AlbumRepository.php
+++ b/app/Repositories/AlbumRepository.php
@@ -199,6 +199,7 @@ class AlbumRepository extends Repository implements ScoutableRepository
             ->onlyStandard()
             ->withUserContext(user: $user ?? $this->auth->user())
             ->sort($sortColumn, $sortDirection)
+            ->orderBy('albums.id')
             ->offset($offset)
             ->limit($limit)
             ->get();

--- a/app/Repositories/ArtistRepository.php
+++ b/app/Repositories/ArtistRepository.php
@@ -121,6 +121,25 @@ class ArtistRepository extends Repository implements ScoutableRepository
         );
     }
 
+    /** @return Collection<int, Artist> */
+    public function getOrdered(
+        string $sortColumn,
+        string $sortDirection,
+        int $limit,
+        int $offset = 0,
+        ?User $user = null,
+    ): Collection {
+        return Artist::query()
+            ->onlyStandard()
+            ->onlyAlbumArtists()
+            ->withUserContext(user: $user ?? $this->auth->user())
+            ->sort($sortColumn, $sortDirection)
+            ->orderBy('artists.id')
+            ->offset($offset)
+            ->limit($limit)
+            ->get();
+    }
+
     public function search(string $keywords, int $limit, ?User $user = null): Collection
     {
         return $this->getMany(

--- a/app/Repositories/SongRepository.php
+++ b/app/Repositories/SongRepository.php
@@ -174,6 +174,23 @@ class SongRepository extends Repository implements ScoutableRepository
     }
 
     /** @return Collection<int, Song> */
+    public function getOrdered(
+        array $sortColumns,
+        string $sortDirection,
+        int $limit,
+        int $offset = 0,
+        ?User $scopedUser = null,
+    ): Collection {
+        return Song::query(type: PlayableType::SONG, user: $scopedUser ?? $this->auth->user())
+            ->withUserContext()
+            ->sort($sortColumns, $sortDirection)
+            ->orderBy('songs.id')
+            ->offset($offset)
+            ->limit($limit)
+            ->get();
+    }
+
+    /** @return Collection<int, Song> */
     public function getFavorites(?User $scopedUser = null, ?PlayableType $type = null): Collection
     {
         return Song::query(type: $type, user: $scopedUser ?? $this->auth->user())

--- a/app/Services/Subsonic/SubsonicSearchService.php
+++ b/app/Services/Subsonic/SubsonicSearchService.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Services\Subsonic;
+
+use App\Models\Album;
+use App\Models\Artist;
+use App\Models\Song;
+use App\Models\User;
+use App\Repositories\AlbumRepository;
+use App\Repositories\ArtistRepository;
+use App\Repositories\SongRepository;
+use Illuminate\Database\Eloquent\Collection;
+
+/**
+ * Backs the Subsonic `search2`/`search3` endpoints. A blank query ("", '', or
+ * absent) enumerates the whole library — the de facto Subsonic behavior clients
+ * like Symfonium rely on to sync — while any other query runs a normal search.
+ */
+class SubsonicSearchService
+{
+    public function __construct(
+        private readonly ArtistRepository $artistRepository,
+        private readonly AlbumRepository $albumRepository,
+        private readonly SongRepository $songRepository,
+    ) {}
+
+    /** @return Collection<int, Artist> */
+    public function searchArtists(string $query, int $count, int $offset, User $user): Collection
+    {
+        return self::isBrowseAll($query)
+            ? $this->artistRepository->getOrdered('artists.name', 'asc', $count, $offset, $user)
+            : $this->artistRepository->search($query, $count, $user);
+    }
+
+    /** @return Collection<int, Album> */
+    public function searchAlbums(string $query, int $count, int $offset, User $user): Collection
+    {
+        return self::isBrowseAll($query)
+            ? $this->albumRepository->getOrdered('albums.name', 'asc', $count, $offset, $user)
+            : $this->albumRepository->search($query, $count, $user);
+    }
+
+    /** @return Collection<int, Song> */
+    public function searchSongs(string $query, int $count, int $offset, User $user): Collection
+    {
+        return (
+            self::isBrowseAll($query)
+                ? $this->songRepository->getOrdered(['songs.title'], 'asc', $count, $offset, $user)
+                : $this->songRepository->search($query, $count, $user)
+        );
+    }
+
+    private static function isBrowseAll(string $query): bool
+    {
+        $query = trim($query);
+
+        return $query === '' || $query === '""' || $query === "''";
+    }
+}

--- a/tests/Feature/Subsonic/Search2Test.php
+++ b/tests/Feature/Subsonic/Search2Test.php
@@ -7,6 +7,7 @@ use App\Models\Artist;
 use App\Models\Song;
 use Illuminate\Support\Arr;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestWith;
 use Tests\TestCase;
 
 use function Tests\create_user;
@@ -69,26 +70,35 @@ class Search2Test extends TestCase
     }
 
     #[Test]
-    public function emptyQueryReturnsEmptyResult(): void
+    #[TestWith(['query='])] // empty query
+    #[TestWith(['query=%22%22'])] // "" — what Symfonium/DSub send to enumerate the library
+    #[TestWith(['query=%27%27'])] // ''
+    #[TestWith(['query=%20%20'])] // whitespace only
+    #[TestWith([''])] // no query param at all
+    public function blankQueryBrowsesEntireLibrary(string $queryString): void
     {
         $user = create_user();
 
-        $response = $this->getJson(
-            '/rest/search2.view?'
-                . Arr::query([
-                    'apiKey' => $user->subsonic_api_key,
-                    'f' => 'json',
-                    'query' => '',
-                ]),
-        )->assertOk();
+        $artist = Artist::factory()->createOne(['name' => 'Radiohead', 'user_id' => $user->id]);
+        $album = Album::factory()->createOne([
+            'name' => 'In Rainbows',
+            'artist_id' => $artist->id,
+            'artist_name' => $artist->name,
+            'user_id' => $user->id,
+        ]);
+        Song::factory()->createOne([
+            'title' => 'Weird Fishes',
+            'album_id' => $album->id,
+            'owner_id' => $user->id,
+        ]);
 
-        self::assertSame(
-            [
-                'artist' => [],
-                'album' => [],
-                'song' => [],
-            ],
-            $response->json('subsonic-response.searchResult2'),
-        );
+        $result = $this
+            ->getJson("/rest/search2.view?apiKey={$user->subsonic_api_key}&f=json&$queryString")
+            ->assertOk()
+            ->json('subsonic-response.searchResult2');
+
+        self::assertContains('Radiohead', array_column($result['artist'] ?? [], 'name'));
+        self::assertContains('In Rainbows', array_column($result['album'] ?? [], 'title'));
+        self::assertContains('Weird Fishes', array_column($result['song'] ?? [], 'title'));
     }
 }

--- a/tests/Feature/Subsonic/Search3Test.php
+++ b/tests/Feature/Subsonic/Search3Test.php
@@ -6,6 +6,7 @@ use App\Models\Album;
 use App\Models\Artist;
 use App\Models\Song;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestWith;
 use Tests\TestCase;
 
 use function Tests\create_user;
@@ -55,39 +56,80 @@ class Search3Test extends TestCase
     }
 
     #[Test]
-    public function missingQueryReturnsEmptyResult(): void
+    #[TestWith(['query='])] // empty query
+    #[TestWith(['query=%22%22'])] // "" — what Symfonium/DSub send to enumerate the library
+    #[TestWith(['query=%27%27'])] // ''
+    #[TestWith(['query=%20%20'])] // whitespace only
+    #[TestWith([''])] // no query param at all
+    public function blankQueryBrowsesEntireLibrary(string $queryString): void
     {
         $user = create_user();
 
-        $this
-            ->getJson("/rest/search3.view?apiKey={$user->subsonic_api_key}&f=json")
+        $artist = Artist::factory()->createOne(['name' => 'Radiohead', 'user_id' => $user->id]);
+        $album = Album::factory()->createOne([
+            'name' => 'In Rainbows',
+            'artist_id' => $artist->id,
+            'artist_name' => $artist->name,
+            'user_id' => $user->id,
+        ]);
+        Song::factory()->createOne([
+            'title' => 'Weird Fishes',
+            'album_id' => $album->id,
+            'owner_id' => $user->id,
+        ]);
+
+        $result = $this
+            ->getJson("/rest/search3.view?apiKey={$user->subsonic_api_key}&f=json&$queryString")
             ->assertOk()
             ->assertJsonPath('subsonic-response.status', 'ok')
-            ->assertExactJson([
-                'subsonic-response' => [
-                    'status' => 'ok',
-                    'version' => '1.16.1',
-                    'type' => 'koel',
-                    'serverVersion' => koel_version(),
-                    'openSubsonic' => true,
-                    'searchResult3' => ['artist' => [], 'album' => [], 'song' => []],
-                ],
-            ]);
+            ->json('subsonic-response.searchResult3');
+
+        self::assertContains('Radiohead', array_column($result['artist'] ?? [], 'name'));
+        self::assertContains('In Rainbows', array_column($result['album'] ?? [], 'name'));
+        self::assertContains('Weird Fishes', array_column($result['song'] ?? [], 'title'));
     }
 
     #[Test]
-    public function emptyQueryReturnsEmptyResult(): void
+    public function browsingHonorsOffsetAndCount(): void
+    {
+        $user = create_user();
+
+        foreach (['A', 'B', 'C'] as $letter) {
+            $artist = Artist::factory()->createOne(['name' => "Artist $letter", 'user_id' => $user->id]);
+            $album = Album::factory()->createOne([
+                'name' => "Album $letter",
+                'artist_id' => $artist->id,
+                'artist_name' => $artist->name,
+                'user_id' => $user->id,
+            ]);
+            Song::factory()->createOne(['title' => "Song $letter", 'album_id' => $album->id, 'owner_id' => $user->id]);
+        }
+
+        $result = $this
+            ->getJson(
+                "/rest/search3.view?apiKey={$user->subsonic_api_key}&f=json&query="
+                . '&artistCount=1&artistOffset=1&albumCount=1&albumOffset=1&songCount=1&songOffset=1',
+            )
+            ->assertOk()
+            ->json('subsonic-response.searchResult3');
+
+        self::assertSame(['Artist B'], array_column($result['artist'], 'name'));
+        self::assertSame(['Album B'], array_column($result['album'], 'name'));
+        self::assertSame(['Song B'], array_column($result['song'], 'title'));
+    }
+
+    #[Test]
+    #[TestWith(['artistOffset'])]
+    #[TestWith(['albumOffset'])]
+    #[TestWith(['songOffset'])]
+    public function rejectsNegativeOffset(string $offsetParam): void
     {
         $user = create_user();
 
         $this
-            ->getJson("/rest/search3.view?apiKey={$user->subsonic_api_key}&f=json&query=")
-            ->assertOk()
-            ->assertJsonPath('subsonic-response.searchResult3', [
-                'artist' => [],
-                'album' => [],
-                'song' => [],
-            ]);
+            ->getJson("/rest/search3.view?apiKey={$user->subsonic_api_key}&f=json&query=&$offsetParam=-1")
+            ->assertJsonPath('subsonic-response.status', 'failed')
+            ->assertJsonPath('subsonic-response.error.code', 10);
     }
 
     #[Test]


### PR DESCRIPTION
Closes #2619.

## Problem
Subsonic clients such as **Symfonium** (also DSub, Ultrasonic) enumerate a library by calling `search3` / `search2` with an **empty query** and paginating through the `*Offset`/`*Count` params. The empty query arrives as `query=""` (URL-encoded `%22%22`), `query=`, or no `query` at all.

Koel short-circuited a blank query to an empty result:

```php
if ($query === '') {
    return SubsonicResponse::ok(['searchResult3' => SearchResultResource::empty()]);
}
```

So the sync reported success (everything `200 OK`) but returned nothing — no artists, albums, or songs ever appeared. (`query=""` didn't even hit the short-circuit; it ran a literal search for the 2-char string `""` and matched nothing.)

## Fix
Treat a blank query (`""`, `''`, whitespace, or absent) as **"browse the whole library"**, matching the de facto Subsonic behavior other servers (Navidrome, gonic, LMS) implement and these clients rely on:

- New `SubsonicSearchService` owns the Subsonic-specific rule: a blank query browses the whole library, any other query runs a normal search. The `search3`/`search2` controllers delegate to it.
- Browsing reuses the repositories' general ordered-slice methods — `AlbumRepository::getOrdered()` (already backing `getAlbumList2`), plus matching `ArtistRepository::getOrdered()` / `SongRepository::getOrdered()` — so no query logic lives in the service.
- Offsets are validated in `Search3Request` (which `Search2Request` extends), honoring `artistOffset`/`albumOffset`/`songOffset` and `*Count`.
- Non-empty queries keep the existing Scout search path.

Removed the now-unused `SearchResult{,2}Resource::empty()`.

## Tests
`Search3Test` / `Search2Test`: blank query (empty, `%22%22`, and missing) browses the library for artists, albums, and songs; offset+count paginate correctly across all three collections; negative offsets are rejected. Full `tests/Feature/Subsonic` suite green (182), PHPStan and mago clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Blank Subsonic queries (including `query=` , quoted `""`, and missing `query`) now browse the full library instead of returning empty artist/album/song payloads.
  - Search2 and Search3 now support pagination for artists/albums/songs using non-negative offsets alongside counts.
- **Bug Fixes**
  - Empty, missing, and quoted query behavior is now consistent across Search2/Search3, with results deterministically ordered and scoped to the authenticated user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->