### PR TITLE
feat: tag logs with the request and user they came from

### DIFF
--- a/app/Http/Middleware/AddRequestContextForLogging.php
+++ b/app/Http/Middleware/AddRequestContextForLogging.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Helpers\Uuid;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Context;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Tag the request so that everything it logs — including from queued jobs it dispatches,
+ * which are logged long after the response has been sent — can be traced back to it.
+ */
+class AddRequestContextForLogging
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        Context::add([
+            'request_id' => Uuid::generate(),
+            // Asking for the user here resolves the guard early, before the auth middleware runs.
+            'user_id' => $request->user()?->id,
+        ]);
+
+        return $next($request);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Exceptions\SubsonicAwareErrorRenderer;
+use App\Http\Middleware\AddRequestContextForLogging;
 use App\Http\Middleware\AuthenticateAudioRequests;
 use App\Http\Middleware\EnsureEmbedsEnabled;
 use App\Http\Middleware\ForceHttps;
@@ -32,6 +33,14 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(static function (Middleware $middleware): void {
+        $middleware->api(prepend: [
+            AddRequestContextForLogging::class,
+        ]);
+
+        $middleware->web(prepend: [
+            AddRequestContextForLogging::class,
+        ]);
+
         $middleware->api(append: [
             RestrictPlusFeatures::class,
             HandleDemoMode::class,

--- a/tests/Feature/RequestContextTest.php
+++ b/tests/Feature/RequestContextTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Helpers\Uuid;
+use Illuminate\Support\Facades\Context;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+use function Tests\create_user;
+
+class RequestContextTest extends TestCase
+{
+    #[Test]
+    public function tagsRequestsWithAnId(): void
+    {
+        $uuid = Uuid::freeze();
+
+        $this->get('api/ping')->assertOk();
+
+        self::assertSame($uuid, Context::get('request_id'));
+    }
+
+    #[Test]
+    public function tagsRequestsWithTheAuthenticatedUser(): void
+    {
+        $user = create_user();
+
+        $this->getAs('api/me', $user)->assertOk();
+
+        self::assertSame($user->id, Context::get('user_id'));
+    }
+
+    #[Test]
+    public function doesNotTagGuestRequestsWithAUser(): void
+    {
+        $this->get('api/ping')->assertOk();
+
+        self::assertNull(Context::get('user_id'));
+    }
+}

--- a/tests/Feature/RequestContextTest.php
+++ b/tests/Feature/RequestContextTest.php
@@ -38,4 +38,14 @@ class RequestContextTest extends TestCase
 
         self::assertNull(Context::get('user_id'));
     }
+
+    #[Test]
+    public function tagsSubsonicRequestsToo(): void
+    {
+        $uuid = Uuid::freeze();
+
+        $this->get('rest/ping.view');
+
+        self::assertSame($uuid, Context::get('request_id'));
+    }
 }


### PR DESCRIPTION
Every log entry now carries the request and user it came from — including entries written by queued jobs, long after the response was sent.

koel has 11 queued job classes and 39 `Log::` calls. Until now, a failure logged from `GenerateAlbumThumbnailJob` or `ExtractSongFolderStructureJob` arrived with no way to tell which user or request caused it. Context propagates through queue serialization, so a job dispatched during a request logs under the same `request_id` and `user_id` as the request itself.

Nothing needs configuring for the logs to pick this up: `LogManager` pushes a `ContextLogProcessor` onto every channel, so whatever is in the context lands in the log record.

### On resolving the user in middleware

`$request->user()` is asked for in the middleware, which resolves the guard early rather than waiting for the auth middleware. Two alternatives didn't work:

- An `Authenticated` event listener never fires — token guards don't dispatch that event.
- Reading the user in `App\Http\Middleware\Authenticate` misses most routes, which use the framework's `Illuminate\Auth\Middleware\Authenticate` instead.

Guest requests simply get a null `user_id`, which is covered by a test.

### Deliberately not included

Jobs like `ScrobbleJob($user, $song, $timestamp)` and `HandleSongUploadJob($path, $user)` keep taking the user as a constructor argument. Their behavior depends on it, and moving it into the context would turn an explicit dependency into a hidden one that breaks when a job is dispatched from the CLI or a test. The context carries only what's safe to lose.

Subsonic requests **are** tagged with a `request_id` — `routes/subsonic.php` is loaded into the `api` group, so the middleware covers `/rest/*.view` too, and there's a test for it. They don't get a `user_id`, because they authenticate through their own middleware after this one runs; tagging those is a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added request tracking across web, API, and Subsonic requests.
  * Logs now include a unique request identifier and, when available, the signed-in user’s identifier.
  * Guest requests are recorded without user-specific context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->