### PR TITLE
fix: missing entries in search results

### DIFF
--- a/app/Services/Search/MultiIndexSqliteEngine.php
+++ b/app/Services/Search/MultiIndexSqliteEngine.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Services\Search;
+
+use TeamTNT\TNTSearch\Engines\SqliteEngine;
+
+/**
+ * Koel writes to several TNTSearch indexes (songs, albums, artists, playlists, podcasts) from a single
+ * process — a library scan saves an artist, an album and a song one after another, and `koel:search:import`
+ * walks every model in one run.
+ *
+ * Upstream's SqliteEngine::selectIndex() swaps the index connection but keeps the wordlist statements it
+ * prepared against the previous one, so once a second index is selected every term is written to the
+ * index that came before it. The affected records end up with no terms of their own and become impossible
+ * to find.
+ *
+ * Reported at https://github.com/teamtnt/tntsearch/issues/367; this class can go once that ships.
+ */
+class MultiIndexSqliteEngine extends SqliteEngine
+{
+    public function selectIndex($indexName): void
+    {
+        parent::selectIndex($indexName);
+
+        $this->statementsPrepared = false;
+        $this->inMemoryTerms = [];
+    }
+}

--- a/config/scout.php
+++ b/config/scout.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Services\Search\MultiIndexSqliteEngine;
+
 return [
     /*
      |--------------------------------------------------------------------------
@@ -103,6 +105,7 @@ return [
     ],
 
     'tntsearch' => [
+        'engine' => MultiIndexSqliteEngine::class,
         'storage' => storage_path('search-indexes'),
         'fuzziness' => env('TNTSEARCH_FUZZINESS', true),
         'fuzzy' => [

--- a/tests/Integration/Services/Search/MultiIndexSqliteEngineTest.php
+++ b/tests/Integration/Services/Search/MultiIndexSqliteEngineTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Integration\Services\Search;
+
+use App\Models\Artist;
+use App\Models\Song;
+use App\Repositories\SongRepository;
+use Illuminate\Support\Facades\File;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+use function Tests\create_user;
+use function Tests\sandbox_path;
+
+class MultiIndexSqliteEngineTest extends TestCase
+{
+    private SongRepository $songRepository;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        File::ensureDirectoryExists(sandbox_path('search-indexes'));
+
+        config([
+            'scout.driver' => 'tntsearch',
+            'scout.tntsearch.storage' => sandbox_path('search-indexes'),
+        ]);
+
+        $this->songRepository = app(SongRepository::class);
+    }
+
+    #[Test]
+    public function songsAreSearchableAfterAnotherIndexHasBeenWrittenTo(): void
+    {
+        $user = create_user();
+
+        Artist::factory()->for($user)->createOne(['name' => 'Ambient']);
+        $song = Song::factory()->for($user, 'owner')->createOne(['title' => 'Tony Anderson - The King']);
+
+        $found = $this->songRepository->search('Tony Anderson', 10, $user);
+
+        self::assertCount(1, $found);
+        self::assertTrue($found->first()->is($song));
+    }
+}


### PR DESCRIPTION
Songs, albums and artists could be missing from search results even though they exist in the library and play fine. Fixes #2618.

The cause is upstream, in `teamtnt/tntsearch`. `SqliteEngine::selectIndex()` opens a new connection for the index being selected but keeps the wordlist statements it prepared against the previous one. From the second index onward, every term is written into the index that came before it, while the doclist rows — prepared fresh on each call — land in the right index referencing term ids that mean nothing there. The record ends up with no terms of its own and nothing can reach it. `$inMemoryTerms` leaks ids across indexes the same way.

Koel has five indexes and routinely writes to more than one per process: a library scan saves an artist, then an album, then a song, each triggering a Scout update, and `koel:search:import` walks every model in one run. Indexing an artist named `Ambient` followed by a song titled `Tony Anderson - The King` leaves the song index empty, with all five of the song's terms sitting in the artist index. Whichever index is written second is the one that loses its terms.

`MultiIndexSqliteEngine` resets the state belonging to the old connection when a new one is opened. It is wired in through `scout.tntsearch.engine`, which `TNTSearch::loadConfig()` already honors, so there is no vendor patch and no new dependency. Every read and write path in the Scout driver calls `selectIndex()` immediately before touching an index, so the one override covers all of them.

Reported upstream at https://github.com/teamtnt/tntsearch/issues/367. The class can be dropped once that ships.

### Upgrading

This stops indexes from being corrupted but does not repair ones already written. Existing installations should run `php artisan koel:search:import` once after upgrading.

### Testing

The new test indexes an artist, then a song, then searches through the real `tntsearch` driver instead of the `collection` driver the other search tests use. It returns zero results without the fix.
