### PR TITLE
feat: report MusicBrainz identifiers to Subsonic clients

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -327,6 +327,7 @@ protected function isAccessible(User $user, ?string $path = null): bool
 
 ## Code Reviews
 - When addressing PR review comments, do NOT blindly follow them. Always use your own knowledge and logic to evaluate whether the feedback makes sense. If it doesn't, push back and explain why.
+- **Never justify proposed work with an unverified claim about an external system.** Before arguing that a change is worth making because some client reads a field, some spec defines it, some service accepts a parameter, or some tool behaves a certain way — go and check. Read the spec page, grep the client's source (`gh search code --repo owner/name 'symbol'`), query the live API. If verifying is not possible, say the claim is unverified **in the same breath as the proposal**, never after the work is built. A rationale that turns out to rest on a guess wastes a review cycle and makes every other claim in the proposal suspect.
 - CodeRabbit (and similar bots) split their output across three GitHub layers. Before claiming a review has been addressed, query **all three**:
   - `gh api repos/{owner}/{repo}/pulls/{n}/comments` — inline review comments on specific file/line positions (🟡 Minor / 🟠 Major / 🔴 Critical / ⚠️ Potential issue).
   - `gh api repos/{owner}/{repo}/issues/{n}/comments` — issue-level (conversation) comments. CodeRabbit's PR-level summary lives here, and the **Nitpick comments** are sometimes bundled in a collapsible section inside that summary's body.

--- a/app/Http/Responses/Subsonic/Resources/AlbumResource.php
+++ b/app/Http/Responses/Subsonic/Resources/AlbumResource.php
@@ -32,6 +32,7 @@ final class AlbumResource
      *     userRating: ?int,
      *     starred: ?string,
      *     played: ?string,
+     *     musicBrainzId: ?string,
      * }
      */
     public static function toArray(Album $album, User $user): array
@@ -49,6 +50,7 @@ final class AlbumResource
             'userRating' => $album->getRatingFor($user) ?: null,
             'starred' => $album->favorited_at?->toIso8601String(),
             'played' => $album->last_played_at?->toIso8601String(),
+            'musicBrainzId' => $album->mbid,
         ];
     }
 }

--- a/app/Http/Responses/Subsonic/Resources/ArtistResource.php
+++ b/app/Http/Responses/Subsonic/Resources/ArtistResource.php
@@ -22,6 +22,7 @@ final class ArtistResource
      *     albumCount: int,
      *     userRating: ?int,
      *     starred: ?string,
+     *     musicBrainzId: ?string,
      * }
      */
     public static function toArray(Artist $artist, User $user): array
@@ -33,6 +34,7 @@ final class ArtistResource
             'albumCount' => $artist->albums_count ?? 0,
             'userRating' => $artist->getRatingFor($user) ?: null,
             'starred' => $artist->favorited_at?->toIso8601String(),
+            'musicBrainzId' => $artist->mbid,
         ];
     }
 }

--- a/app/Http/Responses/Subsonic/Resources/SongResource.php
+++ b/app/Http/Responses/Subsonic/Resources/SongResource.php
@@ -45,6 +45,7 @@ final class SongResource
      *     isVideo: bool,
      *     userRating: ?int,
      *     starred: ?string,
+     *     musicBrainzId: ?string,
      * }
      */
     public static function toArray(Song $song, User $user): array
@@ -72,6 +73,7 @@ final class SongResource
             'isVideo' => false,
             'userRating' => $song->getRatingFor($user) ?: null,
             'starred' => $song->favorited_at?->toIso8601String(),
+            'musicBrainzId' => $song->mbid,
         ];
     }
 }

--- a/tests/Feature/Subsonic/MusicBrainzIdTest.php
+++ b/tests/Feature/Subsonic/MusicBrainzIdTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tests\Feature\Subsonic;
+
+use App\Models\Album;
+use App\Models\Artist;
+use App\Models\Song;
+use PHPUnit\Framework\Attributes\Test;
+
+use function Tests\create_user;
+
+class MusicBrainzIdTest extends SubsonicTestCase
+{
+    private const string RECORDING_MBID = 'e3c3d3ee-3333-4ccc-8ddd-2f2f2f2f2f2f';
+    private const string RELEASE_MBID = 'd2b2c2dd-2222-4bbb-8ccc-1e1e1e1e1e1e';
+    private const string ARTIST_MBID = 'c1a1b1cc-1111-4aaa-8bbb-0d0d0d0d0d0d';
+
+    #[Test]
+    public function exposeTheRecordingIdentifierOnASong(): void
+    {
+        $user = create_user();
+        $song = Song::factory()->createOne(['owner_id' => $user->id, 'mbid' => self::RECORDING_MBID]);
+
+        $this->getSubsonic('getSong.view', $user, [
+            'id' => $song->id,
+        ])->assertSubsonicOk()->assertJsonPath('subsonic-response.song.musicBrainzId', self::RECORDING_MBID);
+    }
+
+    #[Test]
+    public function exposeTheReleaseIdentifierOnAnAlbum(): void
+    {
+        $user = create_user();
+        $album = Album::factory()->createOne(['user_id' => $user->id, 'mbid' => self::RELEASE_MBID]);
+        Song::factory()->for($album)->createOne(['owner_id' => $user->id]);
+
+        $this->getSubsonic('getAlbum.view', $user, [
+            'id' => $album->id,
+        ])->assertSubsonicOk()->assertJsonPath('subsonic-response.album.musicBrainzId', self::RELEASE_MBID);
+    }
+
+    #[Test]
+    public function exposeTheArtistIdentifier(): void
+    {
+        $user = create_user();
+        $artist = Artist::factory()->createOne(['user_id' => $user->id, 'mbid' => self::ARTIST_MBID]);
+        Album::factory()->for($artist)->createOne(['user_id' => $user->id, 'artist_name' => $artist->name]);
+
+        $this->getSubsonic('getArtist.view', $user, [
+            'id' => $artist->id,
+        ])->assertSubsonicOk()->assertJsonPath('subsonic-response.artist.musicBrainzId', self::ARTIST_MBID);
+    }
+
+    #[Test]
+    public function omitTheIdentifierWhenUnknown(): void
+    {
+        $user = create_user();
+        $artist = Artist::factory()->createOne(['user_id' => $user->id, 'mbid' => null]);
+        $album = Album::factory()->for($artist)->createOne([
+            'user_id' => $user->id,
+            'artist_name' => $artist->name,
+            'mbid' => null,
+        ]);
+        $song = Song::factory()
+            ->for($album)
+            ->for($artist)
+            ->createOne([
+                'owner_id' => $user->id,
+                'mbid' => null,
+            ]);
+
+        $this->getSubsonic('getSong.view', $user, [
+            'id' => $song->id,
+        ])->assertSubsonicOk()->assertJsonMissingPath('subsonic-response.song.musicBrainzId');
+
+        $this->getSubsonic('getAlbum.view', $user, [
+            'id' => $album->id,
+        ])->assertSubsonicOk()->assertJsonMissingPath('subsonic-response.album.musicBrainzId');
+
+        $this->getSubsonic('getArtist.view', $user, [
+            'id' => $artist->id,
+        ])->assertSubsonicOk()->assertJsonMissingPath('subsonic-response.artist.musicBrainzId');
+    }
+}


### PR DESCRIPTION
Koel stores a MusicBrainz identifier for songs, albums and artists, and reports none of them to Subsonic clients. Koel already answers `openSubsonic: true`, and the extended spec defines an optional `musicBrainzId` string on `Child`, `AlbumID3` and `ArtistID3`.

| response | field | source |
|---|---|---|
| `Child` (song) | `musicBrainzId` | `songs.mbid`, the recording |
| `AlbumID3` | `musicBrainzId` | `albums.mbid`, the release |
| `ArtistID3` | `musicBrainzId` | `artists.mbid` |

All three are columns already loaded with the model, so no query changes.

### What clients actually do with it

Checked rather than assumed, across the Mac-capable clients:

- **Feishin reads the song identifier.** `src/shared/api/subsonic/subsonic-normalize.ts` maps `item.musicBrainzId` onto its internal `mbzRecordingId`. That also confirms the entity: the spec calls `Child.musicBrainzId` the "track MusicBrainzID" in pre-NGS wording, and Feishin treats it as the recording, which is what `songs.mbid` holds.
- **Feishin does not read the album or artist identifier.** The same normalizer sets `mbzAlbumId: null`, populating album identifiers only from Navidrome's native API. Its other `musicBrainzId` reference belongs to a `getArtistInfo2` schema, not `ArtistID3`.
- **Sonixd and Submariner read none of them.**

So the song field has a confirmed consumer today and the other two do not. They are included anyway because a server that reports the identifier it holds for a song while withholding the ones it holds for that song's album and artist is arbitrarily incomplete, and both are spec-defined fields rather than invented surface. That is a judgement call, not a verified benefit — say the word and I will narrow this to `Child` alone.

### Where it is deliberately absent

`AlbumChildResource` renders an album as a `<child isDir="true">` for `getMusicDirectory`, and `Child.musicBrainzId` is the *track* identifier. Returning an album identifier under it would repeat the release-track/recording confusion that #2669 fixed, so that resource is untouched.

### One deviation from the spec, on purpose

The spec suggests a supporting server should return these fields empty rather than absent, so a client can tell "not supported" from "not known". Koel strips nulls from every Subsonic response, and every other optional field here — `coverArt`, `year`, `userRating`, `starred` — is absent when unset. Following the house behaviour keeps responses consistent and avoids adding an empty string to every row of a library with no identifiers. A test pins the omission, so the decision is easy to reverse.

`JSON_STRUCTURE` is unchanged for the same reason: it lists the keys that always survive `stripNulls`, and this one does not.

### Testing

One file covering the concern across the three endpoints: `getSong`, `getAlbum` and `getArtist` each return the identifier, and a fourth test confirms all three omit the field when the models carry none.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subsonic API responses for songs, albums, and artists now include their MusicBrainz identifiers when available.
  * The `musicBrainzId` field is omitted when no identifier is stored.

* **Tests**
  * Added coverage verifying MusicBrainz identifier behavior across song, album, and artist responses.

* **Documentation**
  * Added guidance for verifying claims about external systems before using them to support proposed work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->