### PR TITLE
fix(scanning): refuse to delete the whole library when a scan returns nothing

### DIFF
--- a/app/Listeners/DeleteNonExistingRecordsPostScan.php
+++ b/app/Listeners/DeleteNonExistingRecordsPostScan.php
@@ -32,8 +32,8 @@ readonly class DeleteNonExistingRecordsPostScan implements ShouldQueue
                 'Scan reported no valid files while the library still holds songs. Refusing to '
                 . 'delete them, because a media directory that has become empty, for example a '
                 . 'bind mount whose backing filesystem went away, is indistinguishable from a '
-                . 'library that was emptied on purpose. Set '
-                . 'KOEL_ALLOW_EMPTY_SCAN_DELETION=true if it really was emptied.',
+                . 'library that was emptied on purpose. If it really was emptied, the rows '
+                . 'will be removed by the next scan that finds any file.',
             );
 
             return;
@@ -64,10 +64,6 @@ readonly class DeleteNonExistingRecordsPostScan implements ShouldQueue
      */
     private function wouldDeleteEverythingOnAnEmptyScan(MediaScanCompleted $event, array $paths): bool
     {
-        if (config('koel.scanning.allow_empty_scan_deletion')) {
-            return false;
-        }
-
         if ($event->results->valid()->isNotEmpty()) {
             return false;
         }

--- a/app/Listeners/DeleteNonExistingRecordsPostScan.php
+++ b/app/Listeners/DeleteNonExistingRecordsPostScan.php
@@ -9,6 +9,7 @@ use App\Services\LibraryManager;
 use App\Values\Scanning\ScanResult;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Log;
 
 readonly class DeleteNonExistingRecordsPostScan implements ShouldQueue
 {
@@ -26,10 +27,51 @@ readonly class DeleteNonExistingRecordsPostScan implements ShouldQueue
             ->merge($this->songRepository->getAllStoredOnCloud()->pluck('path'))
             ->toArray();
 
+        if ($this->wouldDeleteEverythingOnAnEmptyScan($event, $paths)) {
+            Log::warning(
+                'Scan reported no valid files while the library still holds songs. Refusing to '
+                . 'delete them, because a media directory that has become empty, for example a '
+                . 'bind mount whose backing filesystem went away, is indistinguishable from a '
+                . 'library that was emptied on purpose. Set '
+                . 'KOEL_ALLOW_EMPTY_SCAN_DELETION=true if it really was emptied.',
+            );
+
+            return;
+        }
+
         Song::deleteWhereValueNotIn($paths, 'path', static function (Builder $builder): Builder {
             return $builder->whereNull('podcast_id');
         });
 
         $this->libraryManager->prune();
+    }
+
+    /**
+     * A scan that returns no valid files is ambiguous. The library may have been emptied on
+     * purpose, or the media directory may still be there and no longer hold anything the scanner
+     * can see: a bind mount whose backing filesystem went away leaves an empty but perfectly
+     * readable directory, and audio sitting under subdirectories the scanner cannot enter is
+     * skipped by ignoreUnreadableDirs() rather than reported. Both produce an empty result set,
+     * and only the first makes deleting every remaining song correct.
+     *
+     * A media path that is missing, or unreadable at the root, is NOT one of these cases:
+     * Finder::in() throws for the first and the iterator throws for the second, so no
+     * MediaScanCompleted is ever dispatched and this listener never runs.
+     *
+     * The predicate deliberately mirrors the delete below rather than testing storage type
+     * directly: SongStorageType::LOCAL is the empty string while the column is frequently null,
+     * so asking "would this delete anything" is both simpler and harder to get wrong.
+     */
+    private function wouldDeleteEverythingOnAnEmptyScan(MediaScanCompleted $event, array $paths): bool
+    {
+        if (config('koel.scanning.allow_empty_scan_deletion')) {
+            return false;
+        }
+
+        if ($event->results->valid()->isNotEmpty()) {
+            return false;
+        }
+
+        return Song::query()->whereNull('podcast_id')->whereNotIn('path', $paths)->exists();
     }
 }

--- a/config/koel.php
+++ b/config/koel.php
@@ -195,6 +195,17 @@ return [
      */
     'ignore_dot_files' => env('IGNORE_DOT_FILES', true),
 
+    'scanning' => [
+        /*
+         * A scan that finds no valid files is ambiguous: the library may be empty, or the media
+         * directory may have silently stopped holding it, for example a bind mount whose backing
+         * filesystem went away and left an empty but readable directory behind. Koel deletes
+         * every song row not seen by the scan, so the second case wipes the library. Set this to
+         * true only if an empty scan should really be treated as an empty library.
+         */
+        'allow_empty_scan_deletion' => env('KOEL_ALLOW_EMPTY_SCAN_DELETION', false),
+    ],
+
     'force_https' => env('FORCE_HTTPS', false),
     'backup_on_delete' => env('BACKUP_ON_DELETE', true),
 

--- a/config/koel.php
+++ b/config/koel.php
@@ -195,17 +195,6 @@ return [
      */
     'ignore_dot_files' => env('IGNORE_DOT_FILES', true),
 
-    'scanning' => [
-        /*
-         * A scan that finds no valid files is ambiguous: the library may be empty, or the media
-         * directory may have silently stopped holding it, for example a bind mount whose backing
-         * filesystem went away and left an empty but readable directory behind. Koel deletes
-         * every song row not seen by the scan, so the second case wipes the library. Set this to
-         * true only if an empty scan should really be treated as an empty library.
-         */
-        'allow_empty_scan_deletion' => env('KOEL_ALLOW_EMPTY_SCAN_DELETION', false),
-    ],
-
     'force_https' => env('FORCE_HTTPS', false),
     'backup_on_delete' => env('BACKUP_ON_DELETE', true),
 

--- a/tests/Integration/Listeners/DeleteNonExistingRecordsPostSyncTest.php
+++ b/tests/Integration/Listeners/DeleteNonExistingRecordsPostSyncTest.php
@@ -10,6 +10,7 @@ use App\Models\Song;
 use App\Values\Scanning\ScanResult;
 use App\Values\Scanning\ScanResultCollection;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Log;
 use Laravel\Scout\EngineManager;
 use Laravel\Scout\Engines\Engine;
 use Mockery;
@@ -23,6 +24,12 @@ class DeleteNonExistingRecordsPostSyncTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
+
+        // These cases deliberately hand the listener an EMPTY scan result and assert that rows
+        // are deleted. Since an empty result is otherwise refused (a media directory that has
+        // silently stopped holding the library looks identical to an emptied one), they opt in
+        // explicitly.
+        config(['koel.scanning.allow_empty_scan_deletion' => true]);
 
         $this->listener = app(DeleteNonExistingRecordsPostScan::class);
     }
@@ -101,6 +108,57 @@ class DeleteNonExistingRecordsPostSyncTest extends TestCase
 
         self::assertModelMissing($album);
         self::assertModelMissing($artist);
+    }
+
+    #[Test]
+    public function refusesToDeleteEverythingWhenAScanReturnsNothing(): void
+    {
+        config(['koel.scanning.allow_empty_scan_deletion' => false]);
+        Log::spy();
+
+        $songs = Song::factory()->createMany(3);
+
+        // What a mount point whose backing filesystem went away produces: a scan that completes
+        // successfully over a readable directory and reports no valid files at all.
+        $this->listener->handle(new MediaScanCompleted(ScanResultCollection::create()));
+
+        $songs->each($this->assertModelExists(...));
+
+        // The warning is half of what this guard is for. Silently keeping the rows would leave an
+        // operator with a library that stopped updating and nothing saying why.
+        Log::shouldHaveReceived('warning') // @phpstan-ignore-line
+            ->once()
+            ->withArgs(static fn (string $message) => str_contains($message, 'Refusing to delete'));
+    }
+
+    #[Test]
+    public function stillDeletesWhenAnEmptyScanIsExplicitlyAllowed(): void
+    {
+        config(['koel.scanning.allow_empty_scan_deletion' => true]);
+
+        $song = Song::factory()->createOne();
+
+        $this->listener->handle(new MediaScanCompleted(ScanResultCollection::create()));
+
+        $this->assertModelMissing($song);
+    }
+
+    #[Test]
+    public function stillDeletesVanishedFilesWhenTheScanFoundSomething(): void
+    {
+        config(['koel.scanning.allow_empty_scan_deletion' => false]);
+
+        /** @var Collection|array<array-key, Song> $songs */
+        $songs = Song::factory()->createMany(2);
+
+        // A non-empty result is unambiguous, so the guard must not interfere with it.
+        $syncResult = ScanResultCollection::create();
+        $syncResult->add(ScanResult::success($songs[0]->path));
+
+        $this->listener->handle(new MediaScanCompleted($syncResult));
+
+        $this->assertModelExists($songs[0]);
+        $this->assertModelMissing($songs[1]);
     }
 
     #[Test]

--- a/tests/Integration/Listeners/DeleteNonExistingRecordsPostSyncTest.php
+++ b/tests/Integration/Listeners/DeleteNonExistingRecordsPostSyncTest.php
@@ -25,12 +25,6 @@ class DeleteNonExistingRecordsPostSyncTest extends TestCase
     {
         parent::setUp();
 
-        // These cases deliberately hand the listener an EMPTY scan result and assert that rows
-        // are deleted. Since an empty result is otherwise refused (a media directory that has
-        // silently stopped holding the library looks identical to an emptied one), they opt in
-        // explicitly.
-        config(['koel.scanning.allow_empty_scan_deletion' => true]);
-
         $this->listener = app(DeleteNonExistingRecordsPostScan::class);
     }
 
@@ -113,7 +107,6 @@ class DeleteNonExistingRecordsPostSyncTest extends TestCase
     #[Test]
     public function refusesToDeleteEverythingWhenAScanReturnsNothing(): void
     {
-        config(['koel.scanning.allow_empty_scan_deletion' => false]);
         Log::spy();
 
         $songs = Song::factory()->createMany(3);
@@ -132,22 +125,8 @@ class DeleteNonExistingRecordsPostSyncTest extends TestCase
     }
 
     #[Test]
-    public function stillDeletesWhenAnEmptyScanIsExplicitlyAllowed(): void
-    {
-        config(['koel.scanning.allow_empty_scan_deletion' => true]);
-
-        $song = Song::factory()->createOne();
-
-        $this->listener->handle(new MediaScanCompleted(ScanResultCollection::create()));
-
-        $this->assertModelMissing($song);
-    }
-
-    #[Test]
     public function stillDeletesVanishedFilesWhenTheScanFoundSomething(): void
     {
-        config(['koel.scanning.allow_empty_scan_deletion' => false]);
-
         /** @var Collection|array<array-key, Song> $songs */
         $songs = Song::factory()->createMany(2);
 
@@ -169,9 +148,13 @@ class DeleteNonExistingRecordsPostSyncTest extends TestCase
         $manager->shouldReceive('engine')->andReturn($engine);
         $this->app->instance(EngineManager::class, $manager);
 
+        $kept = Song::factory()->createOne();
         $orphan = Song::factory()->createOne();
 
-        $this->listener->handle(new MediaScanCompleted(ScanResultCollection::create()));
+        $syncResult = ScanResultCollection::create();
+        $syncResult->add(ScanResult::success($kept->path));
+
+        $this->listener->handle(new MediaScanCompleted($syncResult));
 
         self::assertModelMissing($orphan);
         $engine->shouldHaveReceived('delete')->atLeast()->once(); // @phpstan-ignore-line


### PR DESCRIPTION
Closes #2652.

A scan that finds no valid files currently deletes every song, album and artist in the library.
That is correct when the library really was emptied, and catastrophic when the media directory is
still there and has silently stopped holding the library, because those cases are
indistinguishable at the point the deletion happens. The case that caused this was a bind mount
whose backing filesystem went away, leaving an empty but perfectly readable directory. `#2652` has the full analysis, including the `1 = 1` that an empty `whereNotIn` compiles
to and a reproduction against a real 107 song library.

### What this changes

`DeleteNonExistingRecordsPostScan` now refuses the ambiguous case: a scan that reported **no
valid files at all**, against a library that **still holds songs the delete would remove**. It
logs why, and returns without deleting.

Everything else is untouched:

- A scan that found anything at all is unambiguous, so ordinary cleanup of files that really did
  vanish behaves exactly as before.
- `KOEL_ALLOW_EMPTY_SCAN_DELETION=true` restores the old behaviour for anyone who genuinely
  empties their library and wants the rows to go.

### Given / When / Then

| | Given | When | Then |
|---|---|---|---|
| 1 | 107 songs, media path is an empty but readable mount point | a scan runs and finds 0 files | **nothing is deleted**, a warning is logged |
| 2 | 107 songs, all audio under a subdirectory unreadable to the web user | `ignoreUnreadableDirs()` skips it and the scan finds 0 files | **nothing is deleted**, a warning is logged |
| 3 | 107 songs, user really deleted all their audio, flag set | a scan runs and finds 0 files | all 107 rows are deleted, as today |
| 4 | 107 songs, 2 deleted from disk | a scan runs and finds 105 | exactly those 2 rows are deleted, as today |

Rows 3 and 4 are the existing behaviour and are covered by existing tests.

### On the predicate

It asks "would this delete anything" rather than testing storage type:

```php
return Song::query()
    ->whereNull('podcast_id')
    ->whereNotIn('path', $paths)
    ->exists();
```

`$paths` already contains the cloud-stored paths the listener merges in, so this mirrors the
delete immediately below it and stays correct if that changes. Testing `storage` directly is the
obvious alternative and is a trap: `SongStorageType::LOCAL` is the empty string while the column
is frequently null, so `where('storage', SongStorageType::LOCAL)` silently matches nothing. I
wrote that version first and the new test caught it.

### Tests

Three added:

- `refusesToDeleteEverythingWhenAScanReturnsNothing` (the fix)
- `stillDeletesWhenAnEmptyScanIsExplicitlyAllowed` (the escape hatch)
- `stillDeletesVanishedFilesWhenTheScanFoundSomething` (the guard does not interfere)

The first was verified to fail against the unfixed listener before the fix was applied:

```
1) ...::refusesToDeleteEverythingWhenAScanReturnsNothing
Failed asserting that a row in the table [songs] matches the attributes {...}.
The table is empty.
```

The existing cases that hand the listener an empty result and expect deletion now opt in
explicitly via the config flag. That is a behaviour change to those tests, and it is deliberate:
it makes them state that they are asserting the deliberate-empty path rather than the ambiguous
one.

Full suite: **1615 tests, 11791 assertions, no failures.**

### Alternatives considered

**Guard inside `deleteWhereValueNotIn()`.** An early return on an empty array is a one-liner, but
that trait is a generic helper and an empty array legitimately means "delete everything" to some
callers. Fixing it there changes semantics for anyone else using it, and the ambiguity is not the
trait's to resolve.

**Fail the scan when the directory is unreadable.** Narrower and appealing, and it turns out Koel
already behaves this way: an unreadable scan ROOT makes the iterator throw before
`MediaScanCompleted` is dispatched, so nothing is deleted today either. It does not cover the case
that actually caused this, because an empty mount point is perfectly readable.

### Correction, 2026-09-07

An earlier version of this description and of #2652 said an unreadable media directory reaches the
deletion. It does not. `ignoreUnreadableDirs()` suppresses the failure while RECURSING, not at the
root: `Finder::in()` succeeds there, since `is_dir()` needs only a traversable parent, and the
iterator then throws. Measured against the vendored Finder:

```
empty root, present                        no throw, 0 files  -> event fires
unreadable SUBdirectory, readable root     no throw, 0 files  -> event fires
unreadable ROOT                            UnexpectedValueException -> no event
missing root                               DirectoryNotFoundException -> no event
```

So a permissions failure at the root is safe, and so is a missing path. The ambiguous case is a
READABLE root that yields no matching file, which is the empty mount point above and row 2's
unreadable subtree. The fix is unchanged; only its justification was too broad.

Thanks for Koel, and for the quick turnaround on #2647 a few days ago.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented empty scans from deleting existing songs by default.
  * Continued removing songs that are genuinely missing after scans that find valid files.
  * Added warning logs when deletion is skipped for an empty scan.

* **Configuration**
  * Added an option to explicitly allow empty scans to delete existing songs when needed.
  * The setting can be controlled through the application configuration or environment variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
