### PR TITLE
fix: fetch song identifiers on albums that already have one

### DIFF
--- a/app/Console/Commands/FetchMbidsCommand.php
+++ b/app/Console/Commands/FetchMbidsCommand.php
@@ -20,7 +20,7 @@ class FetchMbidsCommand extends Command
 {
     protected $signature = 'koel:fetch-mbids';
 
-    protected $description = 'Attempt to fetch missing MusicBrainz identifiers for albums and artists.';
+    protected $description = 'Attempt to fetch missing MusicBrainz identifiers for albums, artists and songs.';
 
     public function __construct(
         private readonly MbidService $mbidService,
@@ -38,18 +38,18 @@ class FetchMbidsCommand extends Command
             return self::FAILURE;
         }
 
-        $albumCount = $this->albumRepository->countWithoutMbid();
+        $albumCount = $this->albumRepository->countWithIncompleteMbids();
         $artistCount = $this->artistRepository->countWithoutMbid();
 
         if ($albumCount === 0 && $artistCount === 0) {
-            $this->info('Every album and artist already has an identifier.');
+            $this->info('Every album, artist and song already has an identifier.');
 
             return self::SUCCESS;
         }
 
         $this->throttleMusicBrainzRequests();
 
-        $this->lookUp($this->albumRepository->lazyGetWithoutMbid(), $albumCount, 'album');
+        $this->lookUp($this->albumRepository->lazyGetWithIncompleteMbids(), $albumCount, 'album');
         $this->lookUp($this->artistRepository->lazyGetWithoutMbid(), $artistCount, 'artist');
 
         $this->newLine();

--- a/app/Repositories/AlbumRepository.php
+++ b/app/Repositories/AlbumRepository.php
@@ -2,6 +2,7 @@
 
 namespace App\Repositories;
 
+use App\Builders\AlbumBuilder;
 use App\Models\Album;
 use App\Models\Artist;
 use App\Models\User;
@@ -23,14 +24,27 @@ use Illuminate\Support\LazyCollection;
 class AlbumRepository extends Repository implements ScoutableRepository
 {
     /** @return LazyCollection<array-key, Album> */
-    public function lazyGetWithoutMbid(): LazyCollection
+    public function lazyGetWithIncompleteMbids(): LazyCollection
     {
-        return Album::query()->onlyStandard()->whereNull('albums.mbid')->lazyById();
+        return self::queryWithIncompleteMbids()->lazyById();
     }
 
-    public function countWithoutMbid(): int
+    public function countWithIncompleteMbids(): int
     {
-        return Album::query()->onlyStandard()->whereNull('albums.mbid')->count();
+        return self::queryWithIncompleteMbids()->count();
+    }
+
+    /**
+     * An album is incomplete while it lacks an identifier of its own or any of its songs lacks one. A
+     * tagged file commonly names the release without naming the recording, so the two run out separately.
+     */
+    private static function queryWithIncompleteMbids(): AlbumBuilder
+    {
+        return Album::query()
+            ->onlyStandard()
+            ->where(static fn (AlbumBuilder $query) => $query->whereNull(
+                'albums.mbid',
+            )->orWhereHas('songs', static fn (Builder $songs) => $songs->whereNull('songs.mbid')));
     }
 
     /**

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -132,10 +132,14 @@ php artisan koel:fetch-artwork --delay=2
 
 ### `koel:fetch-mbids`
 
-Attempt to fetch missing MusicBrainz identifiers for albums and artists. Koel reads these identifiers
-from your files when it scans them, and looks up the rest when you open an album or an artist. Run this
-command to look up everything that is still missing in one go, so songs you have not browsed to also
-carry an identifier when Koel submits a listen to ListenBrainz or answers a Subsonic client.
+Attempt to fetch missing MusicBrainz identifiers for albums, artists and songs. Koel reads these
+identifiers from your files when it scans them, and looks up the rest when you open an album or an
+artist. Run this command to look up everything that is still missing in one go, so songs you have not
+browsed to also carry an identifier when Koel submits a listen to ListenBrainz or answers a Subsonic
+client.
+
+A song's identifier is found through its album, so an album is revisited when any of its songs is still
+missing one, even if the album itself already has one.
 
 MusicBrainz accepts one request per second, so a large library takes a while. You can stop the command at
 any time and run it again later: it only looks up what is still missing, and it never replaces an

--- a/tests/Feature/Commands/FetchMbidsCommandTest.php
+++ b/tests/Feature/Commands/FetchMbidsCommandTest.php
@@ -111,6 +111,7 @@ class FetchMbidsCommandTest extends TestCase
         $this->artisan('koel:fetch-mbids')->assertSuccessful();
 
         self::assertSame('found-recording-mbid', $song->refresh()->mbid);
+        self::assertSame('album-mbid-from-tags', $album->refresh()->mbid);
     }
 
     #[Test]

--- a/tests/Feature/Commands/FetchMbidsCommandTest.php
+++ b/tests/Feature/Commands/FetchMbidsCommandTest.php
@@ -93,6 +93,27 @@ class FetchMbidsCommandTest extends TestCase
     }
 
     #[Test]
+    public function fillInSongIdentifiersOnAnAlbumThatAlreadyHasOne(): void
+    {
+        $this->allowPipelinePipe(GetMbidForArtist::class, 'found-artist-mbid');
+        $this->allowPipelinePipe(GetAlbumTracksUsingMbid::class, [
+            ['title' => 'Schism', 'recording' => ['id' => 'found-recording-mbid']],
+        ]);
+
+        $artist = Artist::factory()->createOne(['name' => 'Tool', 'mbid' => 'artist-mbid-from-tags']);
+        $album = Album::factory()->for($artist)->createOne([
+            'name' => 'Lateralus',
+            'artist_name' => $artist->name,
+            'mbid' => 'album-mbid-from-tags',
+        ]);
+        $song = Song::factory()->for($album)->for($artist)->createOne(['title' => 'Schism', 'mbid' => null]);
+
+        $this->artisan('koel:fetch-mbids')->assertSuccessful();
+
+        self::assertSame('found-recording-mbid', $song->refresh()->mbid);
+    }
+
+    #[Test]
     public function leaveExistingIdentifiersAlone(): void
     {
         $this->mock(GetMbidForArtist::class)->shouldNotReceive('__invoke');
@@ -104,14 +125,16 @@ class FetchMbidsCommandTest extends TestCase
             'artist_name' => $artist->name,
             'mbid' => 'album-mbid-from-tags',
         ]);
+        $song = Song::factory()->for($album)->for($artist)->createOne(['mbid' => 'recording-mbid-from-tags']);
 
         $this
             ->artisan('koel:fetch-mbids')
-            ->expectsOutput('Every album and artist already has an identifier.')
+            ->expectsOutput('Every album, artist and song already has an identifier.')
             ->assertSuccessful();
 
         self::assertSame('artist-mbid-from-tags', $artist->refresh()->mbid);
         self::assertSame('album-mbid-from-tags', $album->refresh()->mbid);
+        self::assertSame('recording-mbid-from-tags', $song->refresh()->mbid);
     }
 
     #[Test]
@@ -130,7 +153,7 @@ class FetchMbidsCommandTest extends TestCase
 
         $this
             ->artisan('koel:fetch-mbids')
-            ->expectsOutput('Every album and artist already has an identifier.')
+            ->expectsOutput('Every album, artist and song already has an identifier.')
             ->assertSuccessful();
     }
 


### PR DESCRIPTION
`koel:fetch-mbids` skipped song identifiers on any album that already had one of its own, which is the majority of a tagged library.

`MbidService::fetchAndStoreAlbumMbids()` handles this correctly — it uses a stored album identifier when there is one and still fetches the release's tracks to fill in recording identifiers. The command simply never handed it those albums: it selected `albums.mbid IS NULL`, so an album with an identifier was passed over and its songs stayed empty.

That is the wrong way round for how tags arrive. `musicbrainz_albumid` names the release and is written by Picard as a matter of course; the recording identifier needs a `UFID` frame or `musicbrainz_trackid` and is far less consistently present. So the albums most likely to carry an identifier are exactly the ones whose songs most need the lookup, and those were the ones being skipped.

An album is now revisited while **either** it or any of its songs lacks an identifier:

```php
Album::query()
    ->onlyStandard()
    ->where(static fn (AlbumBuilder $query) => $query
        ->whereNull('albums.mbid')
        ->orWhereHas('songs', static fn (Builder $songs) => $songs->whereNull('songs.mbid')));
```

`lazyGetWithoutMbid()` / `countWithoutMbid()` become `lazyGetWithIncompleteMbids()` / `countWithIncompleteMbids()` on `AlbumRepository`, since "without" no longer describes the condition. `ArtistRepository` keeps its pair unchanged: an artist has no sub-entity, so a missing identifier of its own is the whole story.

The "nothing to do" message and the command's description both said albums and artists, and now say songs too.

### Testing

A test creates an album and artist that already carry identifiers from tags and a song that does not, then asserts the song ends up with a recording identifier. It fails against the previous selection, which is how the bug was found. `leaveExistingIdentifiersAlone` gained a song *with* an identifier, so it now covers the whole condition rather than only the album half.

### Still out of reach

Songs on the Unknown Album are not covered, and cannot be: the lookup finds a recording through its release, and there is no release to search for. Nothing regresses there — it was never reachable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The MusicBrainz identifier fetch command now detects and fills missing identifiers for songs, including songs on albums that already have identifiers.
  * Command progress and completion messages now include songs alongside albums and artists.

* **Documentation**
  * Updated command documentation to explain song identifier handling and when albums are revisited.

* **Tests**
  * Added coverage for completing a missing song identifier on an identified album.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->