### PR TITLE
feat: match ListenBrainz listens to the exact recording

### DIFF
--- a/app/Http/Integrations/ListenBrainz/Requests/SubmitListensRequest.php
+++ b/app/Http/Integrations/ListenBrainz/Requests/SubmitListensRequest.php
@@ -50,7 +50,22 @@ final class SubmitListensRequest extends Request implements HasBody
         ];
     }
 
-    /** @return array{artist_name: string, track_name: string, release_name?: string, additional_info: array} */
+    /**
+     * @return array{
+     *     artist_name: string,
+     *     track_name: string,
+     *     release_name?: string,
+     *     additional_info: array{
+     *         duration_ms?: int,
+     *         tracknumber?: int,
+     *         recording_mbid?: string,
+     *         release_mbid?: string,
+     *         artist_mbids?: list<string>,
+     *         media_player: string,
+     *         submission_client: string,
+     *     },
+     * }
+     */
     private function getTrackMetadata(): array
     {
         $metadata = [
@@ -74,11 +89,7 @@ final class SubmitListensRequest extends Request implements HasBody
         return $metadata;
     }
 
-    /**
-     * ListenBrainz wants a list here, and an empty one would survive the array_filter() above.
-     *
-     * @return list<string>|null
-     */
+    /** @return list<string>|null */
     private function getArtistMbids(): ?array
     {
         return $this->song->artist->mbid ? [$this->song->artist->mbid] : null;

--- a/app/Http/Integrations/ListenBrainz/Requests/SubmitListensRequest.php
+++ b/app/Http/Integrations/ListenBrainz/Requests/SubmitListensRequest.php
@@ -59,6 +59,9 @@ final class SubmitListensRequest extends Request implements HasBody
             'additional_info' => array_filter([
                 'duration_ms' => $this->song->length ? (int) round($this->song->length * 1000) : null,
                 'tracknumber' => $this->song->track ?: null,
+                'recording_mbid' => $this->song->mbid,
+                'release_mbid' => $this->song->album->mbid,
+                'artist_mbids' => $this->getArtistMbids(),
                 'media_player' => 'Koel',
                 'submission_client' => 'Koel',
             ]),
@@ -69,5 +72,15 @@ final class SubmitListensRequest extends Request implements HasBody
         }
 
         return $metadata;
+    }
+
+    /**
+     * ListenBrainz wants a list here, and an empty one would survive the array_filter() above.
+     *
+     * @return list<string>|null
+     */
+    private function getArtistMbids(): ?array
+    {
+        return $this->song->artist->mbid ? [$this->song->artist->mbid] : null;
     }
 }

--- a/tests/Integration/Services/Integrations/ListenBrainzServiceTest.php
+++ b/tests/Integration/Services/Integrations/ListenBrainzServiceTest.php
@@ -94,6 +94,55 @@ class ListenBrainzServiceTest extends TestCase
     }
 
     #[Test]
+    public function scrobbleSubmitsMusicBrainzIdentifiers(): void
+    {
+        $user = create_user(['preferences' => ['listenbrainz_token' => 'my_token']]);
+        $artist = Artist::factory()->createOne(['mbid' => 'c1a1b1cc-1111-4aaa-8bbb-0d0d0d0d0d0d']);
+        $album = Album::factory()->for($artist)->createOne(['mbid' => 'd2b2c2dd-2222-4bbb-8ccc-1e1e1e1e1e1e']);
+        $song = Song::factory()
+            ->for($artist)
+            ->for($album)
+            ->createOne(['mbid' => 'e3c3d3ee-3333-4ccc-8ddd-2f2f2f2f2f2f']);
+
+        Saloon::fake([SubmitListensRequest::class => MockResponse::make()]);
+
+        $this->service->scrobble($song, $user, 100);
+
+        Saloon::assertSent(static function (SubmitListensRequest $request) use ($song, $album, $artist): bool {
+            $additionalInfo = $request->body()->all()['payload'][0]['track_metadata']['additional_info'];
+
+            self::assertSame($song->mbid, $additionalInfo['recording_mbid']);
+            self::assertSame($album->mbid, $additionalInfo['release_mbid']);
+            self::assertSame([$artist->mbid], $additionalInfo['artist_mbids']);
+
+            return true;
+        });
+    }
+
+    #[Test]
+    public function scrobbleOmitsMissingMusicBrainzIdentifiers(): void
+    {
+        $user = create_user(['preferences' => ['listenbrainz_token' => 'my_token']]);
+        $artist = Artist::factory()->createOne(['mbid' => null]);
+        $album = Album::factory()->for($artist)->createOne(['mbid' => null]);
+        $song = Song::factory()->for($artist)->for($album)->createOne(['mbid' => null]);
+
+        Saloon::fake([SubmitListensRequest::class => MockResponse::make()]);
+
+        $this->service->scrobble($song, $user, 100);
+
+        Saloon::assertSent(static function (SubmitListensRequest $request): bool {
+            $additionalInfo = $request->body()->all()['payload'][0]['track_metadata']['additional_info'];
+
+            self::assertArrayNotHasKey('recording_mbid', $additionalInfo);
+            self::assertArrayNotHasKey('release_mbid', $additionalInfo);
+            self::assertArrayNotHasKey('artist_mbids', $additionalInfo);
+
+            return true;
+        });
+    }
+
+    #[Test]
     public function updateNowPlayingOmitsTimestamp(): void
     {
         $user = create_user(['preferences' => ['listenbrainz_token' => 'my_token']]);

--- a/tests/Integration/Services/Integrations/ListenBrainzServiceTest.php
+++ b/tests/Integration/Services/Integrations/ListenBrainzServiceTest.php
@@ -143,6 +143,32 @@ class ListenBrainzServiceTest extends TestCase
     }
 
     #[Test]
+    public function scrobbleSubmitsWhicheverMusicBrainzIdentifiersAreKnown(): void
+    {
+        $user = create_user(['preferences' => ['listenbrainz_token' => 'my_token']]);
+        $artist = Artist::factory()->createOne(['mbid' => null]);
+        $album = Album::factory()->for($artist)->createOne(['mbid' => null]);
+        $song = Song::factory()
+            ->for($artist)
+            ->for($album)
+            ->createOne(['mbid' => 'e3c3d3ee-3333-4ccc-8ddd-2f2f2f2f2f2f']);
+
+        Saloon::fake([SubmitListensRequest::class => MockResponse::make()]);
+
+        $this->service->scrobble($song, $user, 100);
+
+        Saloon::assertSent(static function (SubmitListensRequest $request) use ($song): bool {
+            $additionalInfo = $request->body()->all()['payload'][0]['track_metadata']['additional_info'];
+
+            self::assertSame($song->mbid, $additionalInfo['recording_mbid']);
+            self::assertArrayNotHasKey('release_mbid', $additionalInfo);
+            self::assertArrayNotHasKey('artist_mbids', $additionalInfo);
+
+            return true;
+        });
+    }
+
+    #[Test]
     public function updateNowPlayingOmitsTimestamp(): void
     {
         $user = create_user(['preferences' => ['listenbrainz_token' => 'my_token']]);


### PR DESCRIPTION
Koel has been collecting MusicBrainz identifiers since #2667 and #2668, and until now nothing read them. Listens went to ListenBrainz carrying only names.

Names are the weak way to identify a listen. ListenBrainz has to match artist, track and release as strings, which is exactly where a cover, a remix, a live take or a remaster collides with the original — the listen lands on whichever recording the text happened to resemble. An identifier removes the ambiguity.

`additional_info` now carries the three identifiers Koel stores:

| field | source |
|---|---|
| `recording_mbid` | `songs.mbid` — from the file's UFID frame or `musicbrainz_trackid`, or matched by title against the release |
| `release_mbid` | `albums.mbid` — from `musicbrainz_albumid`, or MusicBrainz's `releases.0.id` |
| `artist_mbids` | `artists.mbid`, as the single-element list ListenBrainz expects |

Each is dropped when absent, so a library with untagged files submits exactly what it did before.

### Notes

`artist_mbids` is a list where the other two are scalars, and an empty list survives `array_filter()` — so absence has to be `null` rather than `[]`, or every listen from an artist without an identifier would carry `artist_mbids: [null]`. There's a test pinning that.

`albums.mbid` is a *release* identifier, not a release group: `GetReleaseAndReleaseGroupMbidsForAlbum` stores `releases.0.id` and keeps the release-group id only for the Wikidata lookup, and `musicbrainz_albumid` is the release by Picard's convention. So it belongs in `release_mbid`.

### Testing

Two tests: one asserting all three identifiers reach the payload, one asserting all three keys are absent when the models carry none. I checked the second is load-bearing by making `artist_mbids` unconditional — it fails on the `[null]` that would otherwise ship.

### Scope

Identifiers are only as complete as the library. Files tagged by Picard carry them from the scan; everything else acquires them as albums and artists get browsed and MusicBrainz is consulted. There is no backfill command, so an older library will submit identifiers for a growing subset rather than all at once.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - ListenBrainz scrobbles now include available MusicBrainz recording, release, and artist identifiers.
  - Missing identifiers are omitted from submitted scrobble data.
  - Scrobbles support submitting any combination of known MusicBrainz identifiers, including recording-only metadata.

- **Tests**
  - Added coverage confirming identifiers are submitted when available, omitted when missing, and handled correctly when only some identifiers are known.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->