### PR TITLE
fix: keep the current avatar when it isn't part of a profile update

### DIFF
--- a/app/Http/Requests/API/ProfileUpdateRequest.php
+++ b/app/Http/Requests/API/ProfileUpdateRequest.php
@@ -18,7 +18,7 @@ class ProfileUpdateRequest extends Request
         return [
             'name' => 'required',
             'email' => 'required|email|unique:users,email,' . auth()->user()->getAuthIdentifier(),
-            'avatar' => ['sometimes', 'nullable', 'string', 'starts_with:data:'],
+            'avatar' => ['sometimes', 'nullable', 'string', 'starts_with:data:image/'],
         ];
     }
 

--- a/app/Http/Requests/API/ProfileUpdateRequest.php
+++ b/app/Http/Requests/API/ProfileUpdateRequest.php
@@ -2,8 +2,8 @@
 
 namespace App\Http\Requests\API;
 
+use App\Values\User\AvatarUpdateData;
 use App\Values\User\UserUpdateData;
-use Illuminate\Support\Str;
 
 /**
  * @property-read string $name
@@ -18,7 +18,7 @@ class ProfileUpdateRequest extends Request
         return [
             'name' => 'required',
             'email' => 'required|email|unique:users,email,' . auth()->user()->getAuthIdentifier(),
-            'avatar' => 'sometimes',
+            'avatar' => ['sometimes', 'nullable', 'string', 'starts_with:data:'],
         ];
     }
 
@@ -27,7 +27,7 @@ class ProfileUpdateRequest extends Request
         return UserUpdateData::make(
             name: $this->name,
             email: $this->email,
-            avatar: Str::startsWith($this->avatar, 'data:') ? $this->avatar : null,
+            avatar: $this->has('avatar') ? AvatarUpdateData::make($this->avatar) : null,
         );
     }
 }

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -73,8 +73,11 @@ class UserService
             'name' => $dto->name,
             'email' => $dto->email,
             'password' => $dto->password ?? $user->password,
-            'avatar' => $dto->avatar ? $this->maybeStoreAvatar($dto->avatar) : null,
         ];
+
+        if ($dto->avatar) {
+            $data['avatar'] = $dto->avatar->image ? $this->maybeStoreAvatar($dto->avatar->image) : null;
+        }
 
         if ($user->sso_provider) {
             // SSO users cannot change their password or email

--- a/app/Values/User/AvatarUpdateData.php
+++ b/app/Values/User/AvatarUpdateData.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Values\User;
+
+/**
+ * Wraps the new avatar of a user, distinguishing "the avatar is being changed to nothing"
+ * (i.e., removed, falling back to the Gravatar) from "the avatar isn't part of this update at all,"
+ * which is represented by the absence of this object altogether.
+ */
+final readonly class AvatarUpdateData
+{
+    private function __construct(
+        public ?string $image,
+    ) {}
+
+    public static function make(?string $image = null): self
+    {
+        return new self($image);
+    }
+}

--- a/app/Values/User/UserUpdateData.php
+++ b/app/Values/User/UserUpdateData.php
@@ -15,7 +15,7 @@ final readonly class UserUpdateData
         #[SensitiveParameter]
         ?string $plainTextPassword,
         public ?Role $role,
-        public ?string $avatar,
+        public ?AvatarUpdateData $avatar,
     ) {
         $this->password = $plainTextPassword === '' ? null : $plainTextPassword;
     }
@@ -26,7 +26,7 @@ final readonly class UserUpdateData
         #[SensitiveParameter]
         ?string $plainTextPassword = null,
         ?Role $role = null,
-        ?string $avatar = null,
+        ?AvatarUpdateData $avatar = null,
     ): self {
         return new self(
             name: $name,

--- a/resources/assets/js/components/profile-preferences/EditableProfileAvatar.spec.ts
+++ b/resources/assets/js/components/profile-preferences/EditableProfileAvatar.spec.ts
@@ -1,19 +1,46 @@
-import { describe, it } from 'vite-plus/test'
-import { screen } from '@testing-library/vue'
+import { describe, expect, it } from 'vite-plus/test'
+import { screen, waitFor } from '@testing-library/vue'
 import { createHarness } from '@/__tests__/TestHarness'
+import { userStore } from '@/stores/userStore'
 import Component from './EditableProfileAvatar.vue'
 
 describe('editableProfileAvatar.vue', () => {
   const h = createHarness()
 
-  it('renders avatar controls', () => {
-    h.render(Component, {
+  const renderComponent = (avatar?: string | null) => {
+    return h.render(Component, {
       props: {
-        profile: { name: 'John Doe', avatar: 'https://example.com/avatar.png' },
+        name: 'John Doe',
+        avatar,
       },
     })
+  }
 
+  it('previews the current avatar when unchanged', () => {
+    userStore.state.current.avatar = 'https://example.com/current.png'
+
+    renderComponent()
+
+    expect(screen.getByRole('img').getAttribute('src')).toBe('https://example.com/current.png')
     screen.getByTitle('Pick a new avatar')
-    screen.getByTitle('Reset avatar')
+    screen.getByTitle('Remove avatar')
+  })
+
+  it('previews the new avatar and allows resetting it', () => {
+    const { emitted } = renderComponent('data:image/png;base64,Ynl0ZXM=')
+
+    expect(screen.getByRole('img').getAttribute('src')).toBe('data:image/png;base64,Ynl0ZXM=')
+
+    screen.getByTitle('Reset avatar').click()
+
+    expect(emitted()['update:avatar']).toEqual([[undefined]])
+  })
+
+  it('removes the avatar', async () => {
+    const { emitted } = renderComponent()
+
+    await h.user.click(screen.getByTitle('Remove avatar'))
+
+    await waitFor(() => expect(emitted()['update:avatar']).toEqual([[null]]))
   })
 })

--- a/resources/assets/js/components/profile-preferences/EditableProfileAvatar.vue
+++ b/resources/assets/js/components/profile-preferences/EditableProfileAvatar.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="avatar-width ring-4 ring-white mt-8 rounded-full relative overflow-hidden aspect-square">
-    <UserAvatar v-if="profile.avatar" :user="profile as any" class="avatar-width" />
+    <UserAvatar v-if="previewedUser.avatar" :user="previewedUser" class="avatar-width" />
 
     <div
       class="absolute top-0 rounded-full w-full aspect-square flex items-center justify-center gap-2 pt-[50%] bg-black/50 opacity-0 hover:opacity-100 transition-opacity duration-300"
@@ -9,7 +9,7 @@
         <Icon :icon="faUpload" />
       </button>
 
-      <button v-if="avatarChanged" class="control" title="Reset avatar" type="button" @click.prevent="resetAvatar">
+      <button v-if="isChanged" class="control" title="Reset avatar" type="button" @click.prevent="resetAvatar">
         <Icon :icon="faRefresh" />
       </button>
 
@@ -33,10 +33,8 @@ import { gravatar } from '@/utils/helpers'
 import UserAvatar from '@/components/user/UserAvatar.vue'
 import ImageCropper from '@/components/utils/ImageCropper.vue'
 
-const props = defineProps<{ profile: { name: string; avatar?: string } }>()
-const emit = defineEmits<{ (e: 'changed', image: string): void }>()
-
-const { profile } = props
+const props = defineProps<{ name: string; avatar?: string | null }>()
+const emit = defineEmits<{ (e: 'update:avatar', avatar?: string | null): void }>()
 
 const { open, onChange } = useFileDialog({
   accept: 'image/*',
@@ -47,11 +45,17 @@ const { open, onChange } = useFileDialog({
 const openFileDialog = () => open()
 
 const cropperSource = ref<string | null>(null)
+const gravatarUrl = ref<string>()
+
+const isChanged = computed(() => props.avatar !== undefined)
+
+const previewedUser = computed(() => ({
+  name: props.name,
+  avatar: isChanged.value ? (props.avatar ?? gravatarUrl.value) : userStore.current.avatar,
+}))
 
 onChange(files => {
   if (!files?.length) {
-    emit('changed', userStore.current.avatar)
-    cropperSource.value = null
     return
   }
 
@@ -60,17 +64,18 @@ onChange(files => {
   })
 })
 
-const removeAvatar = async () => emit('changed', await gravatar(userStore.current.email))
+const removeAvatar = async () => {
+  gravatarUrl.value = await gravatar(userStore.current.email)
+  emit('update:avatar', null)
+}
 
 const resetAvatar = () => {
-  emit('changed', userStore.current.avatar)
+  emit('update:avatar', undefined)
   cropperSource.value = null
 }
 
-const avatarChanged = computed(() => profile.avatar !== userStore.current.avatar)
-
-const onCrop = (result: string) => {
-  emit('changed', result)
+const onCrop = (image: string) => {
+  emit('update:avatar', image)
   cropperSource.value = null
 }
 

--- a/resources/assets/js/components/profile-preferences/ProfileForm.spec.ts
+++ b/resources/assets/js/components/profile-preferences/ProfileForm.spec.ts
@@ -30,7 +30,7 @@ describe('profileForm.vue', () => {
     expect(updateMock).toHaveBeenCalledWith({
       name: 'Koel User',
       email: 'koel@example.com',
-      avatar: 'https://gravatar.com/foo',
+      avatar: undefined,
     })
 
     expect(alertMock).toHaveBeenCalledWith('Profile updated.')

--- a/resources/assets/js/components/profile-preferences/ProfileForm.vue
+++ b/resources/assets/js/components/profile-preferences/ProfileForm.vue
@@ -33,7 +33,7 @@
       </div>
 
       <div>
-        <EditableProfileAvatar :profile="data" @changed="onAvatarChanged" />
+        <EditableProfileAvatar v-model:avatar="data.avatar" :name="data.name" />
       </div>
     </div>
 
@@ -65,7 +65,8 @@ const isDemo = window.KOEL.is_demo
 
 const { data, handleSubmit } = useForm<UpdateCurrentProfileData>({
   initialValues: {
-    ...pick(currentUser.value, 'name', 'email', 'avatar'),
+    ...pick(currentUser.value, 'name', 'email'),
+    avatar: undefined,
   },
   onSubmit: async data => {
     if (isDemo) {
@@ -75,12 +76,8 @@ const { data, handleSubmit } = useForm<UpdateCurrentProfileData>({
     await authService.updateProfile(data)
   },
   onSuccess: () => {
-    data.avatar = currentUser.value.avatar
+    data.avatar = undefined
     toastSuccess('Profile updated.')
   },
 })
-
-const onAvatarChanged = (avatar: string) => {
-  data.avatar = avatar
-}
 </script>

--- a/resources/assets/js/services/authService.ts
+++ b/resources/assets/js/services/authService.ts
@@ -4,10 +4,14 @@ import { userStore } from '@/stores/userStore'
 import { useLocalStorage } from '@/composables/useLocalStorage'
 import { use } from '@/utils/helpers'
 
+/**
+ * An `avatar` of `undefined` leaves the current avatar untouched, whereas `null` removes it
+ * (falling back to the Gravatar). Any other value is the new avatar as base64-encoded image data.
+ */
 export interface UpdateCurrentProfileData {
   name: string
   email: string
-  avatar?: string
+  avatar?: string | null
 }
 
 const API_TOKEN_STORAGE_KEY = 'api-token'

--- a/tests/Feature/ProfileTest.php
+++ b/tests/Feature/ProfileTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -90,8 +91,18 @@ class ProfileTest extends TestCase
         self::assertNull($user->getRawOriginal('avatar'));
     }
 
+    /** @return array<string, array<string>> */
+    public static function avatarsThatAreNotImageDataProvider(): array
+    {
+        return [
+            'remote URL' => ['https://example.com/avatar.jpg'],
+            'non-image data URL' => ['data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg=='],
+        ];
+    }
+
     #[Test]
-    public function updateProfileRejectsAvatarThatIsNotImageData(): void
+    #[DataProvider('avatarsThatAreNotImageDataProvider')]
+    public function updateProfileRejectsAvatarThatIsNotImageData(string $avatar): void
     {
         $user = create_user(['avatar' => 'foo.jpg']);
 
@@ -100,7 +111,7 @@ class ProfileTest extends TestCase
             [
                 'name' => 'Foo',
                 'email' => $user->email,
-                'avatar' => 'https://example.com/avatar.jpg',
+                'avatar' => $avatar,
             ],
             $user,
         )->assertUnprocessable();

--- a/tests/Feature/ProfileTest.php
+++ b/tests/Feature/ProfileTest.php
@@ -52,6 +52,25 @@ class ProfileTest extends TestCase
     }
 
     #[Test]
+    public function updateProfileKeepingAvatar(): void
+    {
+        $user = create_user(['avatar' => 'foo.jpg']);
+
+        $this->putAs(
+            'api/me',
+            [
+                'name' => 'Foo',
+                'email' => 'bar@baz.com',
+            ],
+            $user,
+        )->assertOk();
+
+        $user->refresh();
+
+        self::assertSame('foo.jpg', $user->getRawOriginal('avatar'));
+    }
+
+    #[Test]
     public function updateProfileRemovingAvatar(): void
     {
         $user = create_user(['avatar' => 'foo.jpg']);
@@ -61,6 +80,7 @@ class ProfileTest extends TestCase
             [
                 'name' => 'Foo',
                 'email' => $user->email,
+                'avatar' => null,
             ],
             $user,
         )->assertOk();
@@ -68,6 +88,24 @@ class ProfileTest extends TestCase
         $user->refresh();
 
         self::assertNull($user->getRawOriginal('avatar'));
+    }
+
+    #[Test]
+    public function updateProfileRejectsAvatarThatIsNotImageData(): void
+    {
+        $user = create_user(['avatar' => 'foo.jpg']);
+
+        $this->putAs(
+            'api/me',
+            [
+                'name' => 'Foo',
+                'email' => $user->email,
+                'avatar' => 'https://example.com/avatar.jpg',
+            ],
+            $user,
+        )->assertUnprocessable();
+
+        self::assertSame('foo.jpg', $user->refresh()->getRawOriginal('avatar'));
     }
 
     #[Test]

--- a/tests/Feature/UserTest.php
+++ b/tests/Feature/UserTest.php
@@ -130,6 +130,26 @@ class UserTest extends TestCase
     }
 
     #[Test]
+    public function adminUpdatesUserKeepingAvatar(): void
+    {
+        $user = create_user(['avatar' => 'foo.jpg']);
+
+        $this->putAs(
+            "api/users/{$user->public_id}",
+            [
+                'name' => 'Foo',
+                'email' => 'bar@baz.com',
+                'role' => 'user',
+            ],
+            create_admin(),
+        )->assertSuccessful();
+
+        $user->refresh();
+
+        self::assertSame('foo.jpg', $user->getRawOriginal('avatar'));
+    }
+
+    #[Test]
     public function privilegeEscalationIsForbiddenWhenUpdating(): void
     {
         $manager = create_manager();

--- a/tests/Integration/Services/UserServiceTest.php
+++ b/tests/Integration/Services/UserServiceTest.php
@@ -5,6 +5,7 @@ namespace Tests\Integration\Services;
 use App\Enums\Acl\Role;
 use App\Exceptions\UserProspectUpdateDeniedException;
 use App\Services\UserService;
+use App\Values\User\AvatarUpdateData;
 use App\Values\User\UserCreateData;
 use App\Values\User\UserUpdateData;
 use Illuminate\Support\Facades\Hash;
@@ -82,7 +83,7 @@ class UserServiceTest extends TestCase
             email: 'steve@iron.com',
             plainTextPassword: 'TheTrooper',
             role: Role::ADMIN,
-            avatar: minimal_base64_encoded_image(),
+            avatar: AvatarUpdateData::make(minimal_base64_encoded_image()),
         ));
 
         $user->refresh();
@@ -92,6 +93,30 @@ class UserServiceTest extends TestCase
         self::assertTrue(Hash::check('TheTrooper', $user->password));
         self::assertSame(Role::ADMIN, $user->role);
         self::assertFileExists(image_storage_path($user->getRawOriginal('avatar')));
+    }
+
+    #[Test]
+    public function updateUserKeepingAvatar(): void
+    {
+        $user = create_user(['avatar' => 'foo.jpg']);
+
+        $this->service->updateUser($user, UserUpdateData::make(name: 'Steve Harris', email: 'steve@iron.com'));
+
+        self::assertSame('foo.jpg', $user->refresh()->getRawOriginal('avatar'));
+    }
+
+    #[Test]
+    public function updateUserRemovingAvatar(): void
+    {
+        $user = create_user(['avatar' => 'foo.jpg']);
+
+        $this->service->updateUser($user, UserUpdateData::make(
+            name: 'Steve Harris',
+            email: 'steve@iron.com',
+            avatar: AvatarUpdateData::make(),
+        ));
+
+        self::assertNull($user->refresh()->getRawOriginal('avatar'));
     }
 
     #[Test]


### PR DESCRIPTION
Saving a profile deleted the user's uploaded avatar, and an admin editing a user did the same to that user's avatar.

`UserService::updateUser()` wrote the avatar column on every update, and the value it wrote was almost always `null`: `ProfileUpdateRequest` mapped anything that wasn't image data to `null`, and `UserUpdateRequest` (the admin path) never set an avatar at all. So changing your own name, or an admin changing anyone's role, silently reverted the avatar to the Gravatar.

The avatar is now only touched when the request actually carries it:

- `avatar` absent — left untouched
- `avatar` present and `null` — removed, falling back to the Gravatar
- `avatar` present as image data — stored as the new avatar

`AvatarUpdateData` carries that distinction, since a plain `?string` can't tell "no avatar in this update" apart from "remove the avatar". The profile form correspondingly sends `avatar` only when the user picked or removed one, and the avatar widget now takes the pending value as a `v-model` instead of reaching into the user store to work out whether anything changed.

Profile updates also now reject an `avatar` that isn't image data, rather than storing an arbitrary URL as the user's avatar.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Profile avatar updates now support new images, resets, and explicit removal.
  * Omitting an avatar change preserves the current image.
  * Removed avatars fall back to Gravatar when available.
* **Bug Fixes**
  * Invalid or remote avatar data is rejected without replacing the existing image.
  * Empty file selections no longer overwrite the current avatar.
* **Tests**
  * Expanded coverage for avatar previews, resets, removal, preservation, and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->