### PR TITLE
fix: keep koel:init going when storage cannot be linked

### DIFF
--- a/app/Console/Commands/InitCommand.php
+++ b/app/Console/Commands/InitCommand.php
@@ -8,6 +8,7 @@ use App\Models\Setting;
 use App\Models\User;
 use App\Repositories\UserRepository;
 use App\Services\DotenvEditor;
+use App\Services\PublicStorageLinker;
 use Illuminate\Console\Command;
 use Illuminate\Encryption\Encrypter;
 use Illuminate\Support\Facades\Artisan;
@@ -34,6 +35,7 @@ class InitCommand extends Command
     public function __construct(
         private readonly UserRepository $userRepository,
         private readonly DotenvEditor $dotenvEditor,
+        private readonly PublicStorageLinker $publicStorageLinker,
     ) {
         parent::__construct();
     }
@@ -267,17 +269,13 @@ class InitCommand extends Command
 
     private function linkStorage(): void
     {
-        $result = self::SUCCESS;
+        $linked = false;
 
-        $this->components->task('Linking storage', static function () use (&$result): void {
-            $result = Artisan::call('storage:link', [
-                '--quiet' => true,
-                '--relative' => true,
-                '--force' => true,
-            ]);
+        $this->components->task('Linking storage', function () use (&$linked): void {
+            $linked = $this->publicStorageLinker->link();
         });
 
-        if ($result !== self::SUCCESS) {
+        if (!$linked) {
             $this->components->warn('Failed to link storage. Album and artist images may not load until you run '
             . '`php artisan storage:link` manually.');
         }

--- a/app/Services/PublicStorageLinker.php
+++ b/app/Services/PublicStorageLinker.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Artisan;
+
+class PublicStorageLinker
+{
+    public function link(): bool
+    {
+        if ($this->linkIsUpToDate()) {
+            return true;
+        }
+
+        return rescue(
+            static fn (): bool => Artisan::call('storage:link', [
+                '--quiet' => true,
+                '--relative' => true,
+                '--force' => true,
+            ]) === Command::SUCCESS,
+            false,
+        );
+    }
+
+    private function linkIsUpToDate(): bool
+    {
+        $link = public_path('storage');
+        $target = realpath(storage_path('app/public'));
+
+        return is_link($link) && $target !== false && realpath($link) === $target;
+    }
+}

--- a/tests/Unit/Services/PublicStorageLinkerTest.php
+++ b/tests/Unit/Services/PublicStorageLinkerTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\PublicStorageLinker;
+use ErrorException;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use Mockery;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class PublicStorageLinkerTest extends TestCase
+{
+    private string $root;
+    private string $link;
+    private string $target;
+    private PublicStorageLinker $linker;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->root = sys_get_temp_dir() . '/koel_storage_link_' . Str::random();
+        $this->link = $this->root . '/public/storage';
+        $this->target = $this->root . '/storage/app/public';
+
+        File::ensureDirectoryExists($this->root . '/public');
+        File::ensureDirectoryExists($this->target);
+
+        app()->usePublicPath($this->root . '/public');
+        app()->useStoragePath($this->root . '/storage');
+        config(['filesystems.links' => [$this->link => $this->target]]);
+
+        $this->linker = new PublicStorageLinker();
+    }
+
+    public function tearDown(): void
+    {
+        File::deleteDirectory($this->root);
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function createsRelativeLinkWhenMissing(): void
+    {
+        self::assertTrue($this->linker->link());
+
+        self::assertTrue(is_link($this->link));
+        self::assertSame(realpath($this->target), realpath($this->link));
+        self::assertStringStartsNotWith('/', readlink($this->link));
+    }
+
+    #[Test]
+    public function recreatesLinkResolvingElsewhere(): void
+    {
+        File::ensureDirectoryExists($this->root . '/somewhere-else');
+        symlink($this->root . '/somewhere-else', $this->link);
+
+        self::assertTrue($this->linker->link());
+
+        self::assertSame(realpath($this->target), realpath($this->link));
+    }
+
+    #[Test]
+    public function recreatesDanglingLink(): void
+    {
+        symlink($this->root . '/gone', $this->link);
+
+        self::assertTrue($this->linker->link());
+
+        self::assertSame(realpath($this->target), realpath($this->link));
+    }
+
+    #[Test]
+    public function leavesUpToDateLinkUntouched(): void
+    {
+        symlink($this->target, $this->link);
+
+        Artisan::partialMock()->shouldNotReceive('call')->with('storage:link', Mockery::any());
+
+        self::assertTrue($this->linker->link());
+        self::assertSame($this->target, readlink($this->link));
+    }
+
+    #[Test]
+    public function returnsFalseWhenLinkingThrows(): void
+    {
+        Artisan::partialMock()
+            ->shouldReceive('call')
+            ->once()
+            ->with('storage:link', Mockery::any())
+            ->andThrow(new ErrorException('symlink(): File exists'));
+
+        self::assertFalse($this->linker->link());
+    }
+}

--- a/tests/Unit/Services/PublicStorageLinkerTest.php
+++ b/tests/Unit/Services/PublicStorageLinkerTest.php
@@ -75,7 +75,7 @@ class PublicStorageLinkerTest extends TestCase
     }
 
     #[Test]
-    public function leavesUpToDateLinkUntouched(): void
+    public function leavesUpToDateAbsoluteLinkUntouched(): void
     {
         symlink($this->target, $this->link);
 
@@ -83,6 +83,17 @@ class PublicStorageLinkerTest extends TestCase
 
         self::assertTrue($this->linker->link());
         self::assertSame($this->target, readlink($this->link));
+    }
+
+    #[Test]
+    public function leavesUpToDateRelativeLinkUntouched(): void
+    {
+        symlink('../storage/app/public', $this->link);
+
+        Artisan::partialMock()->shouldNotReceive('call')->with('storage:link', Mockery::any());
+
+        self::assertTrue($this->linker->link());
+        self::assertSame('../storage/app/public', readlink($this->link));
     }
 
     #[Test]


### PR DESCRIPTION
Fixes #2660.

## The problem

`--force` (added in #2644) makes `storage:link` skip its "link already exists" early return and delete-then-recreate `public/storage` on every run. Where `public/` isn't writable by the user running the command, `Filesystem::delete()` fails silently (it uses `@unlink`), and the subsequent `relativeLink()` hits `EEXIST` and raises an `ErrorException`.

That exception aborts the whole install/upgrade — migrations, seeding and everything after it — over a cosmetic step.

`linkStorage()` looks like it already handles failure gracefully:

```php
if ($result !== self::SUCCESS) {
    $this->components->warn('Failed to link storage. …');
}
```

but that branch was dead code: `StorageLinkCommand::handle()` returns `void`, so `Artisan::call()` yields `0` regardless. A failing `storage:link` can only ever surface as a thrown exception, never as a non-zero exit code.

Reported against Cloudron, where `/app/code` is a read-only image and `public/storage` is symlinked into a persistent volume — the link resolves fine, and `koel:init` still refuses to start the app because it can't rewrite it.

## The fix

A small `PublicStorageLinker` service now owns the decision:

- **Skip the relink when the existing link already resolves to `storage/app/public`.** This is what fixes read-only installs — no write is attempted because none is needed. It also stops churning a working symlink on every upgrade.
- **`rescue()` around the Artisan call**, so a failure degrades to the warning the command always intended. The underlying error is still reported to `laravel.log`.

An existing link is considered up to date whether it's absolute or relative, as long as it resolves to the right target. #2644's actual problem — release archives shipping a link to the build machine's path — is a *dangling* link, which fails the check and gets recreated as before.

## Tests

`PublicStorageLinkerTest` covers creating a relative link from scratch, recreating a link that resolves elsewhere, recreating a dangling link, leaving an up-to-date link untouched, and returning `false` instead of throwing when linking fails.

Checked against the pre-fix code: the last two fail (the failure case with the exact `ErrorException` from the issue) while the three covering #2644's behaviour pass in both versions.
