### PR TITLE
ci: pin the workflow actions and scope the release token

### DIFF
--- a/.github/workflows/lint-backend.yml
+++ b/.github/workflows/lint-backend.yml
@@ -15,6 +15,9 @@ on:
       - docs/**
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-backend.yml
+++ b/.github/workflows/lint-backend.yml
@@ -22,14 +22,14 @@ jobs:
       matrix:
         php-version: [ 8.3 ]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.php-version }}
           tools: composer:v2
       - name: Install PHP dependencies
-        uses: ramsey/composer-install@v2
+        uses: ramsey/composer-install@1919f6c305aea6ab10e6181a8ddf72317ad77e0e # 2.3.1
         with:
           composer-options: --prefer-dist
       - name: Run code style checker

--- a/.github/workflows/lint-backend.yml
+++ b/.github/workflows/lint-backend.yml
@@ -26,6 +26,8 @@ jobs:
         php-version: [ 8.3 ]
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
       - name: Set up PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:

--- a/.github/workflows/lint-frontend.yml
+++ b/.github/workflows/lint-frontend.yml
@@ -28,11 +28,11 @@ jobs:
       matrix:
         node-version: [ 22 ]
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: ${{ matrix.node-version }}
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Check (format + lint)

--- a/.github/workflows/lint-frontend.yml
+++ b/.github/workflows/lint-frontend.yml
@@ -20,6 +20,9 @@ on:
 env:
   LARAVEL_BYPASS_ENV_CHECK: 1
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-frontend.yml
+++ b/.github/workflows/lint-frontend.yml
@@ -32,6 +32,8 @@ jobs:
         node-version: [ 22 ]
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
       - name: Set up PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,22 +13,22 @@ jobs:
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: 8.4
           tools: composer:v2
           extensions: pdo_sqlite, zip, gd
       - name: Install PHP dependencies
-        uses: ramsey/composer-install@v2
+        uses: ramsey/composer-install@1919f6c305aea6ab10e6181a8ddf72317ad77e0e # 2.3.1
         with:
           composer-options: "--prefer-dist --no-dev --optimize-autoloader"
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: 22
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Build project
         run: |
           sudo apt install pngquant zip unzip
@@ -45,7 +45,7 @@ jobs:
           tar -zcf /tmp/koel-${{ steps.get_version.outputs.VERSION }}.tar.gz koel/
       - name: Create release
         id: create_release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: ${{ steps.get_version.outputs.VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
 
 name: Upload Release Assets
 
+permissions:
+  # softprops/action-gh-release creates the draft release and
+  # uploads the archives with the workflow token.
+  contents: write
+
 jobs:
   build:
     name: Upload Release Assets

--- a/.github/workflows/test-backend-mariadb.yml
+++ b/.github/workflows/test-backend-mariadb.yml
@@ -50,6 +50,8 @@ jobs:
       DB_PASSWORD: mariadb
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
       - name: Set up PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:

--- a/.github/workflows/test-backend-mariadb.yml
+++ b/.github/workflows/test-backend-mariadb.yml
@@ -46,15 +46,15 @@ jobs:
       DB_USERNAME: root
       DB_PASSWORD: mariadb
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.php-version }}
           tools: composer:v2
           extensions: pdo_mysql, zip, gd
       - name: Install PHP dependencies
-        uses: ramsey/composer-install@v2
+        uses: ramsey/composer-install@1919f6c305aea6ab10e6181a8ddf72317ad77e0e # 2.3.1
         with:
           composer-options: --prefer-dist
       - name: Generate app key
@@ -64,7 +64,7 @@ jobs:
         env:
           COMPOSER_PROCESS_TIMEOUT: 600
       - name: Upload logs if broken
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
           name: unit-be-mariadb-logs-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/test-backend-mariadb.yml
+++ b/.github/workflows/test-backend-mariadb.yml
@@ -15,6 +15,9 @@ on:
       - docs/**
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-backend-pgsql.yml
+++ b/.github/workflows/test-backend-pgsql.yml
@@ -45,15 +45,15 @@ jobs:
       DB_USERNAME: postgres
       DB_PASSWORD: postgres
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.php-version }}
           tools: composer:v2
           extensions: pdo_pgsql, zip, gd
       - name: Install PHP dependencies
-        uses: ramsey/composer-install@v2
+        uses: ramsey/composer-install@1919f6c305aea6ab10e6181a8ddf72317ad77e0e # 2.3.1
         with:
           composer-options: --prefer-dist
       - name: Generate app key
@@ -63,7 +63,7 @@ jobs:
         env:
           COMPOSER_PROCESS_TIMEOUT: 600
       - name: Upload logs if broken
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
           name: unit-be-pgsql-logs-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/test-backend-pgsql.yml
+++ b/.github/workflows/test-backend-pgsql.yml
@@ -15,6 +15,9 @@ on:
       - docs/**
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-backend-pgsql.yml
+++ b/.github/workflows/test-backend-pgsql.yml
@@ -49,6 +49,8 @@ jobs:
       DB_PASSWORD: postgres
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
       - name: Set up PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:

--- a/.github/workflows/test-backend-sqlite.yml
+++ b/.github/workflows/test-backend-sqlite.yml
@@ -23,16 +23,16 @@ jobs:
         php-version: [ 8.3 ]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.php-version }}
           tools: composer:v2
           coverage: none
           extensions: pdo_sqlite, zip, gd
       - name: Install PHP dependencies
-        uses: ramsey/composer-install@v2
+        uses: ramsey/composer-install@1919f6c305aea6ab10e6181a8ddf72317ad77e0e # 2.3.1
         with:
           composer-options: --prefer-dist
       - name: Generate app key
@@ -42,7 +42,7 @@ jobs:
         env:
           COMPOSER_PROCESS_TIMEOUT: 600
       - name: Upload logs if broken
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
           name: unit-be-logs-${{ github.run_id }}-${{ github.run_attempt }}-sqlite

--- a/.github/workflows/test-backend-sqlite.yml
+++ b/.github/workflows/test-backend-sqlite.yml
@@ -15,6 +15,9 @@ on:
       - docs/**
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-backend-sqlite.yml
+++ b/.github/workflows/test-backend-sqlite.yml
@@ -27,6 +27,8 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
       - name: Set up PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:

--- a/.github/workflows/test-proxy-auth-e2e.yml
+++ b/.github/workflows/test-proxy-auth-e2e.yml
@@ -35,19 +35,19 @@ jobs:
     # Skip on fork PRs — secrets.KOEL_PLUS_LICENSE_KEY isn't available there.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           persist-credentials: false
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: 8.3
           tools: composer:v2
           extensions: pdo_sqlite, sqlite3, zip, gd
 
       - name: Install PHP dependencies
-        uses: ramsey/composer-install@v2
+        uses: ramsey/composer-install@1919f6c305aea6ab10e6181a8ddf72317ad77e0e # 2.3.1
         with:
           composer-options: --prefer-dist
 
@@ -201,7 +201,7 @@ jobs:
 
       - name: Upload logs on failure
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: proxy-auth-e2e-logs-${{ github.run_id }}
           path: |

--- a/.github/workflows/unit-frontend.yml
+++ b/.github/workflows/unit-frontend.yml
@@ -29,9 +29,9 @@ jobs:
         node-version: [ 22 ]
         shard: [ 1/3, 2/3, 3/3 ]
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: pnpm

--- a/.github/workflows/unit-frontend.yml
+++ b/.github/workflows/unit-frontend.yml
@@ -33,6 +33,8 @@ jobs:
         shard: [ 1/3, 2/3, 3/3 ]
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:

--- a/.github/workflows/unit-frontend.yml
+++ b/.github/workflows/unit-frontend.yml
@@ -20,6 +20,9 @@ on:
 env:
   LARAVEL_BYPASS_ENV_CHECK: 1
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Two commits, nothing about how the workflows behave changes.

The first pins every action across the workflows to an exact commit. The release workflow builds the distribution archives and creates the GitHub release, and every action was referenced by a floating tag. A tag is a movable pointer, whoever controls an action repository can point it at different code after review, which is how the tj-actions/changed-files incident (CVE-2025-30066) leaked CI secrets at scale. An exact commit cannot be retargeted. Each pin keeps the version as a trailing comment so it can be checked against the action's releases page. Versions stay exactly where they were, the setup-php and composer-install pins sit on the same commits their floating refs resolve to today.

The second declares token permissions. Only the release workflow keeps `contents: write` (it creates the draft release and uploads the archives), every lint and test workflow drops to a read only token.

One heads-up: if the org ever restricts allowed actions in the repo settings with tag patterns like `owner/action@v2`, those patterns stop matching SHA refs and workflows fail at startup, the fix is `owner/action@*` there. Nothing to do if no such restriction is configured.

## Motivation

Hardening the release path: the workflows that build and publish the koel archives should only ever run action code that existed at review time, and a compromised lint or test step should not hold a writable token.

Found and fixed by [Plumber](https://github.com/getplumber/plumber)'s analysis, reviewed and submitted by me.

## Checklist

- [ ] I've tested my changes thoroughly and added tests where applicable *(workflow-only change, validated by parsing every workflow and re-running the analysis)*
- [ ] I've updated relevant documentation (if any) *(not applicable)*
- [x] My code follows the project's conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Strengthened automation security by limiting repository access to the permissions required for each workflow.
  - Pinned workflow tools to verified, immutable versions and disabled unnecessary credential persistence, reducing supply-chain and credential risks.

- **Chores**
  - Improved the consistency and predictability of testing, linting, and release automation.
  - Preserved secure release publishing with appropriately scoped permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->