### PR TITLE
fix: link storage relatively so packaged releases resolve it

### DIFF
--- a/app/Console/Commands/InitCommand.php
+++ b/app/Console/Commands/InitCommand.php
@@ -270,7 +270,11 @@ class InitCommand extends Command
         $result = self::SUCCESS;
 
         $this->components->task('Linking storage', static function () use (&$result): void {
-            $result = Artisan::call('storage:link', ['--quiet' => true]);
+            $result = Artisan::call('storage:link', [
+                '--quiet' => true,
+                '--relative' => true,
+                '--force' => true,
+            ]);
         });
 
         if ($result !== self::SUCCESS) {


### PR DESCRIPTION
`koel:init` links storage with an absolute path. The release workflow runs `koel:init` on the runner and then archives the tree, so every release ships a symlink pointing at the build machine:

```
$ tar -tvzf koel-v9.11.1.tar.gz | grep public/storage
lrwxrwxrwx koel/public/storage -> /home/runner/work/koel/koel/storage/app/public
```

On any install from that archive the link dangles, so koel can neither read nor write uploaded images and `koel:doctor` reports the image storage directory as unwritable. It affects the Docker image and standalone tarball installs alike.

`--relative` makes the link `../storage/app/public`, which resolves correctly both in place and after the tree is packaged and unpacked elsewhere. Since the release workflow builds from a fresh checkout with no `public/storage`, this alone is what stops future archives shipping a machine-specific path.

`--force` covers upgrades. Laravel's `storage:link` refuses to touch an existing link unless forced, so without it an installation that already has an absolute link keeps it. A real directory at that path is still left alone — `isRemovableSymlink()` requires `is_link()` — so nobody's images get deleted.

Note that a *dangling* link was already handled before this change: `file_exists()` is false for a broken symlink, so `storage:link` falls through to its `is_link()` branch, deletes it and recreates it. What was missing is that the recreated link was absolute again.

Already-published releases are repaired downstream in koel/docker#229; this change is what stops future ones shipping broken.

### Testing

There is no test harness around `koel:init` today, and building one is more than this fix warrants. The behaviour is covered end to end in the Docker image instead, where koel/docker#229 added goss assertions for the symlink and its target that run against a freshly built image on every CI run.

Verified by hand that a built image resolves `public/storage` to `storage/app/public` and that `public/storage/images` is writable by `www-data`, which is the condition `koel:doctor` checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Storage links are now created using relative paths, improving portability across environments.
  - Existing storage links can now be safely refreshed when initializing the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->