### PR TITLE
docs: add one-click Railway self-host option

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -91,8 +91,7 @@ detailed instructions and issue reporting.
 
 ### Using Railway (community)
 
-If you'd rather not run Docker Compose on a server yourself, a community-maintained template deploys Koel with
-PostgreSQL on [Railway](https://railway.com):
+To deploy Koel with PostgreSQL on [Railway](https://railway.com), use this community-maintained template:
 
 [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/koel?utm_medium=integration&utm_source=button&utm_campaign=koel)
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,5 +1,5 @@
 ---
-description: Requirements, installation methods (pre-compiled, source, Docker), configuration, running with FrankenPHP (binary + systemd), upgrading, and downgrading Koel.
+description: Requirements, installation methods (pre-compiled, source, Docker, Railway), configuration, running with FrankenPHP (binary + systemd), upgrading, and downgrading Koel.
 ---
 
 # Getting Started
@@ -25,7 +25,7 @@ The requirements for each part are as follows:
 
 ## Installation
 
-There are four methods to install and start using Koel:
+There are five methods to install and start using Koel:
 
 ### Using the Standalone Binary
 
@@ -88,6 +88,17 @@ and `Caddyfile.example` for [FrankenPHP](/guide/running-with-frankenphp).
 
 Koel has an official Docker image: [koel/docker](https://github.com/koel/docker). Please refer to the repository for
 detailed instructions and issue reporting.
+
+### Using Railway (community)
+
+If you'd rather not run Docker Compose on a server yourself, a community-maintained template deploys Koel with
+PostgreSQL on [Railway](https://railway.com):
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/koel?utm_medium=integration&utm_source=button&utm_campaign=koel)
+
+This is not an official Koel offering — please report template issues to the maintainers at
+[osbytes/template-koel](https://github.com/osbytes/template-koel). After the first deploy, change the default admin
+password immediately (`admin@koel.dev` / `KoelIsCool`).
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

Adds a community-maintained one-click Railway deploy option to the Getting Started install guide (after Docker).

The template runs Koel + PostgreSQL using the published `phanan/koel` image (same stack as [koel/docker](https://github.com/koel/docker)'s Postgres compose path). It is community-maintained deployment config only — not an official Koel offering.

- Live template: https://railway.com/deploy/koel
- Template source: https://github.com/osbytes/template-koel

## Test plan

- [ ] Confirm the Deploy on Railway button renders on the Getting Started docs page
- [ ] Confirm https://railway.com/deploy/koel opens the Koel template deploy flow
- [ ] Confirm the section reads clearly beside the existing Docker instructions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the getting-started guide to include Railway installation.
  * Added instructions for deploying with PostgreSQL through Railway.
  * Included deployment guidance, a disclaimer, issue-reporting information, and a warning about the default administrator password.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->