### PR TITLE
ci: run the workflow security checks continuously

### DIFF
--- a/.github/workflows/plumber.yml
+++ b/.github/workflows/plumber.yml
@@ -1,0 +1,34 @@
+name: Plumber
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  plumber:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write
+      # Needed by score-push to publish the score for the README badge.
+      id-token: write
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      - uses: getplumber/plumber@e815e0bff47f9170e8e0a056df0a851124634ae2 # v0.4.51
+        with:
+          # Code scanning upload needs security-events write, which PRs
+          # from forks do not get. The report stays available as a
+          # workflow artifact there.
+          upload-sarif: ${{ github.event.pull_request.head.repo.fork != true }}
+          # Publishes the score to score.getplumber.io, which feeds the
+          # badge in the README. A failed push never fails the run.
+          score-push: true
+          # Gate at 85 points instead of the all-or-nothing default,
+          # leaves room for a small finding without blocking PRs.
+          min-points: 85

--- a/.plumber.yaml
+++ b/.plumber.yaml
@@ -1,0 +1,16 @@
+# Plumber overlay: inherits every control from the CLI's built-in
+# baseline, only the differences for this repo are written here.
+# Run 'plumber config resolve' to see the full effective config.
+extends: plumber:default
+version: '2.0'
+
+github:
+  controls:
+    githubActionMustComeFromAuthorizedSources:
+      # Keep the curated default list and trust the PHP toolchain and
+      # release actions this repo already uses on top of it.
+      includePlumberDefaults: true
+      trustedGithubActions:
+        - ramsey/composer-install
+        - shivammathur/setup-php
+        - softprops/action-gh-release

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# koel [![Frontend Unit Tests](https://github.com/koel/koel/actions/workflows/unit-frontend.yml/badge.svg)](https://github.com/koel/koel/actions/workflows/unit-frontend.yml) ![Code Quality](https://scrutinizer-ci.com/g/phanan/koel/badges/quality-score.png?b=master) [![OpenCollective](https://opencollective.com/koel/backers/badge.svg)](#sponsors-and-backers) [![OpenCollective](https://opencollective.com/koel/sponsors/badge.svg)](#sponsors-and-backers)
+# koel [![Frontend Unit Tests](https://github.com/koel/koel/actions/workflows/unit-frontend.yml/badge.svg)](https://github.com/koel/koel/actions/workflows/unit-frontend.yml) ![Code Quality](https://scrutinizer-ci.com/g/phanan/koel/badges/quality-score.png?b=master) [![Plumber Score](https://score.getplumber.io/github.com/koel/koel.svg)](https://score.getplumber.io/github.com/koel/koel) [![OpenCollective](https://opencollective.com/koel/backers/badge.svg)](#sponsors-and-backers) [![OpenCollective](https://opencollective.com/koel/sponsors/badge.svg)](#sponsors-and-backers)
 
 ![Showcase](https://user-images.githubusercontent.com/8056274/115028055-bc02a280-9ec4-11eb-991c-69cd2a45b69c.png)
 


### PR DESCRIPTION
Follows up on #2645.

This is the follow-up I mentioned there: a small workflow running the [Plumber](https://github.com/getplumber/plumber) CLI on pushes to master and on PRs, so the pins and token scopes from #2645 stay the way you merged them. Gated at 85 points, one small finding never blocks a PR.

It also publishes a score badge, Scorecard-style: badge shows master, a failed publish never fails CI, no token needed, gray until the first run. Dropping the `score-push` line removes the badge and keeps the check.

I work on Plumber, same disclosure as in the comment. If you would rather not carry the tool, no hard feelings, close it and the hardening stays as is.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Added automated workflow checks for repository security and supply-chain risks.
  - Configured trusted-source controls for approved GitHub Actions.
  - Added a minimum security score threshold and reporting for eligible pull requests.

- **Documentation**
  - Added a Plumber security score badge to the README, linking to the project’s score details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->