### PR TITLE
fix: reach external URLs that use an IPv6 address

### DIFF
--- a/app/Services/Network/Network.php
+++ b/app/Services/Network/Network.php
@@ -3,9 +3,11 @@
 namespace App\Services\Network;
 
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Illuminate\Support\Uri;
 use IPLib\Address\AddressInterface;
 use IPLib\Address\IPv4;
+use IPLib\Address\IPv6;
 use IPLib\Factory;
 use IPLib\Range\Type as RangeType;
 use Throwable;
@@ -79,10 +81,11 @@ class Network
      */
     public function resolveToPublicIps(string $host): array
     {
-        $literal = Factory::parseAddressString($host);
+        $normalizedHost = self::unwrapIpv6Literal($host);
+        $literal = Factory::parseAddressString($normalizedHost);
 
         if ($literal) {
-            if (self::isAmbiguousIpv4Literal($literal, $host)) {
+            if (self::isAmbiguousIpv4Literal($literal, $normalizedHost)) {
                 return [];
             }
 
@@ -90,31 +93,54 @@ class Network
         }
 
         try {
-            $a = dns_get_record($host, DNS_A);
-            $aaaa = dns_get_record($host, DNS_AAAA);
+            $a = dns_get_record($normalizedHost, DNS_A);
+            $aaaa = dns_get_record($normalizedHost, DNS_AAAA);
         } catch (Throwable) {
             return [];
         }
 
-        if ($a === false || $aaaa === false) {
+        if (in_array(false, [$a, $aaaa], true)) {
             // dns_get_record returning false is a resolver failure — fail closed
             // rather than treating it as "host has no records".
             return [];
         }
 
-        $ips = [];
+        $ips = collect([...$a, ...$aaaa])->map(self::readIp(...))->all();
 
-        foreach (array_merge($a, $aaaa) as $record) {
-            $ip = Arr::get($record, 'ip') ?? Arr::get($record, 'ipv6');
+        return self::areAllPublic($ips) ? array_values($ips) : [];
+    }
 
-            if (!$ip || Factory::parseAddressString($ip)?->getRangeType() !== RangeType::T_PUBLIC) {
-                return [];
-            }
+    /** @param array<string, mixed> $record */
+    private static function readIp(array $record): string
+    {
+        return (string) Arr::first(
+            [Arr::get($record, 'ip'), Arr::get($record, 'ipv6')],
+            static fn (?string $ip): bool => filled($ip),
+        );
+    }
 
-            $ips[] = $ip;
-        }
+    /** @param list<string> $ips */
+    private static function areAllPublic(array $ips): bool
+    {
+        return collect($ips)->every(
+            static fn (string $ip): bool => Factory::parseAddressString($ip)?->getRangeType() === RangeType::T_PUBLIC,
+        );
+    }
 
-        return $ips;
+    /**
+     * A URI parser keeps the brackets around an IPv6 literal host — `Uri::host()` and PSR-7
+     * `getHost()` both hand back `[::1]` — and no IP parser accepts that form, so an IPv6
+     * host would otherwise fall through to a DNS lookup that can never succeed.
+     *
+     * Brackets are unwrapped only when they really do wrap an IPv6 literal. A bracketed
+     * IPv4 address is malformed, and keeping it bracketed leaves it unparseable so the
+     * caller fails closed.
+     */
+    public static function unwrapIpv6Literal(string $host): string
+    {
+        $inner = Str::match('/^\[(.+)]$/', $host);
+
+        return Factory::parseAddressString($inner) instanceof IPv6 ? $inner : $host;
     }
 
     /**

--- a/app/Services/Network/SafeHttp.php
+++ b/app/Services/Network/SafeHttp.php
@@ -135,7 +135,7 @@ class SafeHttp
                 throw_unless($ips, UnsafeUrlException::forUrl((string) $uri));
 
                 // IP literals don't trigger a DNS lookup, so nothing to pin.
-                if (!filter_var($host, FILTER_VALIDATE_IP)) {
+                if (!filter_var(Network::unwrapIpv6Literal($host), FILTER_VALIDATE_IP)) {
                     $port = $uri->getPort() ?? ($uri->getScheme() === 'https' ? 443 : 80);
 
                     $options['curl'] ??= [];

--- a/tests/Fakes/FakeNetwork.php
+++ b/tests/Fakes/FakeNetwork.php
@@ -27,7 +27,7 @@ class FakeNetwork extends Network
             return [];
         }
 
-        if (Factory::parseAddressString($host)) {
+        if (Factory::parseAddressString(self::unwrapIpv6Literal($host))) {
             return parent::resolveToPublicIps($host);
         }
 

--- a/tests/Unit/Rules/SafeUrlTest.php
+++ b/tests/Unit/Rules/SafeUrlTest.php
@@ -42,8 +42,12 @@ class SafeUrlTest extends TestCase
     #[Test]
     public function rejectsLoopbackAddress(): void
     {
+        Http::fake(['*' => Http::response()]);
+
         self::assertFalse($this->passes('http://127.0.0.1/feed'));
         self::assertFalse($this->passes('http://[::1]/feed'));
+
+        Http::assertNothingSent();
     }
 
     #[Test]

--- a/tests/Unit/Services/Network/NetworkTest.php
+++ b/tests/Unit/Services/Network/NetworkTest.php
@@ -27,6 +27,8 @@ class NetworkTest extends TestCase
             'private 10.x' => ['10.0.0.1'],
             'link-local' => ['169.254.1.1'],
             'loopback IPv6' => ['::1'],
+            'bracketed loopback IPv6' => ['[::1]'],
+            'bracketed private IPv6' => ['[fd00::1]'],
         ];
     }
 
@@ -125,6 +127,21 @@ class NetworkTest extends TestCase
     {
         self::assertSame(['2606:4700:4700::1111'], $this->network->resolveToPublicIps('2606:4700:4700::1111'));
         self::assertSame(['2606:4700:4700::1111'], $this->network->resolveToPublicIps('2606:4700:4700:0:0:0:0:1111'));
+    }
+
+    #[Test]
+    public function acceptsBracketedIpv6Literals(): void
+    {
+        self::assertSame(['2606:4700:4700::1111'], $this->network->resolveToPublicIps('[2606:4700:4700::1111]'));
+        self::assertTrue($this->network->isPublicHost('[2606:4700:4700::1111]'));
+        self::assertTrue($this->network->isSafeUrl('https://[2606:4700:4700::1111]/feed.xml'));
+    }
+
+    #[Test]
+    public function rejectsBracketedIpv4Literal(): void
+    {
+        self::assertSame([], $this->network->resolveToPublicIps('[8.8.8.8]'));
+        self::assertFalse($this->network->isSafeUrl('https://[8.8.8.8]/feed.xml'));
     }
 
     #[Test]


### PR DESCRIPTION
Koel could not reach any URL written with an IPv6 address — podcast feeds, radio streams, artwork, anything passing through the SSRF guard.

A URI parser keeps the brackets around an IPv6 host: `Uri::host()` and PSR-7 `getHost()` both hand back `[::1]` rather than `::1`. No IP parser accepts that form, so `Network::resolveToPublicIps()` never took its IP-literal branch and instead asked DNS to resolve a string that can never resolve. The guard then refused the URL:

```
resolveToPublicIps('2001:4860:4860::8888')    => ['2001:4860:4860::8888']
resolveToPublicIps('[2001:4860:4860::8888]')  => []
isSafeUrl('https://[2001:4860:4860::8888]/feed') => false
```

The brackets are now unwrapped before the host is parsed, and only when they really do wrap an IPv6 literal — a bracketed IPv4 address is malformed, so it stays bracketed, stays unparseable, and the guard keeps failing closed. `SafeHttp` applies the same unwrapping to its IP-literal check, so a verified IPv6 host is no longer handed to `CURLOPT_RESOLVE` as a pin entry whose host part contains colons.

### Scope

This was never a way past the guard. Both the old and new behavior reject a private address; the old one simply also rejected the public ones. Nothing became reachable that shouldn't be.

### Testing

`NetworkTest` now covers the bracketed form in both directions — a public IPv6 literal is accepted through `resolveToPublicIps`, `isPublicHost` and `isSafeUrl`, and bracketed loopback, bracketed private IPv6 and bracketed IPv4 are all still refused.

`SafeUrlTest::rejectsLoopbackAddress` was passing for the wrong reason. `http://[::1]/feed` was being refused because a real connection attempt to `[::1]:80` timed out, not because the guard recognised loopback: the test drove the guard through `FakeNetwork`, whose bracket-blind check returned the synthetic public `203.0.113.1` for `[::1]` instead of delegating to the real implementation. The test now asserts `Http::assertNothingSent()`, so it fails if the rejection ever depends on a network round trip again. That also takes it from 10.1s to 0.1s, and with it the unit suite from 27.1s to 6.0s.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of bracketed IPv6 addresses in URLs.
  * Public IPv6 literals are now recognized correctly, while private and loopback IPv6 addresses continue to be blocked.
  * Prevented unnecessary DNS lookups and HTTP requests for validated IP literals.
  * Bracketed IPv4 addresses are rejected rather than treated as valid hosts.
  * Network validation continues to fail safely when DNS resolution is unavailable or unsuccessful.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->