### PR TITLE
ci: run all test jobs in parallel and drop coverage reporting

### DIFF
--- a/.github/workflows/test-backend-mariadb.yml
+++ b/.github/workflows/test-backend-mariadb.yml
@@ -43,7 +43,7 @@ jobs:
       DB_HOST: 127.0.1.1
       DB_PORT: 3306
       DB_DATABASE: koel
-      DB_USERNAME: mariadb
+      DB_USERNAME: root
       DB_PASSWORD: mariadb
     steps:
       - uses: actions/checkout@v6
@@ -60,7 +60,7 @@ jobs:
       - name: Generate app key
         run: php artisan key:generate --quiet
       - name: Run tests
-        run: composer test:ci
+        run: composer test
         env:
           COMPOSER_PROCESS_TIMEOUT: 600
       - name: Upload logs if broken

--- a/.github/workflows/test-backend-pgsql.yml
+++ b/.github/workflows/test-backend-pgsql.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Generate app key
         run: php artisan key:generate --quiet
       - name: Run tests
-        run: composer test:ci
+        run: composer test
         env:
           COMPOSER_PROCESS_TIMEOUT: 600
       - name: Upload logs if broken

--- a/.github/workflows/test-backend-sqlite.yml
+++ b/.github/workflows/test-backend-sqlite.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
           tools: composer:v2
-          coverage: xdebug
+          coverage: none
           extensions: pdo_sqlite, zip, gd
       - name: Install PHP dependencies
         uses: ramsey/composer-install@v2
@@ -37,8 +37,8 @@ jobs:
           composer-options: --prefer-dist
       - name: Generate app key
         run: php artisan key:generate --quiet
-      - name: Run tests with coverage
-        run: composer coverage
+      - name: Run tests
+        run: composer test
         env:
           COMPOSER_PROCESS_TIMEOUT: 600
       - name: Upload logs if broken
@@ -47,7 +47,3 @@ jobs:
         with:
           name: unit-be-logs-${{ github.run_id }}-${{ github.run_attempt }}-sqlite
           path: storage/logs
-      - name: Upload coverage
-        uses: codecov/codecov-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/unit-frontend.yml
+++ b/.github/workflows/unit-frontend.yml
@@ -39,7 +39,3 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Run unit tests
         run: pnpm exec vp test --run --shard=${{ matrix.shard }}
-      - name: Collect coverage
-        uses: codecov/codecov-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# koel [![Frontend Unit Tests](https://github.com/koel/koel/actions/workflows/unit-frontend.yml/badge.svg)](https://github.com/koel/koel/actions/workflows/unit-frontend.yml) ![Code Quality](https://scrutinizer-ci.com/g/phanan/koel/badges/quality-score.png?b=master) [![codecov](https://codecov.io/gh/koel/koel/branch/master/graph/badge.svg)](https://codecov.io/gh/koel/koel) [![OpenCollective](https://opencollective.com/koel/backers/badge.svg)](#backers) [![OpenCollective](https://opencollective.com/koel/sponsors/badge.svg)](#sponsors)
+# koel [![Frontend Unit Tests](https://github.com/koel/koel/actions/workflows/unit-frontend.yml/badge.svg)](https://github.com/koel/koel/actions/workflows/unit-frontend.yml) ![Code Quality](https://scrutinizer-ci.com/g/phanan/koel/badges/quality-score.png?b=master) [![OpenCollective](https://opencollective.com/koel/backers/badge.svg)](#backers) [![OpenCollective](https://opencollective.com/koel/sponsors/badge.svg)](#sponsors)
 
 ![Showcase](https://user-images.githubusercontent.com/8056274/115028055-bc02a280-9ec4-11eb-991c-69cd2a45b69c.png)
 

--- a/composer.json
+++ b/composer.json
@@ -122,8 +122,6 @@
     ],
     "koel:init": "@php scripts/koel-init.php",
     "test": "@php artisan test --parallel",
-    "test:ci": "@php artisan test",
-    "coverage": "@php artisan test --coverage-clover=coverage.xml",
     "cs": "mago format --check",
     "cs:fix": "mago format",
     "lint": "mago lint",


### PR DESCRIPTION
Every CI test job now runs in parallel, and coverage reporting is gone.

### Parallel everywhere

All three backend jobs call `composer test`. `composer test:ci` existed only to keep CI serial, so it's removed.

Parallel testing gives each worker its own database (`koel_test_1`, `koel_test_2`, …), which the CI user has to be able to create:

- **MariaDB** connected as `mariadb`, a user the official image grants privileges only on `koel` — no `CREATE DATABASE`. It now connects as `root`, whose password the service already defines via `MYSQL_ROOT_PASSWORD`.
- **PostgreSQL** already connected as the `postgres` superuser, so it needed no change.
- **SQLite** uses `:memory:`, where each worker gets its own database for free.

### Coverage removed

Dropped the `composer coverage` script, the codecov upload steps from both the SQLite and frontend workflows, and the now-stale codecov badge from the README.

The SQLite job also drops `coverage: xdebug` in favor of `coverage: none`. That's likely the bigger win of the two: Xdebug slows PHP substantially even when only collecting line coverage, and that job was the slowest of the three at over 7 minutes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified backend and frontend test workflows.
  * Updated database test execution across MariaDB, PostgreSQL, and SQLite.
  * Removed coverage collection and Codecov uploads.

* **Chores**
  * Removed obsolete Composer test and coverage commands.
  * Removed the Codecov badge from the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->