### PR TITLE
fix: degrade gracefully when license validation fails

### DIFF
--- a/app/Services/License/LicenseService.php
+++ b/app/Services/License/LicenseService.php
@@ -17,9 +17,11 @@ use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
+use Saloon\Exceptions\Request\FatalRequestException;
 use Saloon\Exceptions\Request\RequestException;
 use Throwable;
 
+// @mago-ignore lint:cyclomatic-complexity
 class LicenseService implements LicenseServiceInterface
 {
     private const UNKNOWN_STATUS_CACHE_TTL_IN_MINUTES = 15;
@@ -100,13 +102,17 @@ class LicenseService implements LicenseServiceInterface
             Log::error($e);
 
             return self::cacheUnknownStatus($license);
+        } catch (FatalRequestException $e) {
+            Log::error($e);
+
+            return self::cacheUnknownStatus($license);
         } catch (DecryptException) {
             // the license key has been tampered with somehow
             return self::cacheStatus(LicenseStatus::invalid($license));
         } catch (Throwable $e) {
             Log::error($e);
 
-            return self::cacheUnknownStatus($license);
+            return LicenseStatus::unknown($license);
         }
     }
 

--- a/app/Services/License/LicenseService.php
+++ b/app/Services/License/LicenseService.php
@@ -22,6 +22,8 @@ use Throwable;
 
 class LicenseService implements LicenseServiceInterface
 {
+    private const UNKNOWN_STATUS_CACHE_TTL_IN_MINUTES = 15;
+
     public function __construct(
         private readonly LemonSqueezyConnector $connector,
         #[Config('app.key')]
@@ -95,14 +97,16 @@ class LicenseService implements LicenseServiceInterface
                 return self::cacheStatus(LicenseStatus::invalid($license));
             }
 
-            throw $e;
+            Log::error($e);
+
+            return self::cacheUnknownStatus($license);
         } catch (DecryptException) {
             // the license key has been tampered with somehow
             return self::cacheStatus(LicenseStatus::invalid($license));
         } catch (Throwable $e) {
             Log::error($e);
 
-            return LicenseStatus::unknown($license);
+            return self::cacheUnknownStatus($license);
         }
     }
 
@@ -129,6 +133,19 @@ class LicenseService implements LicenseServiceInterface
     private static function cacheStatus(LicenseStatus $status): LicenseStatus
     {
         Cache::put('license_status', $status, now()->addWeek());
+
+        return $status;
+    }
+
+    /**
+     * Cached only briefly: the validation service is expected back, and until it is, every
+     * uncached call blocks the request for the full HTTP timeout.
+     */
+    private static function cacheUnknownStatus(License $license): LicenseStatus
+    {
+        $status = LicenseStatus::unknown($license);
+
+        Cache::put('license_status', $status, now()->addMinutes(self::UNKNOWN_STATUS_CACHE_TTL_IN_MINUTES));
 
         return $status;
     }

--- a/tests/Integration/Services/License/LicenseServiceTest.php
+++ b/tests/Integration/Services/License/LicenseServiceTest.php
@@ -256,6 +256,17 @@ class LicenseServiceTest extends TestCase
         Saloon::assertSentCount(1);
     }
 
+    #[Test]
+    public function getLicenseStatusDoesNotCacheAFailureThatIsNotTheValidationService(): void
+    {
+        License::factory()->createOne();
+
+        Saloon::fake([ValidateLicenseRequest::class => MockResponse::make(body: '{"not":"a license"}')]);
+
+        self::assertSame(Status::UNKNOWN, $this->service->getStatus()->status);
+        self::assertFalse(Cache::has('license_status'));
+    }
+
     /** @return array<array{int}> */
     public static function provideInconclusiveResponseStatuses(): array
     {

--- a/tests/Integration/Services/License/LicenseServiceTest.php
+++ b/tests/Integration/Services/License/LicenseServiceTest.php
@@ -242,7 +242,7 @@ class LicenseServiceTest extends TestCase
     }
 
     #[Test]
-    public function getLicenseStatusCachesAnUnknownStatus(): void
+    public function getLicenseStatusCachesAnUnknownStatusOnlyBriefly(): void
     {
         License::factory()->createOne();
 
@@ -254,6 +254,11 @@ class LicenseServiceTest extends TestCase
         $this->service->getStatus();
 
         Saloon::assertSentCount(1);
+
+        $this->travel(16)->minutes();
+        $this->service->getStatus();
+
+        Saloon::assertSentCount(2);
     }
 
     #[Test]

--- a/tests/Integration/Services/License/LicenseServiceTest.php
+++ b/tests/Integration/Services/License/LicenseServiceTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Integration\Services\License;
 
+use App\Enums\LicenseStatus as Status;
 use App\Exceptions\FailedToActivateLicenseException;
 use App\Http\Integrations\LemonSqueezy\Requests\ActivateLicenseRequest;
 use App\Http\Integrations\LemonSqueezy\Requests\DeactivateLicenseRequest;
@@ -12,6 +13,7 @@ use App\Values\License\LicenseStatus;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\File;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Saloon\Http\Faking\MockResponse;
 use Saloon\Laravel\Facades\Saloon;
@@ -223,5 +225,46 @@ class LicenseServiceTest extends TestCase
 
         self::assertFalse($this->service->getStatus()->isValid());
         self::assertTrue(Cache::has('license_status'));
+    }
+
+    #[Test]
+    #[DataProvider('provideInconclusiveResponseStatuses')]
+    public function getLicenseStatusIsUnknownWhenValidationCannotConclude(int $responseStatus): void
+    {
+        $license = License::factory()->createOne();
+
+        Saloon::fake([ValidateLicenseRequest::class => MockResponse::make(status: $responseStatus)]);
+
+        $status = $this->service->getStatus();
+
+        self::assertSame(Status::UNKNOWN, $status->status);
+        self::assertTrue($status->license->is($license));
+    }
+
+    #[Test]
+    public function getLicenseStatusCachesAnUnknownStatus(): void
+    {
+        License::factory()->createOne();
+
+        Saloon::fake([
+            ValidateLicenseRequest::class => MockResponse::make(status: Response::HTTP_SERVICE_UNAVAILABLE),
+        ]);
+
+        $this->service->getStatus();
+        $this->service->getStatus();
+
+        Saloon::assertSentCount(1);
+    }
+
+    /** @return array<array{int}> */
+    public static function provideInconclusiveResponseStatuses(): array
+    {
+        return [
+            [Response::HTTP_TOO_MANY_REQUESTS],
+            [Response::HTTP_INTERNAL_SERVER_ERROR],
+            [Response::HTTP_BAD_GATEWAY],
+            [Response::HTTP_SERVICE_UNAVAILABLE],
+            [Response::HTTP_GATEWAY_TIMEOUT],
+        ];
     }
 }


### PR DESCRIPTION
Two defects in `LicenseService::getStatus()`, both on the path taken when the licensing service can't give a straight answer.

## An erroring validation service took the whole app down

`catch (RequestException)` treated only 400 and 404 as answers and rethrew everything else:

```php
if ($e->getStatus() === Response::HTTP_BAD_REQUEST || $e->getStatus() === Response::HTTP_NOT_FOUND) {
    return self::cacheStatus(LicenseStatus::invalid($license));
}

throw $e;
```

A 429 or any 5xx therefore propagated out through `isPlus()` and into `IndexController`, so a bad minute at the provider became a 500 on every page load.

Only a definitive 400/404 now marks a license invalid. Anything else is inconclusive: it gets logged and reported as `UNKNOWN`, exactly like a connection failure already was.

## The inconclusive status was never cached

`valid` and `invalid` both go through `cacheStatus()`. `unknown` was the one that didn't, so nothing was remembered between requests and every single one re-attempted the call and blocked for the full HTTP timeout — and wrote a stack trace while doing it.

It's now cached, but deliberately for minutes rather than the week a conclusive answer gets, so a recovered service is picked up promptly. A persistent outage costs one attempt per window instead of one per request.

## Only the validation service gets the cache

The generic `catch (Throwable)` also covers failures that have nothing to do with the provider — a write failing in `updateOrCreateLicenseFromApiResponseBody()`, or a response whose shape doesn't map. Caching those would hide a local problem for the length of the window.

So the two Saloon connector failures — `RequestException` and `FatalRequestException` — are the only ones cached. Anything else still reports `UNKNOWN` but stays uncached and is retried on the next request, exactly as it behaves on `master`.

Rethrowing those instead was considered and rejected: `isPlus()` runs on every page load, so it would reintroduce the crash this PR removes. Note also that a genuinely dead database already throws at `License::query()->latest()->first()`, which sits outside the `try`.

The extra catch clause tips the class one over the cyclomatic-complexity threshold — verified by removing it and re-running the linter — so it carries a suppression, matching the existing ones in `app/`.

## Testing

Seven cases added to `LicenseServiceTest`, which previously had no failure coverage at all. Reverting each fix turns the matching tests red: the five status cases fail by throwing (the 500 reproduced), the caching case fails on `assertSentCount(1)` seeing two requests (the retry storm reproduced), and the non-connector case fails on the status being cached.

- `LicenseServiceTest`: 17 passed
- Full backend suite: 1612 passed, 11784 assertions
- `composer cs`, `composer lint`, `composer analyze`: clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of inconclusive license-validation responses by reporting an unknown status.
  * Caches unknown statuses for 15 minutes to reduce repeated validation requests.
  * Records fatal validation-request failures while avoiding caching for unrelated failures.
  * Existing invalid-license handling and logging remain unchanged.

* **Tests**
  * Added coverage for inconclusive responses, unknown-status caching, and non-validation failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->