### PR TITLE
fix: stop requesting /null when a playing track has no cover

### DIFF
--- a/resources/assets/js/__tests__/setup.ts
+++ b/resources/assets/js/__tests__/setup.ts
@@ -2,6 +2,7 @@ import vueSnapshotSerializer from 'jest-serializer-vue'
 import { expect, vi } from 'vite-plus/test'
 import './shims/popover'
 import './shims/storage'
+import './shims/mediaSession'
 
 declare global {
   interface Window {

--- a/resources/assets/js/__tests__/shims/mediaSession.ts
+++ b/resources/assets/js/__tests__/shims/mediaSession.ts
@@ -1,0 +1,25 @@
+// jsdom implements neither navigator.mediaSession nor MediaMetadata, so the playback code that
+// reports now-playing info to the OS bails out early and cannot be asserted on. Install the
+// minimal surface that code touches.
+class MediaMetadataShim {
+  public title = ''
+  public artist = ''
+  public album = ''
+  public artwork: MediaImage[] = []
+
+  constructor(init: MediaMetadataInit = {}) {
+    Object.assign(this, init)
+  }
+}
+
+Object.defineProperty(window, 'MediaMetadata', { configurable: true, value: MediaMetadataShim })
+
+Object.defineProperty(navigator, 'mediaSession', {
+  configurable: true,
+  value: {
+    metadata: null,
+    playbackState: 'none',
+    setActionHandler: () => {},
+    setPositionState: () => {},
+  },
+})

--- a/resources/assets/js/services/QueuePlaybackService.spec.ts
+++ b/resources/assets/js/services/QueuePlaybackService.spec.ts
@@ -17,6 +17,7 @@ import { commonStore } from '@/stores/commonStore'
 import { recentlyPlayedStore } from '@/stores/recentlyPlayedStore'
 import { logger } from '@/utils/logger'
 import { playbackService } from '@/services/QueuePlaybackService'
+import { useBranding } from '@/composables/useBranding'
 
 describe('playbackService', () => {
   const h = createHarness({
@@ -364,6 +365,21 @@ describe('playbackService', () => {
     await playbackService.playFirstInQueue()
 
     expect(playMock).toHaveBeenCalledWith(songs[0])
+  })
+
+  it.each<[string, string | null]>([
+    ['the playable cover', 'https://test/cover.jpg'],
+    ['the branding cover', null],
+  ])('sets the media session artwork to %s', (_, albumCover) => {
+    const song = h.factory('song').make({ album_cover: albumCover! })
+    preferences.temporary.show_now_playing_notification = false
+
+    playbackService.showNotification(song)
+
+    const { artwork } = navigator.mediaSession.metadata!
+
+    expect(artwork).toHaveLength(8)
+    artwork!.forEach(image => expect(image.src).toBe(albumCover ?? useBranding().cover))
   })
 
   it('stops listening to media event after deactivation', () => {

--- a/resources/assets/js/services/QueuePlaybackService.ts
+++ b/resources/assets/js/services/QueuePlaybackService.ts
@@ -179,14 +179,15 @@ export class QueuePlaybackService extends BasePlaybackService {
       return
     }
 
+    const cover = getPlayableProp(playable, 'album_cover', 'episode_image') || useBranding().cover
+
     navigator.mediaSession.metadata = new MediaMetadata({
       title: playable.title,
       artist: getPlayableProp(playable, 'artist_name', 'podcast_author'),
       album: getPlayableProp(playable, 'album_name', 'podcast_title'),
       artwork: [48, 64, 96, 128, 192, 256, 384, 512].map(d => ({
-        src: getPlayableProp(playable, 'album_cover', 'episode_image'),
+        src: cover,
         sizes: `${d}x${d}`,
-        type: 'image/png',
       })),
     })
   }


### PR DESCRIPTION
## The bug

When a playing track has no cover art, the OS now-playing notification repeatedly requests `<koel-host>/null`.

`album_cover` is `null` for a track without artwork, and it was passed straight into the media session artwork:

```ts
artwork: [48, 64, 96, 128, 192, 256, 384, 512].map(d => ({
  src: getPlayableProp(playable, 'album_cover', 'episode_image'),
  ...
```

A `null` `src` gets resolved against the origin, so the notification asks the server for the page URL itself — eight times per track, once per declared size. The requests never appear in the browser console because they come from the desktop notification rather than the page.

Reported with a full diagnosis in https://github.com/koel/koel/issues/1773#issuecomment-5376907854.

## The fix

Fall back to the branding cover, matching what `ThumbnailStack` and `PlaylistThumbnail` already do for missing artwork. `useBranding()` was already imported in this file for the document title.

```ts
const cover = getPlayableProp(playable, 'album_cover', 'episode_image') || useBranding().cover
```

A coverless track now shows Koel's bird — or the admin's custom cover on Plus — in the OS notification, instead of a broken image and a stream of bogus requests.

The hardcoded `type: 'image/png'` is gone too. It was already inaccurate, since covers are served as jpg/webp, and the branding fallback is an SVG. `type` is optional in the `MediaImage` spec and browsers sniff the response anyway.

## Testing

Testing this needed a `mediaSession` shim: jsdom implements neither `navigator.mediaSession` nor `MediaMetadata`, so `showNotification()` bailed out early and the code path was unreachable. It follows the existing `__tests__/shims/storage.ts` pattern.

Reverting the fix turns the new branding-cover case red with `expected null to be '…/covers/default.svg'` — the exact `null` behind the `/null` requests.

- `QueuePlaybackService.spec.ts`: 35 passed
- Full frontend suite: 393 files, 1704 tests passed
- `vp check resources/assets`: clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Media Session notifications now display a branded cover when no album or episode artwork is available.
  - Playback notifications continue using the playable’s artwork when provided.
  - Artwork is supplied consistently across supported display sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->