### PR TITLE
fix: refresh the avatar preview after updating the profile

### DIFF
--- a/resources/assets/js/components/profile-preferences/ProfileForm.spec.ts
+++ b/resources/assets/js/components/profile-preferences/ProfileForm.spec.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vite-plus/test'
-import { screen } from '@testing-library/vue'
+import { screen, waitFor } from '@testing-library/vue'
 import { createHarness } from '@/__tests__/TestHarness'
 import { MessageToasterStub } from '@/__tests__/stubs'
 import { authService } from '@/services/authService'
+import { userStore } from '@/stores/userStore'
 import Component from './ProfileForm.vue'
 
 describe('profileForm.vue', () => {
@@ -33,5 +34,22 @@ describe('profileForm.vue', () => {
     })
 
     expect(alertMock).toHaveBeenCalledWith('Profile updated.')
+  })
+
+  it('refreshes the avatar after updating the email address', async () => {
+    h.mock(authService, 'updateProfile', async () => {
+      userStore.state.current.avatar = 'https://gravatar.com/new-email'
+    })
+
+    renderComponent(
+      h.factory('user').make({
+        avatar: 'https://gravatar.com/old-email',
+      }) as CurrentUser,
+    )
+
+    await h.type(screen.getByTestId('email'), 'new@example.com')
+    await h.user.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => expect(screen.getByRole('img').getAttribute('src')).toBe('https://gravatar.com/new-email'))
   })
 })

--- a/resources/assets/js/components/profile-preferences/ProfileForm.vue
+++ b/resources/assets/js/components/profile-preferences/ProfileForm.vue
@@ -74,7 +74,10 @@ const { data, handleSubmit } = useForm<UpdateCurrentProfileData>({
 
     await authService.updateProfile(data)
   },
-  onSuccess: () => toastSuccess('Profile updated.'),
+  onSuccess: () => {
+    data.avatar = currentUser.value.avatar
+    toastSuccess('Profile updated.')
+  },
 })
 
 const onAvatarChanged = (avatar: string) => {


### PR DESCRIPTION
Changing the email address on the Profile & Preferences screen left the avatar preview showing the gravatar of the *old* address.

The avatar is derived server-side from the email, and the updated URL does come back in the `PUT /api/me` response — the top-bar avatar picked it up correctly. The profile screen, however, binds `EditableProfileAvatar` to the form data, which `useForm` snapshots once at mount, so the preview stayed frozen on the mount-time value.

Re-reading the avatar from the current user after a successful save fixes the preview, and also stops the widget from wrongly offering "Reset avatar" (which compares the form value against the store) right after saving.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Profile updates now refresh the displayed avatar after a successful email change.
  * Ensures the avatar shown in profile preferences stays synchronized with the latest account information.

* **Tests**
  * Added coverage for asynchronous avatar updates after saving profile changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->