### PR TITLE
fix: stop querying ratings once per item in Subsonic responses

### DIFF
--- a/app/Http/Controllers/Subsonic/CreatePlaylistController.php
+++ b/app/Http/Controllers/Subsonic/CreatePlaylistController.php
@@ -9,6 +9,7 @@ use App\Http\Responses\Subsonic\Resources\SongResource;
 use App\Http\Responses\Subsonic\SubsonicResponse;
 use App\Models\Song;
 use App\Models\User;
+use App\Repositories\SongRepository;
 use App\Services\Playlist\PlaylistService;
 use App\Values\Playlist\PlaylistCreateData;
 use Illuminate\Contracts\Auth\Authenticatable;
@@ -17,6 +18,7 @@ class CreatePlaylistController extends Controller
 {
     public function __construct(
         private readonly PlaylistService $playlistService,
+        private readonly SongRepository $songRepository,
     ) {}
 
     /** @param User $user */
@@ -29,12 +31,12 @@ class CreatePlaylistController extends Controller
 
         $playlist->loadCount('playables')->loadSum('playables', 'length');
 
+        $songs = $this->songRepository->getByPlaylist($playlist, $user);
+
         return SubsonicResponse::ok([
             'playlist' => PlaylistResource::toArray($playlist)
                 + [
-                    'entry' => $playlist->playables->map(
-                        static fn (Song $song) => SongResource::toArray($song, $user),
-                    )->all(),
+                    'entry' => $songs->map(static fn (Song $song) => SongResource::toArray($song, $user))->all(),
                 ],
         ]);
     }

--- a/app/Http/Responses/Subsonic/Resources/AlbumResource.php
+++ b/app/Http/Responses/Subsonic/Resources/AlbumResource.php
@@ -47,7 +47,7 @@ final class AlbumResource
             'duration' => (int) round($album->songs_sum_length ?? 0),
             'created' => $album->created_at->toIso8601String(),
             'year' => $album->year,
-            'userRating' => $album->getRatingFor($user) ?: null,
+            'userRating' => (int) ($album->rating ?? 0) ?: null,
             'starred' => $album->favorited_at?->toIso8601String(),
             'played' => $album->last_played_at?->toIso8601String(),
             'musicBrainzId' => $album->mbid,

--- a/app/Http/Responses/Subsonic/Resources/ArtistResource.php
+++ b/app/Http/Responses/Subsonic/Resources/ArtistResource.php
@@ -32,7 +32,7 @@ final class ArtistResource
             'name' => $artist->name,
             'coverArt' => $artist->image ? $artist->id : null,
             'albumCount' => $artist->albums_count ?? 0,
-            'userRating' => $artist->getRatingFor($user) ?: null,
+            'userRating' => (int) ($artist->rating ?? 0) ?: null,
             'starred' => $artist->favorited_at?->toIso8601String(),
             'musicBrainzId' => $artist->mbid,
         ];

--- a/app/Http/Responses/Subsonic/Resources/SongResource.php
+++ b/app/Http/Responses/Subsonic/Resources/SongResource.php
@@ -71,7 +71,7 @@ final class SongResource
             'type' => 'music',
             'discNumber' => $song->disc ?: null,
             'isVideo' => false,
-            'userRating' => $song->getRatingFor($user) ?: null,
+            'userRating' => (int) ($song->rating ?? 0) ?: null,
             'starred' => $song->favorited_at?->toIso8601String(),
             'musicBrainzId' => $song->mbid,
         ];

--- a/tests/Feature/Subsonic/CreatePlaylistTest.php
+++ b/tests/Feature/Subsonic/CreatePlaylistTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Subsonic;
 
+use App\Models\Favorite;
 use App\Models\Song;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
@@ -28,6 +29,26 @@ class CreatePlaylistTest extends TestCase
             ->assertJsonPath('subsonic-response.playlist.songCount', 2);
 
         self::assertSame(1, $user->ownedPlaylists()->where('name', 'Subsonic Mix')->count());
+    }
+
+    #[Test]
+    public function entriesCarryFavoriteStatus(): void
+    {
+        $user = create_user();
+        [$favorite, $other] = Song::factory()->count(2)->create(['owner_id' => $user->id])->all();
+        Favorite::factory()->for($user)->for($favorite, 'favoriteable')->createOne();
+
+        $response = $this
+            ->getJson(
+                "/rest/createPlaylist.view?apiKey={$user->subsonic_api_key}"
+                . "&f=json&name=Starred+Mix&songId={$favorite->id}&songId={$other->id}",
+            )
+            ->assertOk()
+            ->assertJsonPath('subsonic-response.playlist.entry.0.id', $favorite->id)
+            ->assertJsonPath('subsonic-response.playlist.entry.1.id', $other->id);
+
+        self::assertNotNull($response->json('subsonic-response.playlist.entry.0.starred'));
+        self::assertNull($response->json('subsonic-response.playlist.entry.1.starred'));
     }
 
     #[Test]

--- a/tests/Feature/Subsonic/UserRatingTest.php
+++ b/tests/Feature/Subsonic/UserRatingTest.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Tests\Feature\Subsonic;
+
+use App\Models\Album;
+use App\Models\Artist;
+use App\Models\Rating;
+use App\Models\Song;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Test;
+
+use function Tests\create_user;
+
+class UserRatingTest extends SubsonicTestCase
+{
+    #[Test]
+    public function randomSongsCarryTheUsersRatingWithoutQueryingEachSong(): void
+    {
+        $user = create_user();
+        [$loved, $meh, $ratedByOthers] = Song::factory()->count(3)->create(['owner_id' => $user->id])->all();
+
+        self::rate($loved, $user, 5);
+        self::rate($meh, $user, 2);
+        self::rate($ratedByOthers, create_user(), 4);
+
+        DB::flushQueryLog();
+        DB::enableQueryLog();
+
+        $songs = $this->getSubsonic('getRandomSongs.view', $user, [
+            'size' => 10,
+        ])->assertSubsonicOk()->json('subsonic-response.randomSongs.song');
+
+        self::assertNoRatingLookups();
+        self::assertEquals([$loved->id => 5, $meh->id => 2, $ratedByOthers->id => null], self::userRatingsById($songs));
+    }
+
+    #[Test]
+    public function albumListCarriesTheUsersRatingWithoutQueryingEachAlbum(): void
+    {
+        $user = create_user();
+        [$loved, $meh, $ratedByOthers] = Album::factory()->count(3)->create(['user_id' => $user->id])->all();
+
+        self::rate($loved, $user, 5);
+        self::rate($meh, $user, 2);
+        self::rate($ratedByOthers, create_user(), 4);
+
+        DB::flushQueryLog();
+        DB::enableQueryLog();
+
+        $albums = $this->getSubsonic('getAlbumList2.view', $user, [
+            'type' => 'newest',
+            'size' => 10,
+        ])->assertSubsonicOk()->json('subsonic-response.albumList2.album');
+
+        self::assertNoRatingLookups();
+        self::assertEquals(
+            [$loved->id => 5, $meh->id => 2, $ratedByOthers->id => null],
+            self::userRatingsById($albums),
+        );
+    }
+
+    #[Test]
+    public function artistIndexCarriesTheUsersRatingWithoutQueryingEachArtist(): void
+    {
+        $user = create_user();
+        [$loved, $meh, $ratedByOthers] = Artist::factory()->count(3)->create(['user_id' => $user->id])->all();
+
+        foreach ([$loved, $meh, $ratedByOthers] as $artist) {
+            Album::factory()->createOne([
+                'artist_id' => $artist->id,
+                'artist_name' => $artist->name,
+                'user_id' => $user->id,
+            ]);
+        }
+
+        self::rate($loved, $user, 5);
+        self::rate($meh, $user, 2);
+        self::rate($ratedByOthers, create_user(), 4);
+
+        DB::flushQueryLog();
+        DB::enableQueryLog();
+
+        $indexes = $this
+            ->getSubsonic('getArtists.view', $user)
+            ->assertSubsonicOk()
+            ->json('subsonic-response.artists.index');
+
+        self::assertNoRatingLookups();
+        self::assertEquals(
+            [$loved->id => 5, $meh->id => 2, $ratedByOthers->id => null],
+            self::userRatingsById(collect($indexes)->flatMap(static fn (array $index) => $index['artist'])->all()),
+        );
+    }
+
+    #[Test]
+    public function createdPlaylistEntriesCarryTheUsersRating(): void
+    {
+        $user = create_user();
+        [$loved, $unrated] = Song::factory()->count(2)->create(['owner_id' => $user->id])->all();
+
+        self::rate($loved, $user, 5);
+
+        $entries = $this
+            ->getJson(
+                "/rest/createPlaylist.view?apiKey={$user->subsonic_api_key}"
+                . "&f=json&name=Rated+Mix&songId={$loved->id}&songId={$unrated->id}",
+            )
+            ->assertSubsonicOk()
+            ->json('subsonic-response.playlist.entry');
+
+        self::assertSame([$loved->id => 5, $unrated->id => null], self::userRatingsById($entries));
+    }
+
+    private static function rate(Model $rateable, User $user, int $rating): void
+    {
+        Rating::factory()->for($user)->for($rateable, 'rateable')->createOne(['rating' => $rating]);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $items
+     *
+     * @return array<string, ?int>
+     */
+    private static function userRatingsById(array $items): array
+    {
+        return collect($items)->mapWithKeys(static fn (array $item) => [
+            $item['id'] => $item['userRating'] ?? null,
+        ])->all();
+    }
+
+    private static function assertNoRatingLookups(): void
+    {
+        $ratingLookups = collect(DB::getQueryLog())
+            ->pluck('query')
+            ->filter(
+                static fn (string $sql): bool => (
+                    preg_match('/^select\s[^(]*\sfrom\s+["`]?ratings["`]?\s/i', $sql) === 1
+                ),
+            )
+            ->values()
+            ->all();
+
+        self::assertSame([], $ratingLookups);
+    }
+}


### PR DESCRIPTION
## Description

The Subsonic song, album and artist resources now read `userRating` from the `rating` column their repositories already select, instead of calling `getRatingFor()`, which ran one query per returned item.

`createPlaylist` was the only path that handed the resource songs without that column: it rendered the plain `playables` relation. It now reads the entries back with `SongRepository::getByPlaylist()`, the same way `getPlaylist` does. Without this, the change above would have dropped `userRating` from its entries. It also fixes `starred`, which that response never carried, because `favorited_at` comes from the same `withUserContext()` select.

Every other path into the three resources already goes through `withUserContext()`: the repository `getOne`/`findOne`/`getMany`/`getAll`/`getByAlbum`/`getByArtist`/`getByPlaylist`/`getByGenre`/`getFavorites`/`getRandom` methods, search (through `getMany`) and the play queue.

## Motivation

Fixes #2663.

Queries per request on a library of 100 songs, each with its own album and artist, counted with `DB::listen`:

| endpoint | before: rating lookups / total | after: rating lookups / total |
|---|---|---|
| `getRandomSongs` (`size=500`) | 100 / 112 | 0 / 12 |
| `getAlbumList2` (`type=newest&size=500`) | 100 / 107 | 0 / 7 |
| `getArtists` | 100 / 104 | 0 / 4 |
| `getIndexes` | 100 / 104 | 0 / 4 |
| `search3` (500 each) | 300 / 317 | 0 / 17 |
| `search2` (500 each) | 200 / 215 | 0 / 15 |
| `getPlaylist` | 100 / 119 | 0 / 19 |
| `getAlbum` | 2 / 17 | 0 / 15 |
| `getArtist` | 2 / 11 | 0 / 9 |
| `getMusicDirectory` (album) | 1 / 14 | 0 / 13 |

## Tests

- `tests/Feature/Subsonic/UserRatingTest.php`: `getRandomSongs`, `getAlbumList2` and `getArtists` return the requesting user's rating, ignore another user's rating, and issue no per-item `ratings` query. `createPlaylist` entries keep their rating.
- `CreatePlaylistTest::entriesCarryFavoriteStatus` covers the `starred` fix.

The new tests fail on `master` and pass with the change. I ran the Subsonic feature tests on SQLite, MariaDB 11.4 and PostgreSQL 17, and ran `composer cs`, `composer lint` and `composer analyze` clean.

## Screenshots (if applicable)

Not applicable.

## Checklist

- [x] I've tested my changes thoroughly and added tests where applicable
- [x] I've updated relevant documentation (if any)
- [x] My code follows the project's conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Subsonic playlist responses now correctly show each song’s starred status for the current user.
  - Song, album, and artist responses now display the correct user ratings.
  - Improved consistency of ratings across random songs, album lists, artist lists, and playlists.

- **Performance**
  - Reduced unnecessary rating lookups when loading Subsonic media responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->