### PR TITLE
test: run the test suite in parallel

### DIFF
--- a/.github/workflows/test-backend-mariadb.yml
+++ b/.github/workflows/test-backend-mariadb.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Generate app key
         run: php artisan key:generate --quiet
       - name: Run tests
-        run: composer test
+        run: composer test:ci
         env:
           COMPOSER_PROCESS_TIMEOUT: 600
       - name: Upload logs if broken

--- a/.github/workflows/test-backend-pgsql.yml
+++ b/.github/workflows/test-backend-pgsql.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Generate app key
         run: php artisan key:generate --quiet
       - name: Run tests
-        run: composer test
+        run: composer test:ci
         env:
           COMPOSER_PROCESS_TIMEOUT: 600
       - name: Upload logs if broken

--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,8 @@
     "phlak/semver": "^5.0",
     "laravel/boost": "^2.0",
     "opcodesio/log-viewer": "^3.19",
-    "carthage-software/mago": "^1.8.0"
+    "carthage-software/mago": "^1.8.0",
+    "brianium/paratest": "^7.0"
   },
   "suggest": {
     "ext-zip": "Allow downloading multiple songs as Zip archives"
@@ -120,7 +121,8 @@
       "@php artisan key:generate"
     ],
     "koel:init": "@php scripts/koel-init.php",
-    "test": "@php artisan test",
+    "test": "@php artisan test --parallel",
+    "test:ci": "@php artisan test",
     "coverage": "@php artisan test --coverage-clover=coverage.xml",
     "cs": "mago format --check",
     "cs:fix": "mago format",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a991b7b1a343e353a2f48c043ac4e31b",
+    "content-hash": "1bc3c17beadede56f356721d4f6526b4",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
@@ -11547,6 +11547,99 @@
     ],
     "packages-dev": [
         {
+            "name": "brianium/paratest",
+            "version": "v7.8.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paratestphp/paratest.git",
+                "reference": "9b324c8fc319cf9728b581c7a90e1c8f6361c5e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paratestphp/paratest/zipball/9b324c8fc319cf9728b581c7a90e1c8f6361c5e5",
+                "reference": "9b324c8fc319cf9728b581c7a90e1c8f6361c5e5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-pcre": "*",
+                "ext-reflection": "*",
+                "ext-simplexml": "*",
+                "fidry/cpu-core-counter": "^1.3.0",
+                "jean85/pretty-package-versions": "^2.1.1",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "phpunit/php-code-coverage": "^11.0.12",
+                "phpunit/php-file-iterator": "^5.1.0",
+                "phpunit/php-timer": "^7.0.1",
+                "phpunit/phpunit": "^11.5.46",
+                "sebastian/environment": "^7.2.1",
+                "symfony/console": "^6.4.22 || ^7.3.4 || ^8.0.3",
+                "symfony/process": "^6.4.20 || ^7.3.4 || ^8.0.3"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^12.0.0",
+                "ext-pcov": "*",
+                "ext-posix": "*",
+                "phpstan/phpstan": "^2.1.33",
+                "phpstan/phpstan-deprecation-rules": "^2.0.3",
+                "phpstan/phpstan-phpunit": "^2.0.11",
+                "phpstan/phpstan-strict-rules": "^2.0.7",
+                "squizlabs/php_codesniffer": "^3.13.5",
+                "symfony/filesystem": "^6.4.13 || ^7.3.2 || ^8.0.1"
+            },
+            "bin": [
+                "bin/paratest",
+                "bin/paratest_for_phpstorm"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ParaTest\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Brian Scaturro",
+                    "email": "scaturrob@gmail.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Filippo Tessarotto",
+                    "email": "zoeslam@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Parallel testing for PHP",
+            "homepage": "https://github.com/paratestphp/paratest",
+            "keywords": [
+                "concurrent",
+                "parallel",
+                "phpunit",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/paratestphp/paratest/issues",
+                "source": "https://github.com/paratestphp/paratest/tree/v7.8.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/Slamdunk",
+                    "type": "github"
+                },
+                {
+                    "url": "https://paypal.me/filippotessarotto",
+                    "type": "paypal"
+                }
+            ],
+            "time": "2026-01-08T08:02:38+00:00"
+        },
+        {
             "name": "carthage-software/mago",
             "version": "1.29.0",
             "source": {
@@ -11604,6 +11697,67 @@
                 }
             ],
             "time": "2026-05-23T18:53:33+00:00"
+        },
+        {
+            "name": "fidry/cpu-core-counter",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theofidry/cpu-core-counter.git",
+                "reference": "db9508f7b1474469d9d3c53b86f817e344732678"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/db9508f7b1474469d9d3c53b86f817e344732678",
+                "reference": "db9508f7b1474469d9d3c53b86f817e344732678",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "fidry/makefile": "^0.2.0",
+                "fidry/php-cs-fixer-config": "^1.1.2",
+                "phpstan/extension-installer": "^1.2.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-deprecation-rules": "^2.0.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^8.5.31 || ^9.5.26",
+                "webmozarts/strict-phpunit": "^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Fidry\\CpuCoreCounter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Théo FIDRY",
+                    "email": "theo.fidry@gmail.com"
+                }
+            ],
+            "description": "Tiny utility to get the number of CPU cores.",
+            "keywords": [
+                "CPU",
+                "core"
+            ],
+            "support": {
+                "issues": "https://github.com/theofidry/cpu-core-counter/issues",
+                "source": "https://github.com/theofidry/cpu-core-counter/tree/1.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theofidry",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-14T07:29:31+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -11696,6 +11850,66 @@
                 "source": "https://github.com/iamcal/SQLParser/tree/v0.7"
             },
             "time": "2026-01-28T22:20:33+00:00"
+        },
+        {
+            "name": "jean85/pretty-package-versions",
+            "version": "2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Jean85/pretty-package-versions.git",
+                "reference": "4d7aa5dab42e2a76d99559706022885de0e18e1a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Jean85/pretty-package-versions/zipball/4d7aa5dab42e2a76d99559706022885de0e18e1a",
+                "reference": "4d7aa5dab42e2a76d99559706022885de0e18e1a",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2.1.0",
+                "php": "^7.4|^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.2",
+                "jean85/composer-provided-replaced-stub-package": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^7.5|^8.5|^9.6",
+                "rector/rector": "^2.0",
+                "vimeo/psalm": "^4.3 || ^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Jean85\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alessandro Lai",
+                    "email": "alessandro.lai85@gmail.com"
+                }
+            ],
+            "description": "A library to get pretty versions strings of installed dependencies",
+            "keywords": [
+                "composer",
+                "package",
+                "release",
+                "versions"
+            ],
+            "support": {
+                "issues": "https://github.com/Jean85/pretty-package-versions/issues",
+                "source": "https://github.com/Jean85/pretty-package-versions/tree/2.1.1"
+            },
+            "time": "2025-03-19T14:43:43+00:00"
         },
         {
             "name": "larastan/larastan",

--- a/tests/Feature/DuplicateUploadActionTest.php
+++ b/tests/Feature/DuplicateUploadActionTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 use function Tests\create_user;
+use function Tests\sandbox_path;
 use function Tests\test_path;
 
 class DuplicateUploadActionTest extends TestCase
@@ -103,10 +104,10 @@ class DuplicateUploadActionTest extends TestCase
     #[Test]
     public function keepSingleDuplicate(): void
     {
-        Setting::set('media_path', public_path('sandbox/media'));
+        Setting::set('media_path', sandbox_path('media'));
 
         $user = create_user();
-        $songPath = public_path('sandbox/media/keep-test.mp3');
+        $songPath = sandbox_path('media/keep-test.mp3');
         File::copy(test_path('songs/full.mp3'), $songPath);
 
         $upload = DuplicateUpload::factory()->for($user)->createOne(['location' => $songPath]);
@@ -119,12 +120,12 @@ class DuplicateUploadActionTest extends TestCase
     #[Test]
     public function keepAllDuplicates(): void
     {
-        Setting::set('media_path', public_path('sandbox/media'));
+        Setting::set('media_path', sandbox_path('media'));
 
         $user = create_user();
 
         foreach (range(1, 2) as $i) {
-            $songPath = public_path("sandbox/media/keep-all-test-{$i}.mp3");
+            $songPath = sandbox_path("media/keep-all-test-{$i}.mp3");
             File::copy(test_path('songs/full.mp3'), $songPath);
             DuplicateUpload::factory()->for($user)->createOne(['location' => $songPath]);
         }

--- a/tests/Feature/KoelPlus/UploadTest.php
+++ b/tests/Feature/KoelPlus/UploadTest.php
@@ -10,6 +10,7 @@ use Tests\PlusTestCase;
 
 use function Tests\create_guest;
 use function Tests\create_user;
+use function Tests\sandbox_path;
 use function Tests\test_path;
 
 class UploadTest extends PlusTestCase
@@ -20,7 +21,7 @@ class UploadTest extends PlusTestCase
     {
         parent::setUp();
 
-        Setting::set('media_path', public_path('sandbox/media'));
+        Setting::set('media_path', sandbox_path('media'));
         $this->file = UploadedFile::fromFile(test_path('songs/full.mp3'), 'song.mp3'); //@phpstan-ignore-line
     }
 
@@ -30,8 +31,8 @@ class UploadTest extends PlusTestCase
         $user = create_user();
 
         $this->postAs('api/upload', ['file' => $this->file], $user)->assertSuccessful();
-        self::assertDirectoryExists(public_path("sandbox/media/__KOEL_UPLOADS_\${$user->id}__"));
-        self::assertFileExists(public_path("sandbox/media/__KOEL_UPLOADS_\${$user->id}__/song.mp3"));
+        self::assertDirectoryExists(sandbox_path("media/__KOEL_UPLOADS_\${$user->id}__"));
+        self::assertFileExists(sandbox_path("media/__KOEL_UPLOADS_\${$user->id}__/song.mp3"));
 
         /** @var Song $song */
         $song = Song::query()->latest()->first();

--- a/tests/Feature/UploadTest.php
+++ b/tests/Feature/UploadTest.php
@@ -12,6 +12,7 @@ use Tests\TestCase;
 
 use function Tests\create_admin;
 use function Tests\create_user;
+use function Tests\sandbox_path;
 use function Tests\test_path;
 
 class UploadTest extends TestCase
@@ -53,7 +54,7 @@ class UploadTest extends TestCase
     #[Test]
     public function uploadSuccessful(): void
     {
-        Setting::set('media_path', public_path('sandbox/media'));
+        Setting::set('media_path', sandbox_path('media'));
 
         $this->postAs('/api/upload', ['file' => $this->file], create_admin())->assertJsonStructure(['song', 'album']);
     }
@@ -62,7 +63,7 @@ class UploadTest extends TestCase
     public function uploadDisabledInDemoMode(): void
     {
         config(['koel.misc.demo' => true]);
-        Setting::set('media_path', public_path('sandbox/media'));
+        Setting::set('media_path', sandbox_path('media'));
 
         try {
             $this->postAs('/api/upload', ['file' => $this->file], create_user())->assertForbidden();

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -6,6 +6,7 @@ use App\Models\Playlist;
 use App\Models\User;
 use App\Services\Image\ImageWriter;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\ParallelTesting;
 
 function create_user(array $attributes = []): User
 {
@@ -73,4 +74,20 @@ function minimal_base64_encoded_image(): string
 function stored_image_name(string $ulid): string
 {
     return sprintf('%s.%s', $ulid, app(ImageWriter::class)->format());
+}
+
+/**
+ * Each parallel worker gets its own sandbox, so that tearing one down doesn't
+ * delete files another worker is still using.
+ */
+function sandbox_dir(): string
+{
+    $token = ParallelTesting::token();
+
+    return $token ? "sandbox-$token" : 'sandbox';
+}
+
+function sandbox_path(string $subPath = ''): string
+{
+    return public_path(sandbox_dir() . "/$subPath");
 }

--- a/tests/Integration/Services/SongStorages/LocalStorageTest.php
+++ b/tests/Integration/Services/SongStorages/LocalStorageTest.php
@@ -12,6 +12,7 @@ use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 use function Tests\create_user;
+use function Tests\sandbox_path;
 use function Tests\test_path;
 
 class LocalStorageTest extends TestCase
@@ -37,14 +38,14 @@ class LocalStorageTest extends TestCase
     #[Test]
     public function storeUploadedFile(): void
     {
-        Setting::set('media_path', public_path('sandbox/media'));
+        Setting::set('media_path', sandbox_path('media'));
         File::copy(test_path('songs/full.mp3'), artifact_path('tmp/random/full.mp3'));
 
         $user = create_user();
 
         $reference = $this->service->storeUploadedFile(artifact_path('tmp/random/full.mp3'), $user);
 
-        self::assertSame(public_path("sandbox/media/__KOEL_UPLOADS_\${$user->id}__/full.mp3"), $reference->location);
+        self::assertSame(sandbox_path("media/__KOEL_UPLOADS_\${$user->id}__/full.mp3"), $reference->location);
         self::assertSame($reference->location, $reference->localPath);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -69,16 +69,16 @@ abstract class TestCase extends BaseTestCase
     private static function createSandbox(): void
     {
         config([
-            'koel.image_storage_dir' => 'sandbox/img/storage',
-            'koel.artifacts_path' => public_path('sandbox/artifacts/'),
+            'koel.image_storage_dir' => sandbox_dir() . '/img/storage',
+            'koel.artifacts_path' => sandbox_path('artifacts/'),
         ]);
 
         File::ensureDirectoryExists(public_path(config('koel.image_storage_dir')));
-        File::ensureDirectoryExists(public_path('sandbox/media/'));
+        File::ensureDirectoryExists(sandbox_path('media/'));
     }
 
     private static function destroySandbox(): void
     {
-        File::deleteDirectory(public_path('sandbox'));
+        File::deleteDirectory(sandbox_path());
     }
 }


### PR DESCRIPTION
Runs the test suite across all available cores. `composer test` drops from ~75s to ~31s locally.

This is the other half of #2634, which was merged while it only contained the bcrypt change.

### Making the suite parallel-safe

`brianium/paratest` on its own doesn't work here — a parallel run produced 524 errors and 21 failures. Every worker shared one sandbox: `TestCase::createSandbox()` pointed `koel.image_storage_dir` and `koel.artifacts_path` at `public/sandbox`, and `destroySandbox()` deleted that whole tree after *every* test. Workers raced each other creating directories (`mkdir(): File exists`) and deleted files other workers were still asserting on.

The sandbox is now scoped to the worker through `ParallelTesting::token()`, via a `sandbox_path()` helper that also replaces the hardcoded `public_path('sandbox/…')` references in the upload tests. Outside a parallel run there's no token and the path stays `public/sandbox`, exactly as before.

`brianium/paratest` is pinned to the v7.8 line: v7.24 requires PHP 8.4, and this project pins `config.platform.php` to `8.3.0`.

### CI keeps running serially

`composer test` is parallel; CI calls a new `composer test:ci`, which isn't. The fast path is the default for humans, and CI's constraint is the thing that's named.

CI is where parallel would bite. Each worker gets its own database (`koel_test_1`, `koel_test_2`, …) — free for SQLite `:memory:`, but not against a real server. PostgreSQL connects as the `postgres` superuser and could create them; MariaDB connects as `mariadb`, which the official image grants privileges only on `koel`, so `CREATE DATABASE` would fail. Even with that fixed, runners are 4-core and every worker would re-run the full migration set against a live server, which can cost more than the parallelism saves.

The SQLite job runs `composer coverage` and is untouched — parallel coverage merging deserves its own look, since the codecov reports depend on it.

All 1590 tests pass in both modes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Test suites now run in parallel locally for faster feedback.
  * Continuous integration uses reliable non-parallel test execution.
  * Test storage paths are isolated per worker, improving reliability during concurrent runs.
  * Upload, duplicate, and local storage tests now use consistent sandbox locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->