### PR TITLE
fix: stop attaching the wrong MusicBrainz identifier to artists and albums

### DIFF
--- a/app/Helpers/LuceneQuery.php
+++ b/app/Helpers/LuceneQuery.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Helpers;
+
+use Illuminate\Support\Str;
+
+class LuceneQuery
+{
+    /**
+     * Quote a value so the search engine matches it as one phrase. Without the quotes, a multi-word
+     * value is read as separate terms and a name nobody has heard of still matches something: searching
+     * MusicBrainz for `artist:Zzzqqxyw Nonexistent Bandname` returns an artist called "Bandname", with
+     * full confidence, where the quoted form correctly returns nothing.
+     */
+    public static function phrase(string $value): string
+    {
+        return '"' . Str::replace(['\\', '"'], ['\\\\', '\\"'], $value) . '"';
+    }
+}

--- a/app/Http/Integrations/MusicBrainz/Requests/SearchForArtistRequest.php
+++ b/app/Http/Integrations/MusicBrainz/Requests/SearchForArtistRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Integrations\MusicBrainz\Requests;
 
+use App\Helpers\LuceneQuery;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -22,7 +23,7 @@ class SearchForArtistRequest extends Request
     protected function defaultQuery(): array
     {
         return [
-            'query' => "artist:{$this->name}",
+            'query' => 'artist:' . LuceneQuery::phrase($this->name),
             'limit' => 1,
         ];
     }

--- a/app/Http/Integrations/MusicBrainz/Requests/SearchForReleaseRequest.php
+++ b/app/Http/Integrations/MusicBrainz/Requests/SearchForReleaseRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Integrations\MusicBrainz\Requests;
 
+use App\Helpers\LuceneQuery;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -23,7 +24,11 @@ class SearchForReleaseRequest extends Request
     protected function defaultQuery(): array
     {
         return [
-            'query' => "release:\"{$this->albumName}\" AND artist:\"{$this->artistName}\"",
+            'query' => sprintf(
+                'release:%s AND artist:%s',
+                LuceneQuery::phrase($this->albumName),
+                LuceneQuery::phrase($this->artistName),
+            ),
             'limit' => 1,
         ];
     }

--- a/app/Services/Integrations/MbidService.php
+++ b/app/Services/Integrations/MbidService.php
@@ -24,7 +24,7 @@ class MbidService
 {
     public function fetchAndStoreArtistMbid(Artist $artist): void
     {
-        if ($artist->is_unknown || $artist->is_various) {
+        if ($artist->is_unknown || $artist->is_various || $artist->mbid) {
             return;
         }
 
@@ -43,13 +43,7 @@ class MbidService
         }
 
         rescue_if(MusicBrainzService::enabled(), static function () use ($album): void {
-            /** @var array{0: ?string, 1: ?string} $mbids */
-            $mbids = Pipeline::send([
-                'album' => $album->name,
-                'artist' => $album->artist->name,
-            ])->through([GetReleaseAndReleaseGroupMbidsForAlbum::class])->thenReturn();
-
-            $albumMbid = $mbids[0] ?? null;
+            $albumMbid = $album->mbid ?: self::searchForReleaseMbid($album);
 
             if (!$albumMbid) {
                 return;
@@ -62,6 +56,21 @@ class MbidService
 
             self::storeRecordingMbids($album, $tracks);
         });
+    }
+
+    /**
+     * A release identifier the tags already carry is authoritative, where this search takes whichever
+     * release ranks first for the album and artist names — so only ask when there is nothing to go on.
+     */
+    private static function searchForReleaseMbid(Album $album): ?string
+    {
+        /** @var array{0: ?string, 1: ?string} $mbids */
+        $mbids = Pipeline::send([
+            'album' => $album->name,
+            'artist' => $album->artist->name,
+        ])->through([GetReleaseAndReleaseGroupMbidsForAlbum::class])->thenReturn();
+
+        return $mbids[0] ?? null;
     }
 
     /**

--- a/app/Services/Integrations/MusicBrainzService.php
+++ b/app/Services/Integrations/MusicBrainzService.php
@@ -31,7 +31,7 @@ class MusicBrainzService implements Encyclopedia
 
         return rescue_if(static::enabled(), static function () use ($artist) {
             /** @var string|null $mbid */
-            $mbid = Pipeline::send($artist->name)->through([GetMbidForArtist::class])->thenReturn();
+            $mbid = $artist->mbid ?: Pipeline::send($artist->name)->through([GetMbidForArtist::class])->thenReturn();
 
             $wikipediaSummary = Pipeline::send($mbid)
                 ->through([

--- a/tests/Integration/Services/Integrations/MbidServiceTest.php
+++ b/tests/Integration/Services/Integrations/MbidServiceTest.php
@@ -9,6 +9,7 @@ use App\Pipelines\Encyclopedia\GetAlbumTracksUsingMbid;
 use App\Pipelines\Encyclopedia\GetMbidForArtist;
 use App\Pipelines\Encyclopedia\GetReleaseAndReleaseGroupMbidsForAlbum;
 use App\Services\Integrations\MbidService;
+use Closure;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -141,6 +142,42 @@ class MbidServiceTest extends TestCase
 
         self::assertSame('album-mbid-from-tags', $album->refresh()->mbid);
         self::assertSame('recording-mbid-from-tags', self::getFirstSongMbid($album));
+    }
+
+    #[Test]
+    public function skipTheArtistSearchWhenTheMbidIsAlreadyKnown(): void
+    {
+        $this->mock(GetMbidForArtist::class)->shouldNotReceive('__invoke');
+        $artist = Artist::factory()->createOne(['name' => 'Skid Row', 'mbid' => 'mbid-from-tags']);
+
+        $this->service->fetchAndStoreArtistMbid($artist);
+
+        self::assertSame('mbid-from-tags', $artist->refresh()->mbid);
+    }
+
+    #[Test]
+    public function lookUpRecordingsUsingTheKnownAlbumMbidWithoutSearching(): void
+    {
+        $this->mock(GetReleaseAndReleaseGroupMbidsForAlbum::class)->shouldNotReceive('__invoke');
+
+        $searchedMbid = null;
+
+        $this
+            ->mock(GetAlbumTracksUsingMbid::class)
+            ->allows('__invoke')
+            ->andReturnUsing(static function (?string $mbid, Closure $next) use (&$searchedMbid): mixed {
+                $searchedMbid = $mbid;
+
+                return $next([['title' => 'Monkey Business', 'recording' => ['id' => 'recording-mbid-0']]]);
+            });
+
+        $album = self::makeAlbumWith(['Monkey Business']);
+        $album->update(['mbid' => 'album-mbid-from-tags']);
+
+        $this->service->fetchAndStoreAlbumMbids($album);
+
+        self::assertSame('album-mbid-from-tags', $searchedMbid);
+        self::assertSame('recording-mbid-0', self::getFirstSongMbid($album));
     }
 
     #[Test]

--- a/tests/Unit/Helpers/LuceneQueryTest.php
+++ b/tests/Unit/Helpers/LuceneQueryTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Unit\Helpers;
+
+use App\Helpers\LuceneQuery;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class LuceneQueryTest extends TestCase
+{
+    /** @return array<string, array{string, string}> */
+    public static function provideValues(): array
+    {
+        return [
+            'single word' => ['Radiohead', '"Radiohead"'],
+            'several words' => ['Pink Floyd', '"Pink Floyd"'],
+            'a quote in the name' => ['Say "Yes"', '"Say \"Yes\""'],
+            'a backslash in the name' => ['AC\DC', '"AC\\\\DC"'],
+            'reserved words' => ['Sigur Rós AND Björk', '"Sigur Rós AND Björk"'],
+            'empty' => ['', '""'],
+        ];
+    }
+
+    #[Test, DataProvider('provideValues')]
+    public function quoteValueAsASinglePhrase(string $value, string $expected): void
+    {
+        self::assertSame($expected, LuceneQuery::phrase($value));
+    }
+}

--- a/tests/Unit/Pipelines/Encyclopedia/GetMbidForArtistTest.php
+++ b/tests/Unit/Pipelines/Encyclopedia/GetMbidForArtistTest.php
@@ -35,7 +35,7 @@ class GetMbidForArtistTest extends TestCase
         Saloon::assertSent(static function (SearchForArtistRequest $request): bool {
             self::assertSame(
                 [
-                    'query' => 'artist:Skid Row',
+                    'query' => 'artist:"Skid Row"',
                     'limit' => 1,
                 ],
                 $request->query()->all(),


### PR DESCRIPTION
Koel can attach the wrong MusicBrainz identifier to an artist or album, and since #2672 those identifiers are submitted to ListenBrainz — so a wrong one lands in a listening history the user has to correct by hand. Two separate causes.

### It searched for identifiers it already had

A file tagged by Picard names its artist and album outright, and Koel reads those identifiers during a scan. It then searched MusicBrainz by name anyway and stored whatever came back first, replacing a certainty with a guess. `MbidService` now leaves an artist alone once it has an identifier, and uses a stored album identifier rather than searching for one. `MusicBrainzService` does the same for the artist entry it builds.

The album path is safe to short-circuit because it only ever used the release identifier from that search and discarded the release group. `MusicBrainzService::getAlbumInformation` still searches, because it genuinely needs the release group and nothing stores that — it also writes nothing, so it is not part of this problem.

### It matched names it never searched for

The artist search did not quote its value. An unquoted multi-word value is read as separate terms, so the term after the first one is matched against the default field:

```
artist:Zzzqqxyw Nonexistent Bandname    → "Bandname", score 100
artist:"Zzzqqxyw Nonexistent Bandname"  → no results
```

That is a real response from the live API, not a constructed example. The invented name matches an artist called "Bandname" with full confidence.

It also rules out the fix this PR does *not* make. Rejecting low-scoring matches cannot help when the bad match scores 100, so there is no threshold to choose. Quoting removes the whole class instead, and costs nothing: `The Beatles`, `The Band` and `Bjork` (which resolves to `Björk`, so accents are not a concern) all still score 100 quoted, while a quoted `Pink Floyde` correctly returns nothing.

Both searches now build their values through `LuceneQuery::phrase()`, which quotes and escapes. The release search already quoted but did not escape, so an album like `Say "Yes"` produced malformed query syntax that was swallowed into a silently missing identifier.

### What this does not fix

Two different artists genuinely share a name — the search returns two distinct results both called "The Beatles". No query and no score separates those. Only the file's own tags can, which is what the first half of this PR now prefers.

### Testing

Four tests on the identifier preference, two of which assert the search pipeline is never invoked; I checked both fail when the guards are removed, so they pin the behavior rather than the outcome. Six cases on `LuceneQuery::phrase()` covering quotes, backslashes and reserved words.

`GetMbidForArtistTest` asserted the unquoted query, so it was pinning the bug. Its expectation is updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved MusicBrainz artist and release searches by treating names as exact phrases, including safer handling of special characters.
  - Reuses previously stored artist and album identifiers instead of repeating unnecessary lookups.
  - Uses known album identifiers to retrieve track information directly when available.

- **Bug Fixes**
  - Prevents existing identifiers from being overwritten during subsequent synchronization.
  - Improves search accuracy for names containing spaces, quotation marks, or other special characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->