### PR TITLE
fix(subsonic): return an empty object, not an empty array, for absent album/artist info

### DIFF
--- a/app/Http/Controllers/Subsonic/GetAlbumInfo2Controller.php
+++ b/app/Http/Controllers/Subsonic/GetAlbumInfo2Controller.php
@@ -8,6 +8,7 @@ use App\Http\Responses\Subsonic\Resources\AlbumInfoResource;
 use App\Http\Responses\Subsonic\SubsonicResponse;
 use App\Repositories\AlbumRepository;
 use App\Services\Contracts\Encyclopedia;
+use stdClass;
 
 class GetAlbumInfo2Controller extends Controller
 {
@@ -22,7 +23,7 @@ class GetAlbumInfo2Controller extends Controller
         $info = $this->encyclopedia->getAlbumInformation($album);
 
         return SubsonicResponse::ok([
-            'albumInfo' => $info ? AlbumInfoResource::toArray($info) : [],
+            'albumInfo' => $info ? AlbumInfoResource::toArray($info) : new stdClass(),
         ]);
     }
 }

--- a/app/Http/Controllers/Subsonic/GetArtistInfo2Controller.php
+++ b/app/Http/Controllers/Subsonic/GetArtistInfo2Controller.php
@@ -8,6 +8,7 @@ use App\Http\Responses\Subsonic\Resources\ArtistInfoResource;
 use App\Http\Responses\Subsonic\SubsonicResponse;
 use App\Repositories\ArtistRepository;
 use App\Services\Contracts\Encyclopedia;
+use stdClass;
 
 class GetArtistInfo2Controller extends Controller
 {
@@ -22,7 +23,7 @@ class GetArtistInfo2Controller extends Controller
         $info = $this->encyclopedia->getArtistInformation($artist);
 
         return SubsonicResponse::ok([
-            'artistInfo2' => $info === null ? [] : ArtistInfoResource::toArray($info),
+            'artistInfo2' => $info === null ? new stdClass() : ArtistInfoResource::toArray($info),
         ]);
     }
 }

--- a/app/Http/Controllers/Subsonic/GetArtistInfoController.php
+++ b/app/Http/Controllers/Subsonic/GetArtistInfoController.php
@@ -8,6 +8,7 @@ use App\Http\Responses\Subsonic\Resources\ArtistInfoResource;
 use App\Http\Responses\Subsonic\SubsonicResponse;
 use App\Repositories\ArtistRepository;
 use App\Services\Contracts\Encyclopedia;
+use stdClass;
 
 /**
  * Subsonic v1 `getArtistInfo`. Per spec the wrapper is `<artistInfo>` (v2 uses
@@ -26,7 +27,7 @@ class GetArtistInfoController extends Controller
         $info = $this->encyclopedia->getArtistInformation($artist);
 
         return SubsonicResponse::ok([
-            'artistInfo' => $info === null ? [] : ArtistInfoResource::toArray($info),
+            'artistInfo' => $info === null ? new stdClass() : ArtistInfoResource::toArray($info),
         ]);
     }
 }

--- a/app/Http/Responses/Subsonic/SubsonicResponse.php
+++ b/app/Http/Responses/Subsonic/SubsonicResponse.php
@@ -9,6 +9,11 @@ use InvalidArgumentException;
 use SimpleXMLElement;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
+// @mago-ignore lint:cyclomatic-complexity
+// The XML serializer must distinguish three shapes rather than two: scalars become attributes,
+// lists become repeated children, and everything else becomes a single child. That third case now
+// includes empty objects, which is how a required-but-empty element such as <albumInfo/> is
+// emitted at all. The extra guard puts the class one over the threshold.
 class SubsonicResponse implements Responsable
 {
     public const string API_VERSION = '1.16.1';
@@ -110,12 +115,15 @@ class SubsonicResponse implements Responsable
         foreach ($data as $key => $value) {
             if (is_scalar($value) || $value === null) {
                 $element->addAttribute($key, self::formatScalar($value));
-            } elseif (Arr::isList($value)) {
+            } elseif (is_array($value) && Arr::isList($value)) {
                 foreach ($value as $item) {
                     self::appendChild($element, $key, is_array($item) ? $item : ['value' => $item]);
                 }
             } else {
-                self::appendChild($element, $key, $value);
+                // Objects land here too, which is how a required-but-empty element such as
+                // <albumInfo/> still gets emitted. An empty *array* would be a list and produce
+                // no element at all, so the no-data case is modelled as an empty object.
+                self::appendChild($element, $key, (array) $value);
             }
         }
     }

--- a/tests/Feature/Subsonic/GetAlbumInfo2Test.php
+++ b/tests/Feature/Subsonic/GetAlbumInfo2Test.php
@@ -43,9 +43,27 @@ class GetAlbumInfo2Test extends TestCase
 
         $this->mock(Encyclopedia::class)->expects('getAlbumInformation')->andReturnNull();
 
-        $this
-            ->getJson("/rest/getAlbumInfo2.view?apiKey={$user->subsonic_api_key}&f=json&id={$album->id}")
-            ->assertOk()
-            ->assertJsonPath('subsonic-response.albumInfo', []);
+        $response = $this->getJson(
+            "/rest/getAlbumInfo2.view?apiKey={$user->subsonic_api_key}&f=json&id={$album->id}",
+        )->assertOk();
+
+        // Asserted against the raw body on purpose: json_decode() maps both {} and [] to an
+        // empty PHP array, so assertJsonPath() cannot tell them apart and would pass either way.
+        self::assertStringContainsString('"albumInfo":{}', $response->getContent());
+    }
+
+    #[Test]
+    public function returnsEmptyAlbumInfoElementInXmlWhenEncyclopediaReturnsNull(): void
+    {
+        $user = create_user();
+        $album = Album::factory()->createOne(['user_id' => $user->id]);
+
+        $this->mock(Encyclopedia::class)->expects('getAlbumInformation')->andReturnNull();
+
+        $response = $this->get("/rest/getAlbumInfo2.view?apiKey={$user->subsonic_api_key}&id={$album->id}")->assertOk();
+
+        $xml = simplexml_load_string($response->getContent());
+
+        self::assertCount(1, $xml->albumInfo);
     }
 }

--- a/tests/Feature/Subsonic/GetAlbumInfo2Test.php
+++ b/tests/Feature/Subsonic/GetAlbumInfo2Test.php
@@ -16,7 +16,7 @@ class GetAlbumInfo2Test extends TestCase
     public function returnsNotesFromEncyclopedia(): void
     {
         $user = create_user();
-        $album = Album::factory()->createOne(['user_id' => $user->id]);
+        $album = Album::factory()->for($user)->createOne();
 
         $this
             ->mock(Encyclopedia::class)
@@ -39,7 +39,7 @@ class GetAlbumInfo2Test extends TestCase
     public function returnsEmptyWhenEncyclopediaReturnsNull(): void
     {
         $user = create_user();
-        $album = Album::factory()->createOne(['user_id' => $user->id]);
+        $album = Album::factory()->for($user)->createOne();
 
         $this->mock(Encyclopedia::class)->expects('getAlbumInformation')->andReturnNull();
 
@@ -56,7 +56,7 @@ class GetAlbumInfo2Test extends TestCase
     public function returnsEmptyAlbumInfoElementInXmlWhenEncyclopediaReturnsNull(): void
     {
         $user = create_user();
-        $album = Album::factory()->createOne(['user_id' => $user->id]);
+        $album = Album::factory()->for($user)->createOne();
 
         $this->mock(Encyclopedia::class)->expects('getAlbumInformation')->andReturnNull();
 

--- a/tests/Feature/Subsonic/GetAlbumInfoTest.php
+++ b/tests/Feature/Subsonic/GetAlbumInfoTest.php
@@ -17,7 +17,7 @@ class GetAlbumInfoTest extends TestCase
     public function returnsNotesFromEncyclopediaUnderAlbumInfoWrapper(): void
     {
         $user = create_user();
-        $album = Album::factory()->createOne(['user_id' => $user->id]);
+        $album = Album::factory()->for($user)->createOne();
 
         $this
             ->mock(Encyclopedia::class)
@@ -47,7 +47,7 @@ class GetAlbumInfoTest extends TestCase
     public function returnsEmptyAlbumInfoObjectWhenEncyclopediaReturnsNull(): void
     {
         $user = create_user();
-        $album = Album::factory()->createOne(['user_id' => $user->id]);
+        $album = Album::factory()->for($user)->createOne();
 
         $this->mock(Encyclopedia::class)->expects('getAlbumInformation')->andReturnNull();
 

--- a/tests/Feature/Subsonic/GetAlbumInfoTest.php
+++ b/tests/Feature/Subsonic/GetAlbumInfoTest.php
@@ -42,4 +42,24 @@ class GetAlbumInfoTest extends TestCase
             ->assertJsonPath('subsonic-response.albumInfo.lastFmUrl', 'https://www.last.fm/album/Foo')
             ->assertJsonPath('subsonic-response.albumInfo.smallImageUrl', 'https://example.test/cover.jpg');
     }
+
+    #[Test]
+    public function returnsEmptyAlbumInfoObjectWhenEncyclopediaReturnsNull(): void
+    {
+        $user = create_user();
+        $album = Album::factory()->createOne(['user_id' => $user->id]);
+
+        $this->mock(Encyclopedia::class)->expects('getAlbumInformation')->andReturnNull();
+
+        $response = $this->getJson(
+            '/rest/getAlbumInfo.view?'
+                . Arr::query([
+                    'apiKey' => $user->subsonic_api_key,
+                    'f' => 'json',
+                    'id' => $album->id,
+                ]),
+        )->assertOk();
+
+        self::assertStringContainsString('"albumInfo":{}', $response->getContent());
+    }
 }

--- a/tests/Feature/Subsonic/GetArtistInfo2Test.php
+++ b/tests/Feature/Subsonic/GetArtistInfo2Test.php
@@ -16,7 +16,7 @@ class GetArtistInfo2Test extends TestCase
     public function returnsBiographyFromEncyclopedia(): void
     {
         $user = create_user();
-        $artist = Artist::factory()->createOne(['user_id' => $user->id]);
+        $artist = Artist::factory()->for($user)->createOne();
 
         $this
             ->mock(Encyclopedia::class)
@@ -39,7 +39,7 @@ class GetArtistInfo2Test extends TestCase
     public function returnsEmptyWhenEncyclopediaReturnsNull(): void
     {
         $user = create_user();
-        $artist = Artist::factory()->createOne(['user_id' => $user->id]);
+        $artist = Artist::factory()->for($user)->createOne();
 
         $this->mock(Encyclopedia::class)->expects('getArtistInformation')->andReturnNull();
 
@@ -55,7 +55,7 @@ class GetArtistInfo2Test extends TestCase
     public function returnsEmptyArtistInfo2ElementInXmlWhenEncyclopediaReturnsNull(): void
     {
         $user = create_user();
-        $artist = Artist::factory()->createOne(['user_id' => $user->id]);
+        $artist = Artist::factory()->for($user)->createOne();
 
         $this->mock(Encyclopedia::class)->expects('getArtistInformation')->andReturnNull();
 

--- a/tests/Feature/Subsonic/GetArtistInfo2Test.php
+++ b/tests/Feature/Subsonic/GetArtistInfo2Test.php
@@ -43,9 +43,28 @@ class GetArtistInfo2Test extends TestCase
 
         $this->mock(Encyclopedia::class)->expects('getArtistInformation')->andReturnNull();
 
-        $this
-            ->getJson("/rest/getArtistInfo2.view?apiKey={$user->subsonic_api_key}&f=json&id={$artist->id}")
-            ->assertOk()
-            ->assertJsonPath('subsonic-response.artistInfo2', []);
+        $response = $this->getJson(
+            "/rest/getArtistInfo2.view?apiKey={$user->subsonic_api_key}&f=json&id={$artist->id}",
+        )->assertOk();
+
+        // Raw body, not assertJsonPath: json_decode() maps {} and [] to the same PHP value.
+        self::assertStringContainsString('"artistInfo2":{}', $response->getContent());
+    }
+
+    #[Test]
+    public function returnsEmptyArtistInfo2ElementInXmlWhenEncyclopediaReturnsNull(): void
+    {
+        $user = create_user();
+        $artist = Artist::factory()->createOne(['user_id' => $user->id]);
+
+        $this->mock(Encyclopedia::class)->expects('getArtistInformation')->andReturnNull();
+
+        $response = $this->get(
+            "/rest/getArtistInfo2.view?apiKey={$user->subsonic_api_key}&id={$artist->id}",
+        )->assertOk();
+
+        $xml = simplexml_load_string($response->getContent());
+
+        self::assertCount(1, $xml->artistInfo2);
     }
 }

--- a/tests/Feature/Subsonic/GetArtistInfoTest.php
+++ b/tests/Feature/Subsonic/GetArtistInfoTest.php
@@ -17,7 +17,7 @@ class GetArtistInfoTest extends TestCase
     public function returnsBiographyFromEncyclopediaUnderArtistInfoWrapper(): void
     {
         $user = create_user();
-        $artist = Artist::factory()->createOne(['user_id' => $user->id]);
+        $artist = Artist::factory()->for($user)->createOne();
 
         $this
             ->mock(Encyclopedia::class)
@@ -47,7 +47,7 @@ class GetArtistInfoTest extends TestCase
     public function returnsEmptyArtistInfoWhenEncyclopediaReturnsNull(): void
     {
         $user = create_user();
-        $artist = Artist::factory()->createOne(['user_id' => $user->id]);
+        $artist = Artist::factory()->for($user)->createOne();
 
         $this->mock(Encyclopedia::class)->expects('getArtistInformation')->andReturnNull();
 

--- a/tests/Feature/Subsonic/GetArtistInfoTest.php
+++ b/tests/Feature/Subsonic/GetArtistInfoTest.php
@@ -60,6 +60,8 @@ class GetArtistInfoTest extends TestCase
                 ]),
         )->assertOk();
 
-        self::assertSame([], $response->json('subsonic-response.artistInfo'));
+        // Raw body, not ->json(): json_decode() maps {} and [] to the same PHP value, so a
+        // decoded comparison passes whichever one the server emitted.
+        self::assertStringContainsString('"artistInfo":{}', $response->getContent());
     }
 }


### PR DESCRIPTION
Fixes #2646.

## The bug

`getAlbumInfo`, `getAlbumInfo2`, `getArtistInfo` and `getArtistInfo2` return the info wrapper as an empty JSON **array** when the encyclopedia has nothing for that album or artist:

```
now:  {"subsonic-response":{...,"albumInfo":[]}}
this: {"subsonic-response":{...,"albumInfo":{}}}
```

`json_encode` renders an empty PHP array as `[]`, and the controllers used `[]` for the no-data branch.

The OpenSubsonic spec marks these fields **required** and types them as objects, and the spec maintainers ruled on this exact case in opensubsonic/open-subsonic-api#163:

> Returning `null` is incorrect. For this example (a valid request, with no data), it should be an empty object.

An empty array fails for the same reason `null` does: present, but not an object.

## The XML path had the mirror of the same bug

An empty array satisfies `Arr::isList()`, so `serializeTo()` took the repeated-children branch, iterated zero times, and emitted **no element at all**. The required field was simply absent from the document:

```xml
<!-- before -->
<subsonic-response status="ok" .../>
<!-- after -->
<subsonic-response status="ok" ...><albumInfo/></subsonic-response>
```

So the serializer now distinguishes three shapes rather than two: scalars become attributes, lists become repeated children, and everything else, objects included, becomes a single child.

## Why clients care

`py-opensonic`, used by Music Assistant's OpenSubsonic provider, passes the field straight to a typed deserializer with no guard in 10.0.0 through 10.3.0:

```python
return AlbumInfo.from_dict(dres['albumInfo'])
```

which raises `ValueError: ... should be a dict instance` and breaks **track** playback while album playback keeps working, because only the track path calls `getAlbumInfo2`. The same crash against another server was reported as music-assistant/support#4065 and closed as an upstream issue after the spec ruling above, so a client-side workaround has already been considered and declined.

Measured on a self-hosted v9.11.1 instance: 36 of 58 albums returned the array form.

## Tests

The two pre-existing assertions of this shape asserted the buggy value, and could not have caught the fix either way:

```php
->assertJsonPath('subsonic-response.albumInfo', []);
```

`json_decode()` maps both `{}` and `[]` to an empty PHP array, so a decoded assertion passes whichever one the server emitted. The tests now assert on the raw body, plus two new XML cases and a missing empty-case test for `getAlbumInfo`.

- Reverting only the `app/` change turns **6 of the 10** tests in these four classes red.
- Full suite green: **1605 passed, 11771 assertions**.
- `composer cs`, `composer lint` and `composer analyze` all clean.

## One thing to flag

`SubsonicResponse` was already at the cyclomatic-complexity threshold, and the third shape puts it one over, so I added a `@mago-ignore` with a reason, matching the existing suppressions in `app/`. If you would rather see the XML serializer extracted into its own class instead, say so and I will do that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Empty album and artist information responses are now represented consistently as empty objects in JSON.
  * XML responses now include appropriate empty album or artist information elements when no data is available.
  * Improved serialization of object and scalar response values across supported formats.

* **Tests**
  * Added and updated coverage for empty album and artist responses in JSON and XML.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->