### PR TITLE
fix: build the same Gravatar URL on the client and the server

### DIFF
--- a/app/Helpers.php
+++ b/app/Helpers.php
@@ -82,7 +82,7 @@ function gravatar(string $email, int $size = 192): string
     $url = config('services.gravatar.url');
     $default = config('services.gravatar.default');
 
-    return sprintf("%s/%s?s=$size&d=$default", $url, md5(Str::lower($email)));
+    return sprintf("%s/%s?s=$size&d=$default", $url, hash('sha256', Str::lower(trim($email))));
 }
 
 function avatar_or_gravatar(?string $avatar, string $email): string

--- a/app/Helpers.php
+++ b/app/Helpers.php
@@ -79,10 +79,12 @@ function rescue_unless($condition, callable $callback, $default = null): mixed
 
 function gravatar(string $email, int $size = 192): string
 {
-    $url = config('services.gravatar.url');
-    $default = config('services.gravatar.default');
+    $query = http_build_query([
+        's' => $size,
+        'd' => config('services.gravatar.default'),
+    ]);
 
-    return sprintf("%s/%s?s=$size&d=$default", $url, hash('sha256', Str::lower(trim($email))));
+    return sprintf('%s/%s?%s', config('services.gravatar.url'), hash('sha256', Str::lower(trim($email))), $query);
 }
 
 function avatar_or_gravatar(?string $avatar, string $email): string

--- a/resources/assets/js/__tests__/setup.ts
+++ b/resources/assets/js/__tests__/setup.ts
@@ -55,6 +55,7 @@ window.KOEL = {
   is_demo: false,
   pusher: { app_key: '', app_cluster: '' },
   branding: { name: 'Koel', logo: '', cover: '' },
+  gravatar: { url: 'https://www.gravatar.com/avatar', default: 'robohash' },
   mailer_configured: true,
   sso_providers: [],
   accepted_audio_extensions: [],

--- a/resources/assets/js/types.d.ts
+++ b/resources/assets/js/types.d.ts
@@ -68,6 +68,10 @@ interface KoelGlobals {
     readonly app_cluster: string
   }
   branding: Branding
+  gravatar: {
+    readonly url: string
+    readonly default: string
+  }
   mailer_configured: boolean
   sso_providers: SSOProvider[]
   sso_oidc_label?: string

--- a/resources/assets/js/utils/helpers.spec.ts
+++ b/resources/assets/js/utils/helpers.spec.ts
@@ -1,7 +1,32 @@
-import { describe, expect, it, vi } from 'vite-plus/test'
-import { arrayify, flattenParams, limitBy, use } from './helpers'
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test'
+import { arrayify, flattenParams, gravatar, limitBy, use } from './helpers'
 
 describe('helpers utils', () => {
+  describe('gravatar()', () => {
+    // Must match the URL built by the gravatar() PHP helper, which is what the server serves as an avatar.
+    const EMAIL_SHA256 = 'efbe2fad818a477cc2eef45f6be5fd0a1111aead627c3529562f17f0375d4523'
+
+    afterEach(() => (window.KOEL.gravatar = { url: 'https://www.gravatar.com/avatar', default: 'robohash' }))
+
+    it('identifies the email by its SHA-256 hash', async () => {
+      expect(await gravatar('koel@example.com')).toBe(
+        `https://www.gravatar.com/avatar/${EMAIL_SHA256}?s=192&d=robohash`,
+      )
+    })
+
+    it('normalizes the email before hashing', async () => {
+      expect(await gravatar('  KOEL@Example.com  ')).toBe(await gravatar('koel@example.com'))
+    })
+
+    it('honors the configured URL and default', async () => {
+      window.KOEL.gravatar = { url: 'https://gravatar.example.com/avatar', default: 'identicon' }
+
+      expect(await gravatar('koel@example.com', 64)).toBe(
+        `https://gravatar.example.com/avatar/${EMAIL_SHA256}?s=64&d=identicon`,
+      )
+    })
+  })
+
   it('use() triggers a closure with a defined value', () => {
     const mock = vi.fn()
     use('foo', mock)

--- a/resources/assets/js/utils/helpers.spec.ts
+++ b/resources/assets/js/utils/helpers.spec.ts
@@ -25,6 +25,14 @@ describe('helpers utils', () => {
         `https://gravatar.example.com/avatar/${EMAIL_SHA256}?s=64&d=identicon`,
       )
     })
+
+    it('encodes a default that is an image URL', async () => {
+      window.KOEL.gravatar = { url: 'https://www.gravatar.com/avatar', default: 'https://example.com/avatar.png' }
+
+      expect(await gravatar('koel@example.com')).toBe(
+        `https://www.gravatar.com/avatar/${EMAIL_SHA256}?s=192&d=https%3A%2F%2Fexample.com%2Favatar.png`,
+      )
+    })
   })
 
   it('use() triggers a closure with a defined value', () => {

--- a/resources/assets/js/utils/helpers.ts
+++ b/resources/assets/js/utils/helpers.ts
@@ -80,7 +80,9 @@ export const moveItemsInList = <T>(list: T[], items: T | T[], target: T, placeme
 
 export const gravatar = async (email: string, size = 192) => {
   const hash = await sha256(email.trim().toLowerCase())
-  return `https://www.gravatar.com/avatar/${hash}?s=${size}&d=robohash`
+  const { url, default: fallback } = window.KOEL.gravatar
+
+  return `${url}/${hash}?s=${size}&d=${fallback}`
 }
 
 export const openPopup = (url: string, name: string, width: number, height: number, parent: Window) => {

--- a/resources/assets/js/utils/helpers.ts
+++ b/resources/assets/js/utils/helpers.ts
@@ -81,8 +81,9 @@ export const moveItemsInList = <T>(list: T[], items: T | T[], target: T, placeme
 export const gravatar = async (email: string, size = 192) => {
   const hash = await sha256(email.trim().toLowerCase())
   const { url, default: fallback } = window.KOEL.gravatar
+  const query = new URLSearchParams({ s: String(size), d: fallback })
 
-  return `${url}/${hash}?s=${size}&d=${fallback}`
+  return `${url}/${hash}?${query}`
 }
 
 export const openPopup = (url: string, name: string, width: number, height: number, parent: Window) => {

--- a/resources/views/base.blade.php
+++ b/resources/views/base.blade.php
@@ -41,6 +41,10 @@
                 'app_cluster' => config('broadcasting.connections.pusher.options.cluster'),
             ],
             'branding' => koel_branding(),
+            'gravatar' => [
+                'url' => config('services.gravatar.url'),
+                'default' => config('services.gravatar.default'),
+            ],
         ];
     @endphp
     window.KOEL = @json($koelGlobals);

--- a/tests/Unit/Helpers/GravatarTest.php
+++ b/tests/Unit/Helpers/GravatarTest.php
@@ -37,4 +37,15 @@ class GravatarTest extends TestCase
             64,
         ));
     }
+
+    #[Test]
+    public function encodesADefaultThatIsAnImageUrl(): void
+    {
+        config(['services.gravatar.default' => 'https://example.com/avatar.png']);
+
+        self::assertSame(
+            'https://www.gravatar.com/avatar/' . self::EMAIL_SHA256 . '?s=192&d=https%3A%2F%2Fexample.com%2Favatar.png',
+            gravatar('koel@example.com'),
+        );
+    }
 }

--- a/tests/Unit/Helpers/GravatarTest.php
+++ b/tests/Unit/Helpers/GravatarTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Unit\Helpers;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class GravatarTest extends TestCase
+{
+    private const string EMAIL_SHA256 = 'efbe2fad818a477cc2eef45f6be5fd0a1111aead627c3529562f17f0375d4523';
+
+    #[Test]
+    public function identifiesTheEmailByItsSha256Hash(): void
+    {
+        self::assertSame(
+            'https://www.gravatar.com/avatar/' . self::EMAIL_SHA256 . '?s=192&d=robohash',
+            gravatar('koel@example.com'),
+        );
+    }
+
+    #[Test]
+    public function normalizesTheEmailBeforeHashing(): void
+    {
+        self::assertSame(gravatar('koel@example.com'), gravatar('  KOEL@Example.com  '));
+    }
+
+    #[Test]
+    public function honorsTheConfiguredUrlAndDefault(): void
+    {
+        config([
+            'services.gravatar.url' => 'https://gravatar.example.com/avatar',
+            'services.gravatar.default' => 'identicon',
+        ]);
+
+        self::assertSame('https://gravatar.example.com/avatar/' . self::EMAIL_SHA256 . '?s=64&d=identicon', gravatar(
+            'koel@example.com',
+            64,
+        ));
+    }
+}


### PR DESCRIPTION
The client and the server disagreed on how to build a Gravatar URL: `Helpers.php` hashed the email with MD5 and honored `GRAVATAR_URL` / `GRAVATAR_DEFAULT`, while `helpers.ts` hashed with SHA-256 and hardcoded `https://www.gravatar.com/avatar` with `d=robohash`.

The only client-side caller is the preview shown after removing your avatar, so the preview never quite matched the avatar the server went on to serve — and on an instance with a configured Gravatar host, it previewed an image from the wrong host entirely.

Both sides now identify the email by its SHA-256 hash (Gravatar's current recommendation; MD5 is legacy) and both read the configured URL and default, which the client gets via `window.KOEL.gravatar`. A test on each side pins the same email to the same URL.

Worth noting for the release: generated fallbacks are seeded from the hash, so users **without** a Gravatar account will get a different robohash face than before. Users with a real Gravatar account are unaffected — Gravatar resolves the MD5 and SHA-256 forms of an address to the same account.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Avatar URLs now use normalized email addresses with SHA-256 hashing.
  * Avatar service URLs and default avatar styles follow application configuration.
  * Avatar image parameters are encoded reliably for broader compatibility.

* **Tests**
  * Added coverage for email normalization, hashing, configurable avatar settings, and encoded image URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->