### PR TITLE
fix: restore SSO login callbacks

### DIFF
--- a/resources/assets/js/composables/useSsoLogin.spec.ts
+++ b/resources/assets/js/composables/useSsoLogin.spec.ts
@@ -3,6 +3,7 @@ import { createHarness } from '@/__tests__/TestHarness'
 import { useSsoLogin } from './useSsoLogin'
 
 const openPopupMock = vi.fn()
+const token: CompositeToken = { token: 'api-token', 'audio-token': 'audio-token' }
 
 vi.mock('@/utils/helpers', async importOriginal => ({
   ...(await importOriginal<typeof import('@/utils/helpers')>()),
@@ -34,9 +35,11 @@ describe('useSsoLogin', () => {
   }
 
   it('opens the popup at the redirect URL', () => {
-    start()
+    const { popup } = start()
 
     expect(openPopupMock).toHaveBeenCalledWith('/auth/oidc/redirect', 'OpenID Login', 768, 640, window)
+
+    post(token, window.location.origin, popup)
   })
 
   it('throws when the popup cannot be opened', () => {
@@ -47,43 +50,52 @@ describe('useSsoLogin', () => {
     expect(() => startSsoLogin('/auth/oidc/redirect', 'OpenID Login', vi.fn())).toThrow()
   })
 
-  it('accepts a token posted by the popup it opened', () => {
+  it('accepts a composite token posted by the popup it opened', () => {
     const { onToken, popup } = start()
 
-    post('the-token', window.location.origin, popup)
+    post(token, window.location.origin, popup)
 
-    expect(onToken).toHaveBeenCalledWith('the-token')
+    expect(onToken).toHaveBeenCalledWith(token)
   })
 
   it('ignores a token posted from a foreign origin', () => {
     const { onToken, popup } = start()
 
-    post('forged-token', 'https://evil.test', popup)
+    post(token, 'https://evil.test', popup)
 
     expect(onToken).not.toHaveBeenCalled()
+
+    post(token, window.location.origin, popup)
+    expect(onToken).toHaveBeenCalledWith(token)
   })
 
   it('ignores a token posted by a window it did not open', () => {
-    const { onToken } = start()
-
-    post('forged-token', window.location.origin, openForeignWindow())
-
-    expect(onToken).not.toHaveBeenCalled()
-  })
-
-  it('ignores a non-string payload', () => {
     const { onToken, popup } = start()
 
-    post({ token: 'the-token' }, window.location.origin, popup)
+    post(token, window.location.origin, openForeignWindow())
 
     expect(onToken).not.toHaveBeenCalled()
+
+    post(token, window.location.origin, popup)
+    expect(onToken).toHaveBeenCalledWith(token)
+  })
+
+  it('ignores an invalid composite token payload', () => {
+    const { onToken, popup } = start()
+
+    post({ token: 'api-token' }, window.location.origin, popup)
+
+    expect(onToken).not.toHaveBeenCalled()
+
+    post(token, window.location.origin, popup)
+    expect(onToken).toHaveBeenCalledWith(token)
   })
 
   it('stops listening once a token has been accepted', () => {
     const { onToken, popup } = start()
 
-    post('the-token', window.location.origin, popup)
-    post('second-token', window.location.origin, popup)
+    post(token, window.location.origin, popup)
+    post({ token: 'second-api-token', 'audio-token': 'second-audio-token' }, window.location.origin, popup)
 
     expect(onToken).toHaveBeenCalledOnce()
   })

--- a/resources/assets/js/composables/useSsoLogin.ts
+++ b/resources/assets/js/composables/useSsoLogin.ts
@@ -3,7 +3,7 @@ import { openPopup } from '@/utils/helpers'
 export const useSsoLogin = () => {
   let stopListening = () => {}
 
-  const startSsoLogin = (redirectUrl: string, popupName: string, onToken: (token: string) => void) => {
+  const startSsoLogin = (redirectUrl: string, popupName: string, onToken: (token: CompositeToken) => void) => {
     stopListening()
 
     const popup = openPopup(redirectUrl, popupName, 768, 640, window)
@@ -20,7 +20,7 @@ export const useSsoLogin = () => {
         return
       }
 
-      if (typeof message.data !== 'string') {
+      if (typeof message.data?.token !== 'string' || typeof message.data?.['audio-token'] !== 'string') {
         return
       }
 


### PR DESCRIPTION
## Description

Restores Google and OpenID Connect popup login by accepting the composite token object sent by Koel's SSO callback page.

The handler now:

- expects a `CompositeToken`;
- validates both `token` and `audio-token`;
- preserves the same-origin and popup-source checks introduced in #2642;
- preserves one-shot listener cleanup after the first valid callback.

The regression tests now use the payload produced by the backend and cover malformed payloads, foreign origins, unexpected windows, and one-shot listener cleanup.

## Motivation

The backend SSO controllers pass `CompositeToken::toArray()` to the callback view. The resulting `postMessage` payload is an object, but the frontend handler introduced in #2642 accepted only strings, so every successful Google or OpenID Connect callback was silently ignored.

Fixes #2657.

## Screenshots (if applicable)

Not applicable.

## Checklist

- [x] I've tested my changes thoroughly and added tests where applicable
- [x] I've updated relevant documentation (if any)
- [x] My code follows the project's conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated SSO login handling to accept composite authentication tokens containing both standard and audio token values.
  - Improved message validation to reject incomplete or invalid authentication data.
  - Valid login responses continue to be accepted after invalid or rejected messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->