### PR TITLE
fix: show the avatar cropper full-screen

### DIFF
--- a/resources/assets/js/components/utils/ImageCropper.spec.ts
+++ b/resources/assets/js/components/utils/ImageCropper.spec.ts
@@ -15,6 +15,15 @@ describe('imageCropper.vue', () => {
     screen.getByText('Cancel')
   })
 
+  it('renders outside of its host, which would clip it', () => {
+    const { container } = h.render(Component, {
+      props: { source: 'data:image/png;base64,abc' },
+    })
+
+    expect(container.textContent).toBe('')
+    screen.getByText('Crop')
+  })
+
   it('emits cancel on cancel click', async () => {
     const { emitted } = h.render(Component, {
       props: { source: 'data:image/png;base64,abc' },

--- a/resources/assets/js/components/utils/ImageCropper.vue
+++ b/resources/assets/js/components/utils/ImageCropper.vue
@@ -1,19 +1,23 @@
 <template>
-  <div class="w-full h-full fixed top-0 left-0 flex items-center justify-center z-99 bg-black/70">
-    <div class="relative max-w-full max-h-full rounded-md flex">
-      <Cropper
-        ref="cropper"
-        :max-width="config.maxWidth"
-        :min-width="config.minWidth"
-        :src="source"
-        :stencil-props="{ aspectRatio: 1 }"
-      />
-      <div class="fixed top-6 right-6 flex flex-1 gap-2">
-        <Btn variant="success" @click.prevent="crop">Crop</Btn>
-        <Btn variant="ghost" @click.prevent="emits('cancel')">Cancel</Btn>
+  <!-- Teleported to the body: screens establish a containing block for fixed positioning, which would
+       otherwise size this overlay to the current screen and clip it to that screen's bounds. -->
+  <Teleport to="body">
+    <div class="w-full h-full fixed top-0 left-0 flex items-center justify-center z-99 bg-black/70">
+      <div class="relative max-w-full max-h-full rounded-md flex">
+        <Cropper
+          ref="cropper"
+          :max-width="config.maxWidth"
+          :min-width="config.minWidth"
+          :src="source"
+          :stencil-props="{ aspectRatio: 1 }"
+        />
+        <div class="fixed top-6 right-6 flex flex-1 gap-2">
+          <Btn variant="success" @click.prevent="crop">Crop</Btn>
+          <Btn variant="ghost" @click.prevent="emits('cancel')">Cancel</Btn>
+        </div>
       </div>
     </div>
-  </div>
+  </Teleport>
 </template>
 
 <script lang="ts" setup>


### PR DESCRIPTION
Picking a new avatar opened the cropper as a sliver inside the avatar circle instead of covering the screen.

The overlay is `fixed inset-0`, but `ScreenBase` carries `transform-gpu` (`transform: translateZ(0)`), and any transform other than `none` makes an element the containing block for its fixed-positioned descendants. So the overlay sized itself to the screen pane and was then clipped by the `overflow-hidden` on the avatar wrapper it was nested in.

The cropper is now teleported to the body, which is where an overlay belongs anyway — same approach as `Carousel`, and the equivalent of how the toaster and dialogs escape by living at the app root. Fixing it in CSS instead would mean swapping `transform-gpu` for `relative` on `ScreenBase`, which re-anchors every other fixed element inside a screen (the scroll-to-top button, the theme preview exit button, Floating UI popovers) and breaks again as soon as any ancestor gains a transform or filter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the image cropper overlay’s positioning by rendering it at the document level.
  * Preserved existing crop controls and configuration while improving accessibility and display behavior.

* **Tests**
  * Added coverage confirming the cropper remains accessible when displayed outside its original container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->