### PR TITLE
feat: allow favoriting a song straight from the home screen

### DIFF
--- a/resources/assets/js/components/screens/home/PlayableCard.spec.ts
+++ b/resources/assets/js/components/screens/home/PlayableCard.spec.ts
@@ -1,6 +1,7 @@
 import { screen } from '@testing-library/vue'
 import { describe, expect, it, vi } from 'vite-plus/test'
 import { createHarness } from '@/__tests__/TestHarness'
+import { playableStore } from '@/stores/playableStore'
 
 const isCachedMock = vi.fn().mockReturnValue(false)
 const isCachingMock = vi.fn().mockReturnValue(false)
@@ -41,7 +42,10 @@ describe('playableCard.vue', () => {
       ...overrides,
     })
 
-    return h.render(Component, { props: { playable: song } })
+    return {
+      ...h.render(Component, { props: { playable: song } }),
+      props: { playable: song },
+    }
   }
 
   it('renders song info', () => {
@@ -89,6 +93,20 @@ describe('playableCard.vue', () => {
     renderCard()
     screen.getByTitle('Caching for offline playback')
     expect(screen.queryByTitle('Available offline')).toBeNull()
+  })
+
+  it('toggles favorite state when the Favorite button is clicked', async () => {
+    const toggleFavoriteMock = h.mock(playableStore, 'toggleFavorite')
+    const { props } = renderCard({ favorite: false })
+
+    await h.user.click(screen.getByRole('button', { name: 'Favorite' }))
+
+    expect(toggleFavoriteMock).toHaveBeenCalledWith(props.playable)
+  })
+
+  it('renders the button as undo-able for a favorite song', () => {
+    renderCard({ favorite: true })
+    screen.getByRole('button', { name: 'Undo Favorite' })
   })
 
   it('shows error icon when caching fails', () => {

--- a/resources/assets/js/components/screens/home/PlayableCard.spec.ts
+++ b/resources/assets/js/components/screens/home/PlayableCard.spec.ts
@@ -7,6 +7,11 @@ const isCachedMock = vi.fn().mockReturnValue(false)
 const isCachingMock = vi.fn().mockReturnValue(false)
 const hasCachingErrorMock = vi.fn().mockReturnValue(false)
 const getCachingErrorMock = vi.fn().mockReturnValue(undefined)
+const playMock = vi.fn()
+
+vi.mock('@/services/playbackManager', () => ({
+  playback: () => ({ play: playMock, pause: vi.fn(), resume: vi.fn() }),
+}))
 
 vi.mock('@/composables/useOfflinePlayback', () => ({
   useOfflinePlayback: () => ({
@@ -30,6 +35,7 @@ describe('playableCard.vue', () => {
       hasCachingErrorMock.mockReturnValue(false)
       getCachingErrorMock.mockClear()
       getCachingErrorMock.mockReturnValue(undefined)
+      playMock.mockClear()
     },
   })
 
@@ -102,6 +108,26 @@ describe('playableCard.vue', () => {
     await h.user.click(screen.getByRole('button', { name: 'Favorite' }))
 
     expect(toggleFavoriteMock).toHaveBeenCalledWith(props.playable)
+  })
+
+  it('toggles favorite without starting playback when the button is activated with Enter', async () => {
+    const toggleFavoriteMock = h.mock(playableStore, 'toggleFavorite')
+    const { props } = renderCard({ favorite: false })
+
+    screen.getByRole('button', { name: 'Favorite' }).focus()
+    await h.user.keyboard('{Enter}')
+
+    expect(toggleFavoriteMock).toHaveBeenCalledWith(props.playable)
+    expect(playMock).not.toHaveBeenCalled()
+  })
+
+  it('plays the song when the card itself is activated with Enter', async () => {
+    const { props } = renderCard()
+
+    screen.getByTestId('song-card').focus()
+    await h.user.keyboard('{Enter}')
+
+    expect(playMock).toHaveBeenCalledWith(props.playable)
   })
 
   it('renders the button as undo-able for a favorite song', () => {

--- a/resources/assets/js/components/screens/home/PlayableCard.vue
+++ b/resources/assets/js/components/screens/home/PlayableCard.vue
@@ -6,7 +6,7 @@
     draggable="true"
     tabindex="0"
     @dblclick="play"
-    @keydown.enter.prevent="play"
+    @keydown.enter.self.prevent="play"
     @dragstart="onDragStart"
     @contextmenu.prevent="onContextMenu"
   >

--- a/resources/assets/js/components/screens/home/PlayableCard.vue
+++ b/resources/assets/js/components/screens/home/PlayableCard.vue
@@ -32,8 +32,18 @@
       </span>
       <span class="block truncate text-k-fg-50 text-[0.9rem]">{{ artist }}</span>
     </span>
-    <span class="text-k-fg-50 text-[0.9rem] tabular-nums">
-      {{ fmtLength }}
+    <span class="flex flex-col items-end gap-1">
+      <FavoriteButton
+        :favorite="playable.favorite"
+        class="text-k-fg-50 hover:text-k-fg transition-opacity"
+        :class="
+          playable.favorite ? 'opacity-100' : 'opacity-0 group-hover:opacity-100 focus:opacity-100 no-hover:opacity-100'
+        "
+        @toggle="toggleFavorite"
+      />
+      <span class="text-k-fg-50 text-[0.9rem] tabular-nums">
+        {{ fmtLength }}
+      </span>
     </span>
   </li>
 </template>
@@ -48,9 +58,11 @@ import { useDraggable } from '@/composables/useDragAndDrop'
 import { useContextMenu } from '@/composables/useContextMenu'
 import { useOfflinePlayback } from '@/composables/useOfflinePlayback'
 import { playback } from '@/services/playbackManager'
+import { playableStore } from '@/stores/playableStore'
 
 import PlayableThumbnail from '@/components/playable/PlayableThumbnail.vue'
 import OfflineMark from '@/components/ui/OfflineMark.vue'
+import FavoriteButton from '@/components/ui/FavoriteButton.vue'
 
 const PlayableContextMenu = defineAsyncComponent(() => import('@/components/playable/PlayableContextMenu.vue'))
 
@@ -78,6 +90,8 @@ const play = () => {
     playback().play(playable.value)
   }
 }
+
+const toggleFavorite = () => playableStore.toggleFavorite(playable.value)
 
 const onDragStart = (event: DragEvent) => startDragging(event, [playable.value])
 


### PR DESCRIPTION
Songs listed on the home screen (Recently Played, Most Played, New Songs, Hidden Gems, Random Songs, You Might Also Like) can now be favorited in place, without opening the context menu or navigating to a list view.

The heart sits above the duration in the right-hand column of each song row, and reuses the existing `FavoriteButton` component, so it inherits the filled/outline states, the tooltip, and the `Favorite` / `Undo Favorite` accessible labels. Toggling goes through `playableStore.toggleFavorite()` — the same path the list views and the footer controls use.

Following the convention used elsewhere in the app, the button is revealed on row hover (and on focus, for keyboard users) unless the song is already a favorite, in which case it stays visible. On touch devices, where there is no hover, it is always visible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a favorite button to playable cards.
  - Favorite controls reflect the current favorite state and support toggling favorites directly from the card.
  - Added keyboard support: pressing Enter on the favorite button toggles the favorite, while pressing Enter on the card starts playback.

- **Bug Fixes**
  - Improved favorite interactions to update the correct song.
  - Prevented favorite-button keyboard actions from unintentionally starting playback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->