### PR TITLE
test: run the test suite in parallel

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,6 +14,7 @@
     </testsuites>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="APP_URL" value="http://localhost/"/>
         <env name="APP_KEY" value="16efa6c23c2e8c705826b0e66778fbe7"/>
         <env name="STORAGE_DRIVER" value="local"/>


### PR DESCRIPTION
Runs the test suite across all available cores. `composer test` now takes **~15s** instead of ~200s.

### Making the suite parallel-safe

`brianium/paratest` alone doesn't work here — a parallel run produced 524 errors and 21 failures. Every worker shared one sandbox: `TestCase::createSandbox()` pointed `koel.image_storage_dir` and `koel.artifacts_path` at `public/sandbox`, and `destroySandbox()` deleted that whole tree after *every* test. So workers raced each other creating directories (`mkdir(): File exists`) and deleted files other workers were still asserting on.

The sandbox is now scoped to the worker via `ParallelTesting::token()`, through a `sandbox_path()` helper that also replaces the hardcoded `public_path('sandbox/…')` references in the upload tests. Outside a parallel run the token is absent and the path stays `public/sandbox`, exactly as before.

`brianium/paratest` is pinned to the v7.8 line: v7.24 requires PHP 8.4, and this project pins `config.platform.php` to `8.3.0`.

### Lowering the bcrypt cost

`phpunit.xml.dist` never set `BCRYPT_ROUNDS`, so `config/hashing.php` fell back to its default of 10 — and `UserFactory` sets `'password' => 'secret'`, which the model casts to hashed. Nearly every test creates a user, so nearly every test paid for a production-grade hash. The framework does no automatic reduction here; it's the `laravel/laravel` skeleton's `phpunit.xml` that carries this line, and koel's `phpunit.xml.dist` didn't.

The two changes compound rather than overlap:

| | bcrypt cost 10 | bcrypt cost 4 |
|---|---|---|
| serial | ~200s | ~45s |
| parallel | 29.6s | **14.7s** |

All 1590 tests pass in both modes.

### CI stays serial

`composer test` is parallel, and CI calls a new `composer test:ci`, which isn't — the fast path is the default for humans, and CI's constraint is the thing that's named.

CI is where parallel would bite. Each worker gets its own database (`koel_test_1`, `koel_test_2`, …), which is free for SQLite `:memory:` but not against a real server: PostgreSQL connects as the `postgres` superuser and could create them, whereas MariaDB connects as `mariadb`, a user the official image grants privileges only on `koel` — so `CREATE DATABASE` would fail. Even with that fixed, runners are 4-core and every worker would re-run the full migration set against a live server, which can cost more than the parallelism saves.

The SQLite job runs `composer coverage` and is untouched; parallel coverage merging deserves its own look, since the codecov reports depend on it.
